### PR TITLE
Optimize text layout a bit

### DIFF
--- a/baseview/src/application.rs
+++ b/baseview/src/application.rs
@@ -308,10 +308,10 @@ impl ApplicationRunner {
 
         apply_visibility(&mut self.context, &tree);
 
-        apply_text_constraints(&mut self.context, &tree);
-
         // Layout
         if self.context.style.needs_relayout {
+            apply_text_constraints(&mut self.context, &tree);
+
             vizia_core::apply_layout(
                 &mut self.context.cache,
                 &self.context.tree,

--- a/core/src/style_system.rs
+++ b/core/src/style_system.rs
@@ -154,6 +154,17 @@ pub fn apply_text_constraints(cx: &mut Context, tree: &Tree) {
             continue;
         }
 
+        // content-size is only used if any dimension is auto
+        if cx.style.min_width.get(entity).copied().unwrap_or_default() != Units::Auto
+            && cx.style.min_height.get(entity).copied().unwrap_or_default() != Units::Auto
+            && cx.style.width.get(entity).copied().unwrap_or_default() != Units::Auto
+            && cx.style.height.get(entity).copied().unwrap_or_default() != Units::Auto
+            && cx.style.max_width.get(entity).map_or(true, |w| w != &Units::Auto)
+            && cx.style.max_height.get(entity).map_or(true, |h| h != &Units::Auto)
+        {
+            continue;
+        }
+
         let desired_width = cx.style.width.get(entity).cloned().unwrap_or_default();
         let desired_height = cx.style.height.get(entity).cloned().unwrap_or_default();
         let text = cx.style.text.get(entity);

--- a/core/src/style_system.rs
+++ b/core/src/style_system.rs
@@ -146,6 +146,10 @@ pub fn apply_text_constraints(cx: &mut Context, tree: &Tree) {
             continue;
         }
 
+        if cx.cache.display.get(entity) == Some(&Display::None) {
+            continue;
+        }
+
         if tree.is_ignored(entity) {
             continue;
         }

--- a/glutin/src/application.rs
+++ b/glutin/src/application.rs
@@ -325,10 +325,10 @@ impl Application {
 
                     apply_visibility(&mut context, &tree);
 
-                    apply_text_constraints(&mut context, &tree);
-
                     // Layout
                     if context.style.needs_relayout {
+                        apply_text_constraints(&mut context, &tree);
+
                         vizia_core::apply_layout(&mut context.cache, &context.tree, &context.style);
                         context.style.needs_relayout = false;
                     }


### PR DESCRIPTION
- Do not measure text on elements with display: none
- Do not measure text on elements with none of min/max/size: auto
- Only measure text on relayout