### PR TITLE
Remove some styling and ownership restrictions from scrollview

### DIFF
--- a/core/src/default_theme.css
+++ b/core/src/default_theme.css
@@ -297,6 +297,12 @@ scrollview {
     overflow: hidden;
 }
 
+scrollview>.scroll_content {
+    min-width: 100%;
+    min-height: 100%;
+    position-type: self-directed;
+}
+
 scrollview>scrollbar.horizontal {
     left: 0px;
     width: 1s;

--- a/core/src/default_theme.css
+++ b/core/src/default_theme.css
@@ -300,6 +300,8 @@ scrollview {
 scrollview>.scroll_content {
     min-width: 100%;
     min-height: 100%;
+    width: auto;
+    height: auto;
     position-type: self-directed;
 }
 

--- a/core/src/views/scrollview.rs
+++ b/core/src/views/scrollview.rs
@@ -97,7 +97,7 @@ impl ScrollView<scroll_data_derived_lenses::root> {
         content: F,
     ) -> Handle<Self>
     where
-        F: 'static + Fn(&mut Context),
+        F: 'static + FnOnce(&mut Context),
     {
         Self { data: ScrollData::root }.build2(cx, move |cx| {
             ScrollData {
@@ -124,7 +124,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
         content: F,
     ) -> Handle<Self>
     where
-        F: 'static + Fn(&mut Context),
+        F: 'static + FnOnce(&mut Context),
     {
         if cx.data::<ScrollData>().is_none() {
             panic!("ScrollView::custom requires a ScrollData to be built into a parent");
@@ -137,11 +137,10 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
 
     fn common_builder<F>(cx: &mut Context, data: L, content: F, scroll_x: bool, scroll_y: bool)
     where
-        F: 'static + Fn(&mut Context),
+        F: 'static + FnOnce(&mut Context),
     {
         VStack::new(cx, content)
-            .size(Units::Auto)
-            .position_type(PositionType::SelfDirected)
+            .class("scroll_content")
             .bind(data.clone(), |handle, data| {
                 let data = data.get(handle.cx);
                 let left = (data.child_x - data.parent_x) * data.scroll_x;


### PR DESCRIPTION
While trying to integrate scrollview into my app, I found that it was difficult to use because:

- It needed a Fn instead of a FnOnce
- There were inline style properties that couldn't be overridden
- The default of auto width and height leads to some strange behavior when the child is smaller than the parent

This addresses all of these.