### PR TITLE
Add toggle_class methods to add or remove a class

### DIFF
--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -78,6 +78,20 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
+    pub fn toggle_class(self, name: &str, applied: bool) -> Self {
+        if let Some(class_list) = self.cx.style.classes.get_mut(self.entity) {
+            if applied {
+                class_list.insert(name.to_string());
+            } else {
+                class_list.remove(name);
+            }
+        }
+
+        self.cx.style.needs_restyle = true;
+
+        self
+    }
+
     pub fn font(self, font_name: &str) -> Self {
         self.cx.style.font.insert(self.entity, font_name.to_owned());
 

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -78,16 +78,19 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
-    pub fn toggle_class(self, name: &str, applied: bool) -> Self {
-        if let Some(class_list) = self.cx.style.classes.get_mut(self.entity) {
-            if applied {
-                class_list.insert(name.to_string());
-            } else {
-                class_list.remove(name);
+    pub fn toggle_class(self, name: &str, applied: impl Res<bool>) -> Self {
+        let name = name.to_owned();
+        applied.set_or_bind(self.cx, self.entity, move |cx, entity, applied| {
+            if let Some(class_list) = cx.style.classes.get_mut(entity) {
+                if applied {
+                    class_list.insert(name.clone());
+                } else {
+                    class_list.remove(&name);
+                }
             }
-        }
 
-        self.cx.style.needs_restyle = true;
+            cx.style.needs_restyle = true;
+        });
 
         self
     }

--- a/core/src/style/prop.rs
+++ b/core/src/style/prop.rs
@@ -171,6 +171,31 @@ pub trait PropSet: AsEntity + Sized {
         self.entity()
     }
 
+    fn toggle_class(self, cx: &mut Context, class_name: &str, applied: bool) -> Entity {
+        if let Some(class_list) = cx.style.classes.get_mut(self.entity()) {
+            if applied {
+                class_list.insert(class_name.to_string());
+            } else {
+                class_list.remove(class_name);
+            }
+        } else if applied {
+            let mut class_list = HashSet::new();
+            class_list.insert(class_name.to_string());
+            cx.style
+                .classes
+                .insert(self.entity(), class_list)
+                .expect("Failed to insert class name");
+        } else {
+            return self.entity();
+        }
+
+        cx.style.needs_restyle = true;
+        cx.style.needs_relayout = true;
+        cx.style.needs_redraw = true;
+
+        self.entity()
+    }
+
     // TODO move to PropGet
     fn get_parent(self, cx: &mut Context) -> Option<Entity> {
         self.entity().parent(&cx.tree)


### PR DESCRIPTION
This adds logic for classes to be removed, instead of just added. Additionally, class membership can be bound to a bool. I updated the number_input example to demonstrate this.