### PR TITLE
Add tab focus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ path = "examples/7GUIs/flight_booker.rs"
 name = "7guis_crud"
 path = "examples/7GUIs/crud.rs"
 
+[[example]]
+name = "focus_order"
+path = "examples/accessibility/focus_order.rs"
+
 [features]
 default = ["glutin", "clipboard"]
 clipboard = ["vizia_core/clipboard"]

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -224,6 +224,16 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
+    pub fn focusable(self, state: bool) -> Self {
+        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
+            abilities.set(Abilities::FOCUSABLE, state);
+        }
+
+        self.cx.style.needs_restyle = true;
+
+        self
+    }
+
     pub fn child_space(self, value: Units) -> Self {
         self.cx.style.child_left.insert(self.entity, value);
         self.cx.style.child_right.insert(self.entity, value);

--- a/core/src/modifiers/actions.rs
+++ b/core/src/modifiers/actions.rs
@@ -364,6 +364,122 @@ impl<V: View> View for Move<V> {
     }
 }
 
+// FocusIn
+pub struct FocusIn<V: View> {
+    view: Box<dyn ViewHandler>,
+    action: Option<Box<dyn Fn(&mut Context)>>,
+
+    p: PhantomData<V>,
+}
+
+impl<V: View> FocusIn<V> {
+    pub fn new<'a, F>(handle: Handle<'a, V>, action: F) -> Handle<'a, FocusIn<V>>
+    where
+        F: 'static + Fn(&mut Context),
+    {
+        if let Some(mut view) = handle.cx.views.remove(&handle.entity) {
+            if view.downcast_ref::<V>().is_some() {
+                let item = Self { view, action: Some(Box::new(action)), p: Default::default() };
+
+                handle.cx.views.insert(handle.entity, Box::new(item));
+            } else {
+                if let Some(view) = view.downcast_mut::<FocusIn<V>>() {
+                    view.action = Some(Box::new(action));
+                }
+                handle.cx.views.insert(handle.entity, view);
+            }
+        }
+
+        Handle { entity: handle.entity, p: Default::default(), cx: handle.cx }
+    }
+}
+
+impl<V: View> View for FocusIn<V> {
+    fn element(&self) -> Option<String> {
+        self.view.element()
+    }
+
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        self.view.event(cx, event);
+
+        if let Some(window_event) = event.message.downcast() {
+            match window_event {
+                WindowEvent::FocusIn => {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx);
+
+                        self.action = Some(action);
+                    }
+                }
+
+                _ => {}
+            }
+        }
+    }
+
+    fn draw(&self, cx: &mut Context, canvas: &mut crate::Canvas) {
+        self.view.draw(cx, canvas);
+    }
+}
+
+// FocusOut
+pub struct FocusOut<V: View> {
+    view: Box<dyn ViewHandler>,
+    action: Option<Box<dyn Fn(&mut Context)>>,
+
+    p: PhantomData<V>,
+}
+
+impl<V: View> FocusOut<V> {
+    pub fn new<'a, F>(handle: Handle<'a, V>, action: F) -> Handle<'a, FocusOut<V>>
+    where
+        F: 'static + Fn(&mut Context),
+    {
+        if let Some(mut view) = handle.cx.views.remove(&handle.entity) {
+            if view.downcast_ref::<V>().is_some() {
+                let item = Self { view, action: Some(Box::new(action)), p: Default::default() };
+
+                handle.cx.views.insert(handle.entity, Box::new(item));
+            } else {
+                if let Some(view) = view.downcast_mut::<FocusOut<V>>() {
+                    view.action = Some(Box::new(action));
+                }
+                handle.cx.views.insert(handle.entity, view);
+            }
+        }
+
+        Handle { entity: handle.entity, p: Default::default(), cx: handle.cx }
+    }
+}
+
+impl<V: View> View for FocusOut<V> {
+    fn element(&self) -> Option<String> {
+        self.view.element()
+    }
+
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        self.view.event(cx, event);
+
+        if let Some(window_event) = event.message.downcast() {
+            match window_event {
+                WindowEvent::FocusOut => {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx);
+
+                        self.action = Some(action);
+                    }
+                }
+
+                _ => {}
+            }
+        }
+    }
+
+    fn draw(&self, cx: &mut Context, canvas: &mut crate::Canvas) {
+        self.view.draw(cx, canvas);
+    }
+}
+
 // Geo
 pub struct Geo<V: View> {
     view: Box<dyn ViewHandler>,
@@ -450,6 +566,14 @@ pub trait Actions<'a> {
     where
         F: 'static + Fn(&mut Context, f32, f32);
 
+    fn on_focus_in<F>(self, action: F) -> Handle<'a, FocusIn<Self::View>>
+    where
+        F: 'static + Fn(&mut Context);
+
+    fn on_focus_out<F>(self, action: F) -> Handle<'a, FocusOut<Self::View>>
+    where
+        F: 'static + Fn(&mut Context);
+
     fn on_geo_changed<F>(self, action: F) -> Handle<'a, Geo<Self::View>>
     where
         F: 'static + Fn(&mut Context, GeometryChanged);
@@ -497,6 +621,20 @@ impl<'a, V: View> Actions<'a> for Handle<'a, V> {
         F: 'static + Fn(&mut Context, f32, f32),
     {
         Move::new(self, action)
+    }
+
+    fn on_focus_in<F>(self, action: F) -> Handle<'a, FocusIn<Self::View>>
+    where
+        F: 'static + Fn(&mut Context),
+    {
+        FocusIn::new(self, action)
+    }
+
+    fn on_focus_out<F>(self, action: F) -> Handle<'a, FocusOut<Self::View>>
+    where
+        F: 'static + Fn(&mut Context),
+    {
+        FocusOut::new(self, action)
     }
 
     fn on_geo_changed<F>(self, action: F) -> Handle<'a, Geo<Self::View>>

--- a/core/src/state/binding.rs
+++ b/core/src/state/binding.rs
@@ -94,6 +94,7 @@ where
         let _: Handle<Self> = Handle { entity: id, p: Default::default(), cx }
             .width(Units::Stretch(1.0))
             .height(Units::Stretch(1.0))
+            .focusable(false)
             .ignore();
     }
 }

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -1,0 +1,30 @@
+use crate::{
+    Abilities, DoubleEndedTreeTour, Entity, Style, TourDirection, Tree, TreeIterator, TreeTour,
+};
+
+pub fn is_focusable<'a>(style: &'a Style, node: Entity) -> bool {
+    style
+        .abilities
+        .get(node)
+        .and_then(|abilities| Some(abilities.contains(Abilities::FOCUSABLE)))
+        .unwrap_or(true)
+}
+
+pub fn focus_forward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
+    TreeIterator { tree, tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())) }
+        .filter(|node| is_focusable(style, *node))
+        .nth(1)
+}
+
+pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
+    TreeIterator {
+        tree,
+        tours: DoubleEndedTreeTour::new_raw(
+            TreeTour::new(Some(Entity::root())),
+            TreeTour::with_direction(Some(node), TourDirection::Leaving),
+        ),
+        //tours: DoubleEndedTreeTour::new(Some(Entity::root()), Some(node)),
+    }
+    .filter(|node| is_focusable(style, *node))
+    .nth_back(1)
+}

--- a/core/src/tree/mod.rs
+++ b/core/src/tree/mod.rs
@@ -24,3 +24,6 @@ pub use tree_ext::*;
 
 mod debug_iter;
 pub use debug_iter::TreeDepthIterator;
+
+mod focus_iter;
+pub use focus_iter::{focus_backward, focus_forward, is_focusable};

--- a/core/src/tree/tree_iter.rs
+++ b/core/src/tree/tree_iter.rs
@@ -2,8 +2,8 @@ use crate::{DoubleEndedTreeTour, Entity, TourDirection, TourStep, Tree};
 
 /// Iterator for iterating through the tree in depth first preorder.
 pub struct TreeIterator<'a> {
-    tree: &'a Tree,
-    tours: DoubleEndedTreeTour,
+    pub(crate) tree: &'a Tree,
+    pub(crate) tours: DoubleEndedTreeTour,
 }
 
 impl<'a> TreeIterator<'a> {

--- a/core/src/tree/tree_tour.rs
+++ b/core/src/tree/tree_tour.rs
@@ -68,6 +68,10 @@ impl TreeTour {
         Self { current: start, direction: TourDirection::Entering }
     }
 
+    pub fn with_direction(start: Option<Entity>, direction: TourDirection) -> Self {
+        Self { current: start, direction }
+    }
+
     /// Traverse tree until next item is yielded, or iteration stops.
     ///
     /// The callback is called each time a node is "entered" or "left", as described by the second
@@ -157,6 +161,10 @@ impl DoubleEndedTreeTour {
 
     pub fn new_same(start_both: Option<Entity>) -> Self {
         Self { forward: TreeTour::new(start_both), backward: TreeTour::new(start_both) }
+    }
+
+    pub fn new_raw(forward: TreeTour, backward: TreeTour) -> Self {
+        Self { forward, backward }
     }
 
     pub fn next_with<O, F>(&mut self, tree: &Tree, mut cb: F) -> Option<O>

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -16,7 +16,7 @@ impl Button {
         Label: 'static + View,
     {
         Self { action: Some(Box::new(action)) }.build2(cx, move |cx| {
-            (label)(cx);
+            (label)(cx).focusable(false);
         })
     }
 }

--- a/core/src/views/stack.rs
+++ b/core/src/views/stack.rs
@@ -12,9 +12,11 @@ impl VStack {
     where
         F: FnOnce(&mut Context),
     {
-        Self {}.build2(cx, |cx| {
-            (content)(cx);
-        })
+        Self {}
+            .build2(cx, |cx| {
+                (content)(cx);
+            })
+            .focusable(false)
     }
 }
 
@@ -37,6 +39,7 @@ impl HStack {
                 (content)(cx);
             })
             .layout_type(LayoutType::Row)
+            .focusable(false)
     }
 }
 
@@ -54,9 +57,11 @@ impl ZStack {
     where
         F: FnOnce(&mut Context),
     {
-        Self {}.build2(cx, |cx| {
-            (content)(cx);
-        })
+        Self {}
+            .build2(cx, |cx| {
+                (content)(cx);
+            })
+            .focusable(false)
     }
 }
 

--- a/examples/accessibility/focus_order.rs
+++ b/examples/accessibility/focus_order.rs
@@ -1,0 +1,59 @@
+use vizia::*;
+
+const STYLE: &str = r#"
+    button:focus {
+        border-width: 1px;
+        border-color: blue;
+    }
+"#;
+
+#[derive(Lens)]
+pub struct AppData {
+    text: String,
+}
+
+pub enum AppEvent {
+    SetText(String),
+}
+
+impl Model for AppData {
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        if let Some(app_event) = event.message.downcast() {
+            match app_event {
+                AppEvent::SetText(text) => {
+                    self.text = text.clone();
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let window_description = WindowDescription::new().with_title("Focus Order");
+    Application::new(window_description, |cx| {
+        cx.add_theme(STYLE);
+
+        AppData { text: "".to_string() }.build(cx);
+
+        VStack::new(cx, |cx| {
+            HStack::new(cx, |cx| {
+                Button::new(cx, |_| {}, |cx| Label::new(cx, "Button 1"))
+                    .on_focus_in(|cx| cx.emit(AppEvent::SetText("Button 1".to_string())))
+                    .on_focus_out(|cx| cx.emit(AppEvent::SetText("".to_string())));
+                Button::new(cx, |_| {}, |cx| Label::new(cx, "Button 2"))
+                    .on_focus_in(|cx| cx.emit(AppEvent::SetText("Button 2".to_string())))
+                    .on_focus_out(|cx| cx.emit(AppEvent::SetText("".to_string())));
+                Button::new(cx, |_| {}, |cx| Label::new(cx, "Button 3"))
+                    .on_focus_in(|cx| cx.emit(AppEvent::SetText("Button 3".to_string())))
+                    .on_focus_out(|cx| cx.emit(AppEvent::SetText("".to_string())));
+            })
+            .col_between(Pixels(10.0))
+            .height(Auto);
+
+            Label::new(cx, AppData::text.map(|text| format!("Focused: {}", text)));
+        })
+        .child_space(Pixels(10.0))
+        .row_between(Pixels(10.0));
+    })
+    .run();
+}

--- a/examples/accessibility/focus_order.rs
+++ b/examples/accessibility/focus_order.rs
@@ -17,7 +17,7 @@ pub enum AppEvent {
 }
 
 impl Model for AppData {
-    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+    fn event(&mut self, _: &mut Context, event: &mut Event) {
         if let Some(app_event) = event.message.downcast() {
             match app_event {
                 AppEvent::SetText(text) => {


### PR DESCRIPTION
Adds ability to move focus using tab (forward) and shift + tab (backwards). Also adds action modifiers for `FocusIn` and `FocusOut` events.