### PR TITLE
Update for upstream baseview changes and OpenGL context creation

### DIFF
--- a/baseview/Cargo.toml
+++ b/baseview/Cargo.toml
@@ -9,9 +9,8 @@ description = "Baseview backend for vizia"
 
 
 [dependencies]
-raw-gl-context = {git = "https://github.com/glowcoil/raw-gl-context", rev = "01f6251e7605e1d7de4bf1fead39693819398ef0"}
 vizia_core = { path = "../core" }
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "f6e99e9aa6f5aeb6b721cb05e4d882a51d995909"}
-keyboard-types = { version = "0.5.0", default-features = false }
-raw-window-handle = "0.3"
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "b3712638bacb3fdf2883cb5aa3f6caed0e91ac8c", features = ["opengl"] }
+keyboard-types = { version = "0.6.2", default-features = false }
+raw-window-handle = "0.4"
 femtovg = {version = "0.3.0", default-features = false}

--- a/baseview/src/parent_window.rs
+++ b/baseview/src/parent_window.rs
@@ -5,29 +5,35 @@ pub struct ParentWindow(pub *mut ::std::ffi::c_void);
 #[cfg(target_os = "macos")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::macos::MacOSHandle;
+        use raw_window_handle::AppKitHandle;
 
-        RawWindowHandle::MacOS(MacOSHandle {
-            ns_view: self.0 as *mut ::std::ffi::c_void,
-            ..MacOSHandle::empty()
-        })
+        let mut handle = AppKitHandle::empty();
+        handle.ns_view = self.0;
+
+        RawWindowHandle::AppKit(handle)
     }
 }
 
 #[cfg(target_os = "windows")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::windows::WindowsHandle;
+        use raw_window_handle::Win32Handle;
 
-        RawWindowHandle::Windows(WindowsHandle { hwnd: self.0, ..WindowsHandle::empty() })
+        let mut handle = Win32Handle::empty();
+        handle.hwnd = self.0;
+
+        RawWindowHandle::Win32(handle)
     }
 }
 
 #[cfg(target_os = "linux")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::unix::XcbHandle;
+        use raw_window_handle::XcbHandle;
 
-        RawWindowHandle::Xcb(XcbHandle { window: self.0 as u32, ..XcbHandle::empty() })
+        let mut handle = XcbHandle::empty();
+        handle.window = self.0 as u32;
+
+        RawWindowHandle::Xcb(handle)
     }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ image = { version = "0.24.0", default-features = false, features = ["png"] } # i
 morphorm = {git = "https://github.com/vizia/morphorm", features = ["rounding"], rev = "8d955d2f1d5b698e4fd1dbdfe36b3f3d9adbd19a" }
 bitflags = "1.3.2"
 fnv = "1.0.7"
-keyboard-types = { version = "0.5.0", default-features = false }
+keyboard-types = { version = "0.6.2", default-features = false }
 fluent-bundle = "0.15.2"
 fluent-langneg = "0.13"
 fluent-syntax = "0.11.0"

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -258,7 +258,7 @@ impl Context {
     }
 
     pub fn add_stylesheet(&mut self, path: &str) -> Result<(), std::io::Error> {
-        let style_string = std::fs::read_to_string(path.clone())?;
+        let style_string = std::fs::read_to_string(path)?;
         self.resource_manager.stylesheets.push(path.to_owned());
         self.style.parse_theme(&style_string);
 

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -10,7 +10,7 @@ description = "Winit backend for vizia"
 [dependencies]
 winit = "0.26.1"
 femtovg = { version = "0.3.0", default-features = false }
-keyboard-types = { version = "0.5.0", default-features = false }
+keyboard-types = { version = "0.6.2", default-features = false }
 vizia_core = { path = "../core", version = "0.1" }
 #fnv = "1.0.7"
 


### PR DESCRIPTION
OpenGL context creation is now handled by baseview instead of by raw-gl-context for the reasons outlined in https://github.com/RustAudio/baseview/pull/115. This fixes issues on a variety of desktop Linux configurations. raw-window-handle and keyboard-types have also been updated to match those used by baseview.