### PR TITLE
Allow whitespace around > selectors

### DIFF
--- a/core/src/style/parser.rs
+++ b/core/src/style/parser.rs
@@ -250,8 +250,16 @@ fn parse_selectors<'i, 't>(
                 whitespace = false;
             }
 
-            Token::WhiteSpace(ref _ws) => {
-                whitespace = true;
+            Token::WhiteSpace(_ws) => {
+                // Parent relations can (and in almost every style guide, do) have whitespace
+                // surrounding the `>`. In those cases we should treat this as if there were no
+                // whitespace since the rest of this parser uses whitespace strictly to indicate
+                // regular nesting. Bit of a hack, but I didn't dare touching the rest of the
+                // parser.
+                whitespace = !matches!(
+                    selectors.last(),
+                    Some(Selector { relation: SelectorRelation::Parent, .. })
+                );
             }
 
             // Pseudo-class


### PR DESCRIPTION
Before this these selectors would be treated to target nested children. It's typical to use whitespace here, and most style guides and CSS formatters even enforce it. There's probably a neater way to implement this, but I wanted to avoid modifying the rest of the CSS parser.