### PR TITLE
Basic localization with fluent

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,10 +19,11 @@ morphorm = {git = "https://github.com/vizia/morphorm", features = ["rounding"], 
 bitflags = "1.3.2"
 fnv = "1.0.7"
 keyboard-types = { version = "0.5.0", default-features = false }
-# fluent-bundle = "0.15.2"
-# fluent-langneg = "0.13"
-# fluent-syntax = "0.11.0"
-# unic-langid = "0.9"
+fluent-bundle = "0.15.2"
+fluent-langneg = "0.13"
+fluent-syntax = "0.11.0"
+unic-langid = "0.9"
+locale_config = "*"  # see https://github.com/rust-locale/locale_config for wildcard explanation
 cssparser = "0.27.2"
 unicode-segmentation = "1.8.0"
 copypasta = {version = "0.7.1", optional = true}

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 use copypasta::ClipboardContext;
 use femtovg::TextContext;
 use fnv::FnvHashMap;
+use unic_langid::LanguageIdentifier;
 // use fluent_bundle::{FluentBundle, FluentResource};
 // use unic_langid::LanguageIdentifier;
 
@@ -362,6 +363,10 @@ impl Context {
         self.resource_manager.images.remove(path);
         self.style.needs_redraw = true;
         self.style.needs_relayout = true;
+    }
+
+    pub fn add_translation(&mut self, lang: LanguageIdentifier, ftl: String) {
+        self.resource_manager.add_translation(lang, ftl)
     }
 
     pub fn spawn<F>(&self, target: F)

--- a/core/src/localization/mod.rs
+++ b/core/src/localization/mod.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+use fluent_bundle;
+use fluent_bundle::FluentArgs;
+use crate::{Binding, Context, Data, Entity, Lens, Res};
+
 pub trait LocalizedStringKey<'a> {
     fn key(&self) -> &'a str;
 }
@@ -11,5 +16,133 @@ impl<'a> LocalizedStringKey<'a> for &'a str {
 impl<'a> LocalizedStringKey<'a> for &'a String {
     fn key(&self) -> &'a str {
         self.as_str()
+    }
+}
+
+pub trait LensWrapSmallTrait {
+    fn get_str(&self, cx: &Context) -> String;
+    fn make_clone(&self) -> Box<dyn LensWrapSmallTrait>;
+    fn bind(&self, cx: &mut Context, closure: Box<dyn Fn(&mut Context)>);
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LensWrapSmall<L> {
+    lens: L,
+}
+
+impl<L> LensWrapSmallTrait for LensWrapSmall<L>
+where
+    L: Lens,
+    <L as Lens>::Target: ToString + Data,
+{
+    fn get_str(&self, cx: &Context) -> String {
+        self.lens.view(cx.data().expect("Failed to get data from context. Has it been built into the tree?"), |data| {
+            match data {
+                Some(x) => x.to_string(),
+                None => "".to_string(),
+            }
+        })
+    }
+
+    fn make_clone(&self) -> Box<dyn LensWrapSmallTrait> {
+        Box::new(self.clone())
+    }
+    fn bind(&self, cx: &mut Context, closure: Box<dyn Fn(&mut Context)>) {
+        Binding::new(cx, self.lens.clone(), move |cx, _| closure(cx));
+    }
+}
+
+pub struct Localized {
+    key: &'static str,
+    args: HashMap<&'static str, Box<dyn LensWrapSmallTrait>>,
+}
+
+impl Clone for Localized {
+    fn clone(&self) -> Self {
+        Self {
+            key: self.key,
+            args: self.args.iter().map(|(k, v)| (*k, v.make_clone())).collect()
+        }
+    }
+}
+
+impl Localized {
+    fn get_args(&self, cx: &Context) -> FluentArgs {
+        let mut res = FluentArgs::new();
+        for (name, arg) in &self.args {
+            res.set(name.to_owned(), arg.get_str(cx));
+        }
+        res
+    }
+
+    pub fn new(key: &'static str) -> Self {
+        Self {
+            key,
+            args: HashMap::new(),
+        }
+    }
+
+    pub fn arg<L>(mut self, key: &'static str, lens: L) -> Self
+    where
+        L: Lens,
+        <L as Lens>::Target: ToString + Data,
+    {
+        self.args.insert(key, Box::new(LensWrapSmall { lens }));
+        self
+    }
+}
+
+impl Res<String> for Localized {
+    fn get_val(&self, cx: &Context) -> String {
+        let bundle = cx.resource_manager.current_translation();
+        let message = if let Some(msg) = bundle.get_message(self.key) {
+            msg
+        } else {
+            return format!("{{MISSING(1): {}}}", self.key);
+        };
+
+        let value = if let Some(value) = message.value() {
+            value
+        } else {
+            return format!("{{MISSING(2): {}}}", self.key);
+        };
+
+        let mut err = vec![];
+        let args = self.get_args(cx);
+        let res = bundle.format_pattern(value, Some(&args), &mut err);
+
+        if err.is_empty() {
+            res.to_string()
+        } else {
+            format!("{} {{ERROR: {:?}}}", res, err)
+        }
+    }
+
+    fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F) where F: 'static + Clone + Fn(&mut Context, Entity, String) {
+        let prev_current = cx.current;
+        let prev_count = cx.count;
+        cx.current = entity;
+        cx.count = cx.tree.get_num_children(entity).unwrap() as usize;
+        let lenses = self.args.values().map(|x| x.make_clone()).collect();
+        let self2 = self.clone();
+        bind_recursive(cx, &lenses, move |cx| {
+            closure(cx, entity, self2.get_val(cx));
+        });
+        cx.current = prev_current;
+        cx.count = prev_count;
+    }
+}
+
+fn bind_recursive<F>(cx: &mut Context, lenses: &Vec<Box<dyn LensWrapSmallTrait>>, closure: F)
+where
+    F: 'static + Clone + Fn(&mut Context)
+{
+    if let Some((lens, rest)) = lenses.split_last() {
+        let rest = rest.iter().map(|x| x.make_clone()).collect();
+        lens.bind(cx, Box::new(move |cx| {
+            bind_recursive(cx, &rest, closure.clone());
+        }));
+    } else {
+        closure(cx);
     }
 }

--- a/core/src/localization/mod.rs
+++ b/core/src/localization/mod.rs
@@ -3,22 +3,6 @@ use fluent_bundle;
 use fluent_bundle::FluentArgs;
 use crate::{Binding, Context, Data, Entity, Lens, Res};
 
-pub trait LocalizedStringKey<'a> {
-    fn key(&self) -> &'a str;
-}
-
-impl<'a> LocalizedStringKey<'a> for &'a str {
-    fn key(&self) -> &'a str {
-        self
-    }
-}
-
-impl<'a> LocalizedStringKey<'a> for &'a String {
-    fn key(&self) -> &'a str {
-        self.as_str()
-    }
-}
-
 pub trait LensWrapSmallTrait {
     fn get_str(&self, cx: &Context) -> String;
     fn make_clone(&self) -> Box<dyn LensWrapSmallTrait>;

--- a/core/src/resource.rs
+++ b/core/src/resource.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 
 use crate::{Canvas, Context, Entity};
+use fluent_bundle::{FluentBundle, FluentResource};
 use image::GenericImageView;
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
-use fluent_bundle::{FluentBundle, FluentResource};
 use unic_langid::LanguageIdentifier;
 
 pub struct StoredImage {
@@ -78,7 +78,10 @@ impl ResourceManager {
             themes: Vec::new(),
             fonts: HashMap::new(),
             images: HashMap::new(),
-            translations: HashMap::from([(LanguageIdentifier::default(), FluentBundle::new(vec![LanguageIdentifier::default()]))]),
+            translations: HashMap::from([(
+                LanguageIdentifier::default(),
+                FluentBundle::new(vec![LanguageIdentifier::default()]),
+            )]),
             language: LanguageIdentifier::default(),
             image_loader: None,
             count: 0,
@@ -86,9 +89,16 @@ impl ResourceManager {
     }
 
     fn renegotiate_language(&mut self) {
-        let locale = locale_config::Locale::current().to_string().parse().unwrap_or_else(|_| LanguageIdentifier::default());
+        let locale = locale_config::Locale::current()
+            .to_string()
+            .parse()
+            .unwrap_or_else(|_| LanguageIdentifier::default());
         let requested = [locale];
-        let available = self.translations.keys().filter(|x| x != &&LanguageIdentifier::default()).collect::<Vec<_>>();
+        let available = self
+            .translations
+            .keys()
+            .filter(|x| x != &&LanguageIdentifier::default())
+            .collect::<Vec<_>>();
         let default: LanguageIdentifier = "en-CA".parse().unwrap();
         let default_ref = &default; // ???
         let langs = fluent_langneg::negotiate::negotiate_languages(
@@ -101,8 +111,10 @@ impl ResourceManager {
     }
 
     pub fn add_translation(&mut self, lang: LanguageIdentifier, ftl: String) {
-        let res = fluent_bundle::FluentResource::try_new(ftl).expect("Failed to parse translation as FTL");
-        let bundle = self.translations.entry(lang.clone()).or_insert_with(|| FluentBundle::new(vec![lang]));
+        let res = fluent_bundle::FluentResource::try_new(ftl)
+            .expect("Failed to parse translation as FTL");
+        let bundle =
+            self.translations.entry(lang.clone()).or_insert_with(|| FluentBundle::new(vec![lang]));
         bundle.add_resource(res).expect("Failed to add resource to bundle");
         self.renegotiate_language();
     }

--- a/core/src/resource.rs
+++ b/core/src/resource.rs
@@ -88,14 +88,14 @@ impl ResourceManager {
     fn renegotiate_language(&mut self) {
         let locale = locale_config::Locale::current().to_string().parse().unwrap_or_else(|_| LanguageIdentifier::default());
         let requested = [locale];
-        let available = self.translations.keys().collect::<Vec<_>>();
+        let available = self.translations.keys().filter(|x| x != &&LanguageIdentifier::default()).collect::<Vec<_>>();
         let default: LanguageIdentifier = "en-CA".parse().unwrap();
         let default_ref = &default; // ???
         let langs = fluent_langneg::negotiate::negotiate_languages(
             &requested,
             available.as_slice(),
             Some(&default_ref),
-            fluent_langneg::NegotiationStrategy::Matching
+            fluent_langneg::NegotiationStrategy::Filtering,
         );
         self.language = (**langs.first().unwrap()).to_owned();
     }

--- a/core/src/resource.rs
+++ b/core/src/resource.rs
@@ -4,6 +4,8 @@ use crate::{Canvas, Context, Entity};
 use image::GenericImageView;
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
+use fluent_bundle::{FluentBundle, FluentResource};
+use unic_langid::LanguageIdentifier;
 
 pub struct StoredImage {
     pub image: ImageOrId,
@@ -61,6 +63,8 @@ pub struct ResourceManager {
     pub themes: Vec<String>,      // Themes are the string content stylesheets
     pub images: HashMap<String, StoredImage>,
     pub fonts: HashMap<String, FontOrId>,
+    pub translations: HashMap<LanguageIdentifier, FluentBundle<FluentResource>>,
+    pub language: LanguageIdentifier,
 
     pub image_loader: Option<Box<dyn Fn(&mut Context, &str)>>,
 
@@ -74,9 +78,37 @@ impl ResourceManager {
             themes: Vec::new(),
             fonts: HashMap::new(),
             images: HashMap::new(),
+            translations: HashMap::from([(LanguageIdentifier::default(), FluentBundle::new(vec![LanguageIdentifier::default()]))]),
+            language: LanguageIdentifier::default(),
             image_loader: None,
             count: 0,
         }
+    }
+
+    fn renegotiate_language(&mut self) {
+        let locale = locale_config::Locale::current().to_string().parse().unwrap_or_else(|_| LanguageIdentifier::default());
+        let requested = [locale];
+        let available = self.translations.keys().collect::<Vec<_>>();
+        let default: LanguageIdentifier = "en-CA".parse().unwrap();
+        let default_ref = &default; // ???
+        let langs = fluent_langneg::negotiate::negotiate_languages(
+            &requested,
+            available.as_slice(),
+            Some(&default_ref),
+            fluent_langneg::NegotiationStrategy::Matching
+        );
+        self.language = (**langs.first().unwrap()).to_owned();
+    }
+
+    pub fn add_translation(&mut self, lang: LanguageIdentifier, ftl: String) {
+        let res = fluent_bundle::FluentResource::try_new(ftl).expect("Failed to parse translation as FTL");
+        let bundle = self.translations.entry(lang.clone()).or_insert_with(|| FluentBundle::new(vec![lang]));
+        bundle.add_resource(res).expect("Failed to add resource to bundle");
+        self.renegotiate_language();
+    }
+
+    pub fn current_translation(&self) -> &FluentBundle<FluentResource> {
+        self.translations.get(&self.language).unwrap()
     }
 
     pub(crate) fn add_font(&mut self, _name: &str, _path: &str) {}

--- a/core/src/state/binding.rs
+++ b/core/src/state/binding.rs
@@ -136,7 +136,7 @@ pub trait Res<T> {
     }
     fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F)
     where
-        F: 'static + Fn(&mut Context, Entity, T);
+        F: 'static + Clone + Fn(&mut Context, Entity, T);
 }
 
 impl_res_simple!(i8);

--- a/examples/l10n.rs
+++ b/examples/l10n.rs
@@ -22,6 +22,8 @@ impl Model for AppData {
 fn main() {
     Application::new(WindowDescription::new(), |cx| {
         cx.add_translation("en-US".parse().unwrap(), include_str!("resources/en-US/hello.ftl").to_owned());
+        cx.add_translation("fr".parse().unwrap(), include_str!("resources/fr/hello.ftl").to_owned());
+
         AppData { name: "Audrey".to_owned() }.build(cx);
 
         Label::new(cx, Localized::new("hello-world"));

--- a/examples/l10n.rs
+++ b/examples/l10n.rs
@@ -1,0 +1,30 @@
+use vizia::*;
+
+#[derive(Lens)]
+pub struct AppData {
+    name: String,
+}
+
+pub enum AppEvent {
+    SetName(String),
+}
+
+impl Model for AppData {
+    fn event(&mut self, _cx: &mut Context, event: &mut Event) {
+        if let Some(msg) = event.message.downcast() {
+            match msg {
+                AppEvent::SetName(s) => self.name = s.clone(),
+            }
+        }
+    }
+}
+
+fn main() {
+    Application::new(WindowDescription::new(), |cx| {
+        cx.add_translation("en-US".parse().unwrap(), include_str!("resources/en-US/hello.ftl").to_owned());
+        AppData { name: "Audrey".to_owned() }.build(cx);
+
+        Label::new(cx, Localized::new("hello-world"));
+        Label::new(cx, Localized::new("intro").arg("name", AppData::name));
+    }).run()
+}

--- a/examples/l10n.rs
+++ b/examples/l10n.rs
@@ -3,10 +3,12 @@ use vizia::*;
 #[derive(Lens)]
 pub struct AppData {
     name: String,
+    emails: i32,
 }
 
 pub enum AppEvent {
     SetName(String),
+    ReceiveEmail,
 }
 
 impl Model for AppData {
@@ -14,6 +16,7 @@ impl Model for AppData {
         if let Some(msg) = event.message.downcast() {
             match msg {
                 AppEvent::SetName(s) => self.name = s.clone(),
+                AppEvent::ReceiveEmail => self.emails += 1,
             }
         }
     }
@@ -24,17 +27,21 @@ fn main() {
         cx.add_translation("en-US".parse().unwrap(), include_str!("resources/en-US/hello.ftl").to_owned());
         cx.add_translation("fr".parse().unwrap(), include_str!("resources/fr/hello.ftl").to_owned());
 
-        AppData { name: "Audrey".to_owned() }.build(cx);
+        AppData { name: "Audrey".to_owned(), emails: 1 }.build(cx);
 
-        Label::new(cx, Localized::new("hello-world"));
-        HStack::new(cx, |cx| {
-            Label::new(cx, Localized::new("enter-name"));
-            Textbox::new(cx, AppData::name)
-                .width(Units::Pixels(300.0))
-                .on_edit(|cx, text| {
-                    cx.emit(AppEvent::SetName(text));
-                });
+        VStack::new(cx, |cx| {
+            Label::new(cx, Localized::new("hello-world"));
+            HStack::new(cx, |cx| {
+                Label::new(cx, Localized::new("enter-name"));
+                Textbox::new(cx, AppData::name)
+                    .width(Units::Pixels(300.0))
+                    .on_edit(|cx, text| {
+                        cx.emit(AppEvent::SetName(text));
+                    });
+            });
+            Label::new(cx, Localized::new("intro").arg("name", AppData::name));
+            Label::new(cx, Localized::new("emails").arg("unread_emails", AppData::emails));
+            Button::new(cx, |cx| cx.emit(AppEvent::ReceiveEmail), |cx| Label::new(cx, Localized::new("refresh")));
         });
-        Label::new(cx, Localized::new("intro").arg("name", AppData::name));
     }).run()
 }

--- a/examples/l10n.rs
+++ b/examples/l10n.rs
@@ -25,6 +25,14 @@ fn main() {
         AppData { name: "Audrey".to_owned() }.build(cx);
 
         Label::new(cx, Localized::new("hello-world"));
+        HStack::new(cx, |cx| {
+            Label::new(cx, Localized::new("enter-name"));
+            Textbox::new(cx, AppData::name)
+                .width(Units::Pixels(300.0))
+                .on_edit(|cx, text| {
+                    cx.emit(AppEvent::SetName(text));
+                });
+        });
         Label::new(cx, Localized::new("intro").arg("name", AppData::name));
     }).run()
 }

--- a/examples/l10n.rs
+++ b/examples/l10n.rs
@@ -24,8 +24,14 @@ impl Model for AppData {
 
 fn main() {
     Application::new(WindowDescription::new(), |cx| {
-        cx.add_translation("en-US".parse().unwrap(), include_str!("resources/en-US/hello.ftl").to_owned());
-        cx.add_translation("fr".parse().unwrap(), include_str!("resources/fr/hello.ftl").to_owned());
+        cx.add_translation(
+            "en-US".parse().unwrap(),
+            include_str!("resources/en-US/hello.ftl").to_owned(),
+        );
+        cx.add_translation(
+            "fr".parse().unwrap(),
+            include_str!("resources/fr/hello.ftl").to_owned(),
+        );
 
         AppData { name: "Audrey".to_owned(), emails: 1 }.build(cx);
 
@@ -33,15 +39,18 @@ fn main() {
             Label::new(cx, Localized::new("hello-world"));
             HStack::new(cx, |cx| {
                 Label::new(cx, Localized::new("enter-name"));
-                Textbox::new(cx, AppData::name)
-                    .width(Units::Pixels(300.0))
-                    .on_edit(|cx, text| {
-                        cx.emit(AppEvent::SetName(text));
-                    });
+                Textbox::new(cx, AppData::name).width(Units::Pixels(300.0)).on_edit(|cx, text| {
+                    cx.emit(AppEvent::SetName(text));
+                });
             });
             Label::new(cx, Localized::new("intro").arg("name", AppData::name));
             Label::new(cx, Localized::new("emails").arg("unread_emails", AppData::emails));
-            Button::new(cx, |cx| cx.emit(AppEvent::ReceiveEmail), |cx| Label::new(cx, Localized::new("refresh")));
+            Button::new(
+                cx,
+                |cx| cx.emit(AppEvent::ReceiveEmail),
+                |cx| Label::new(cx, Localized::new("refresh")),
+            );
         });
-    }).run()
+    })
+    .run()
 }

--- a/examples/resources/en-US/hello.ftl
+++ b/examples/resources/en-US/hello.ftl
@@ -1,1 +1,2 @@
-hello-world = Hello World
+hello-world = Hello, world!
+intro = Welcome, { $name }.

--- a/examples/resources/en-US/hello.ftl
+++ b/examples/resources/en-US/hello.ftl
@@ -1,2 +1,3 @@
 hello-world = Hello, world!
+enter-name = Please enter your name:
 intro = Welcome, { $name }.

--- a/examples/resources/en-US/hello.ftl
+++ b/examples/resources/en-US/hello.ftl
@@ -1,3 +1,9 @@
 hello-world = Hello, world!
 enter-name = Please enter your name:
 intro = Welcome, { $name }.
+emails =
+    { $unread_emails ->
+        [one] You have one unread email.
+       *[other] You have { $unread_emails } unread emails.
+    }
+refresh = Refresh

--- a/examples/resources/fr/hello.ftl
+++ b/examples/resources/fr/hello.ftl
@@ -1,1 +1,3 @@
-hello-world = Bonjour monde!
+hello-world = Bonjour, monde!
+intro = Bienvenue, { $name }
+enter-name = Veuillez saisir votre nom

--- a/examples/resources/fr/hello.ftl
+++ b/examples/resources/fr/hello.ftl
@@ -1,3 +1,9 @@
 hello-world = Bonjour, monde!
 intro = Bienvenue, { $name }
 enter-name = Veuillez saisir votre nom
+emails =
+    { $unread_emails ->
+        [one] Vous avez un e-mail non lu.
+       *[other] Vous avez { $unread_emails } e-mails non lus.
+    }
+refresh = Actualiser la page


### PR DESCRIPTION
See the i10n.rs example for example usage. Long story short, you can provide a `Localized` struct anywhere a string is expected in a property setter. This struct allows you to grab a key out of the current locale's translation (translations are added with cx.add_translation(lang, flt_syntax)) and format it with a given number of args. Args are lenses, and the resulting text will be bound to the content of all the provided lenses.

```rust
Label::new(cx, Localized::new("my-key").arg("my-arg1", lens1).arg("my-arg2", lens2))
```