### PR TITLE
Add ListIter to allow control of how the List view indexes a collection

### DIFF
--- a/core/src/views/mod.rs
+++ b/core/src/views/mod.rs
@@ -8,7 +8,7 @@ mod button;
 pub use button::Button;
 
 mod list;
-pub use list::{DataHandle, ItemPtr, List};
+pub use list::{DataHandle, ItemPtr, List, ListIter};
 
 mod table;
 pub use table::Table;

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,43 +1,89 @@
+use std::collections::HashMap;
+
 use vizia::*;
 
 const STYLE: &str = r#"
 
 "#;
 
-#[derive(Default, Lens)]
+#[derive(Clone)]
+pub struct MyData {
+    text: String,
+}
+
+#[derive(Clone)]
+pub struct CustomCollection {
+    data: HashMap<String, MyData>,
+}
+
+impl Data for CustomCollection {
+    fn same(&self, other: &Self) -> bool {
+
+        if self.data.len() != other.data.len() {
+            return false;
+        }
+
+        for ((key1,_),(key2,_)) in self.data.iter().zip(other.data.iter()) {
+            if key1 != key2 {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+#[derive(Lens)]
 pub struct AppData {
-    value: bool,
+    collection: CustomCollection,
 }
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::ToggleValue => {
-                    self.value ^= true;
-                }
-            }
-        }
+
     }
 }
 
 #[derive(Debug)]
 pub enum AppEvent {
-    ToggleValue,
+
 }
 
 fn main() {
     Application::new(WindowDescription::new().with_title("Test"), |cx| {
         cx.add_theme(STYLE);
 
-        AppData::default().build(cx);
-        HStack::new(cx, |cx| {
-            Label::new(cx, "\u{e88a}");
-        })
-        .font_size(50.0)
-        .font("material");
+        let mut data = HashMap::new();
+        data.insert("First".to_string(), MyData{text: "one".to_string()});
+        data.insert("Second".to_string(), MyData{text: "two".to_string()});
+        data.insert("Third".to_string(), MyData{text: "three".to_string()});
+
+        AppData {
+            collection: CustomCollection {
+                data,
+            }
+        }.build(cx);
+
+        List::new(cx, AppData::collection, |cx, item|{
+            Label::new(cx, &item.get(cx).clone());
+        });
     })
     .run();
 }
 
-// .border_shape_top_left(BorderCornerShape::Bevel)
+impl ListIter<String> for CustomCollection {
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn get_value(&self, index: usize) -> Option<&String> {
+
+        for (q, (key, _)) in self.data.iter().enumerate() {
+            if q == index {
+                return Some(key);
+            }
+        }
+
+        None
+    }
+}


### PR DESCRIPTION
This allows more control over which parts of a collections are accessed when iterated by index. There are two major downsides that could do with improvment:

1. The collection must be indexable with a `usize`. This is because the list generates its items by iterating from 0 to the length of the collection and uses the index for the `ItemPtr`, which contains a lens for retrieving the indexed data. This works fine for something like a `Vec` but will fail for a `HashMap` if the number of items changes. A possible solution might be to have a generic index type on the `ItemPtr` which would allow for a key instead of a `usize`.
2. The collection must implement `Data`. For the case of a `HashMap` with keys which implement `Data` but with values which do not, this is workable because a custom implementation of `Data` can be used to compare just the keys for changes. However, the downside is that the whole collection must implement `Clone` to satisfy the requirement on `Data`. One possible solution to this is to have another method on the `Data` trait, something like `get()`, which allows the user to specify a piece of the collection to be cloned and compared instead of the whole thing, e.g. just the keys in a `HashMap`.

See the `test.rs` example for usage example.