### PR TITLE
First draft of rearrangable items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ path = "examples/lists/multiselectable_list.rs"
 name = "static_list"
 path = "examples/lists/static_list.rs"
 
+[[example]]
+name = "rearrangable"
+path = "examples/controls/rearrangable.rs"
+
 
 [features]
 default = ["glutin", "clipboard"]

--- a/core/src/views/mod.rs
+++ b/core/src/views/mod.rs
@@ -42,3 +42,6 @@ pub use popup::*;
 
 mod radio_buttons;
 pub use radio_buttons::*;
+
+mod rearrangable;
+pub use rearrangable::*;

--- a/core/src/views/rearrangable.rs
+++ b/core/src/views/rearrangable.rs
@@ -30,7 +30,9 @@ impl Rearrangable {
     {
         Self { }
             .build2(cx, move |cx| {
-                RearrangeState { held: None }.build(cx);
+                if cx.data::<RearrangeState>().is_none() {
+                    RearrangeState { held: None }.build(cx);
+                }
                 Binding::new(cx, RearrangeState::held, move |cx, held| {
                     let builder = builder.clone();
                     let swapper = swapper.clone();

--- a/core/src/views/rearrangable.rs
+++ b/core/src/views/rearrangable.rs
@@ -1,0 +1,75 @@
+use crate::{View, Context, Handle, ForEach, Event, Lens, Model, Binding, HStack, MouseButtonState, Actions};
+
+pub struct Rearrangable {
+}
+
+#[derive(Lens)]
+pub struct RearrangeState {
+    held: Option<usize>,
+}
+
+impl Model for RearrangeState {
+    fn event(&mut self, _cx: &mut Context, event: &mut Event) {
+        match event.message.downcast() {
+            Some(RearrangeStateEvent::Set(idx)) => self.held = *idx,
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RearrangeStateEvent {
+    Set(Option<usize>)
+}
+
+impl Rearrangable {
+    pub fn new<F, F2>(cx: &mut Context, count: usize, builder: F, swapper: F2) -> Handle<'_, Self>
+    where
+        F: 'static + Fn(&mut Context, usize) + Clone,
+        F2: 'static + Fn(&mut Context, usize, usize) + Clone,
+    {
+        Self { }
+            .build2(cx, move |cx| {
+                RearrangeState { held: None }.build(cx);
+                Binding::new(cx, RearrangeState::held, move |cx, held| {
+                    let builder = builder.clone();
+                    let swapper = swapper.clone();
+                    ForEach::new(cx, 0..count, move |cx, idx| {
+                        let builder = builder.clone();
+                        let swapper = swapper.clone();
+                        let handle = HStack::new(cx, move |cx| {
+                            (builder)(cx, idx);
+                        });
+                        handle.cx.style.classes.remove(handle.entity);
+                        if Some(idx) == *held.get(handle.cx) {
+                            handle.class("dragging")
+                        } else {
+                            handle
+                        }
+                            .on_press(move |cx| {
+                                cx.emit(RearrangeStateEvent::Set(Some(idx)));
+                            })
+                            .on_release(move |cx| {
+                                cx.emit(RearrangeStateEvent::Set(None));
+                            })
+                            .on_over(move |cx| {
+                                if cx.mouse.left.state == MouseButtonState::Pressed {
+                                    if let Some(held_idx) = *held.get(cx) {
+                                        if held_idx != idx {
+                                            cx.emit(RearrangeStateEvent::Set(Some(idx)));
+                                            (swapper.clone())(cx, held_idx, idx);
+                                        }
+                                    }
+                                }
+                            });
+                    });
+                });
+            })
+    }
+}
+
+impl View for Rearrangable {
+    fn element(&self) -> Option<String> {
+        Some("rearrangable".to_owned())
+    }
+}

--- a/examples/controls/rearrangable.rs
+++ b/examples/controls/rearrangable.rs
@@ -1,0 +1,64 @@
+use vizia::*;
+use vizia_glutin::application::Application;
+
+const STYLE: &'static str = r##"
+rearrangable {
+    width: 100px;
+    height: auto;
+    space: 1s;
+}
+
+label {
+    color: white;
+    background-color: #0000ff;
+    child-space: 1s;
+    width: 100%;
+    height: 30px;
+    border-color: black;
+    border-width: 1px;
+}
+
+.dragging label {
+    background-color: #3030ff;
+}
+"##;
+
+#[derive(Lens)]
+pub struct AppState {
+    pub items: Vec<i32>,
+}
+
+impl Model for AppState {
+    fn event(&mut self, _cx: &mut Context, event: &mut Event) {
+        match event.message.downcast() {
+            Some(AppEvent::Swap(a, b)) => {
+                self.items.swap(*a, *b);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum AppEvent {
+    Swap(usize, usize),
+}
+
+fn main() {
+    Application::new(WindowDescription::new().with_title("Rearrangable"), |cx| {
+        cx.add_theme(STYLE);
+        AppState {
+            items: (10..15).collect()
+        }.build(cx);
+
+        // TODO: bind only to the relevant data (items.len(), items[idx]) instead of the whole list
+        Binding::new(cx, AppState::items, move |cx, items| {
+            Rearrangable::new(cx, items.get(cx).len(), move |cx, idx| {
+                Label::new(cx, &format!("Item {}", items.get(cx)[idx]));
+            }, move |cx, a, b| {
+                cx.emit(AppEvent::Swap(a, b));
+            });
+        });
+    })
+        .run();
+}


### PR DESCRIPTION
This adds a new widget `Rearrangable` which allows its children to be dragged and reordered. It has several problems:

1) It requires its closures to be Clone, and then makes judicious use of this trait. I'm not sure how else to code this to make the lifetimes happy.
2) You can currently only drag a widget one space at a time, then you have to grab it again. I suspect this is because of #25 causing the holding state to be reset whenever the data updates.

The main use case I have in mind for this is to build tabs that can be reordered.