### PR TITLE
Add ability to bind to local view data

### DIFF
--- a/core/src/events/event_handler.rs
+++ b/core/src/events/event_handler.rs
@@ -16,7 +16,7 @@ pub trait ViewHandler: Any {
 
 impl dyn ViewHandler {
     /// Check if a view handler is a certain type.
-    pub fn is<T: Any + 'static>(&self) -> bool {
+    pub fn is<T: Any>(&self) -> bool {
         // Get TypeId of the type this function is instantiated with
         let t = TypeId::of::<T>();
 

--- a/core/src/events/event_handler.rs
+++ b/core/src/events/event_handler.rs
@@ -42,7 +42,7 @@ impl dyn ViewHandler {
     /// Attempt to cast a view handler to an immutable reference to the specified type.
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
-        T: Any + 'static,
+        T: Any,
     {
         if self.is::<T>() {
             unsafe { Some(&*(self as *const dyn ViewHandler as *const T)) }

--- a/core/src/events/event_handler.rs
+++ b/core/src/events/event_handler.rs
@@ -16,7 +16,7 @@ pub trait ViewHandler: Any {
 
 impl dyn ViewHandler {
     /// Check if a view handler is a certain type.
-    pub fn is<T: ViewHandler + 'static>(&self) -> bool {
+    pub fn is<T: Any + 'static>(&self) -> bool {
         // Get TypeId of the type this function is instantiated with
         let t = TypeId::of::<T>();
 
@@ -30,7 +30,7 @@ impl dyn ViewHandler {
     /// Attempt to cast a view handler to a mutable reference to the specified type.
     pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: ViewHandler + 'static,
+        T: Any + 'static,
     {
         if self.is::<T>() {
             unsafe { Some(&mut *(self as *mut dyn ViewHandler as *mut T)) }
@@ -42,7 +42,7 @@ impl dyn ViewHandler {
     /// Attempt to cast a view handler to an immutable reference to the specified type.
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
-        T: ViewHandler + 'static,
+        T: Any + 'static,
     {
         if self.is::<T>() {
             unsafe { Some(&*(self as *const dyn ViewHandler as *const T)) }

--- a/core/src/events/event_handler.rs
+++ b/core/src/events/event_handler.rs
@@ -30,7 +30,7 @@ impl dyn ViewHandler {
     /// Attempt to cast a view handler to a mutable reference to the specified type.
     pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
     where
-        T: Any + 'static,
+        T: Any,
     {
         if self.is::<T>() {
             unsafe { Some(&mut *(self as *mut dyn ViewHandler as *mut T)) }

--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     idx_to_pos, measure_text_lines,
     style::{BorderCornerShape, GradientDirection},
-    text_layout, Context, Event, FontOrId, Handle, ViewHandler, ModelDataStore,
+    text_layout, Context, Event, FontOrId, Handle, ModelDataStore, ViewHandler,
 };
 
 use femtovg::{

--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     idx_to_pos, measure_text_lines,
     style::{BorderCornerShape, GradientDirection},
-    text_layout, Context, Event, FontOrId, Handle, ViewHandler,
+    text_layout, Context, Event, FontOrId, Handle, ViewHandler, ModelDataStore,
 };
 
 use femtovg::{

--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use crate::{
     style::{BorderCornerShape, GradientDirection},
-    Context, Event, FontOrId, Handle, ViewHandler,
+    Context, Event, FontOrId, Handle, ModelDataStore, ViewHandler,
 };
 
 use femtovg::{
@@ -27,6 +29,15 @@ pub trait View: 'static + Sized {
         cx.cache.add(id).expect("Failed to add to cache");
         cx.style.add(id);
         cx.views.insert(id, Box::new(self));
+
+        cx.data.insert(
+            id,
+            ModelDataStore {
+                data: HashMap::default(),
+                lenses_dedup: HashMap::default(),
+                lenses_dup: vec![],
+            },
+        );
 
         let handle = Handle { entity: id, p: Default::default(), cx };
 

--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -30,14 +30,16 @@ pub trait View: 'static + Sized {
         cx.style.add(id);
         cx.views.insert(id, Box::new(self));
 
-        cx.data.insert(
-            id,
-            ModelDataStore {
-                data: HashMap::default(),
-                lenses_dedup: HashMap::default(),
-                lenses_dup: vec![],
-            },
-        );
+        cx.data
+            .insert(
+                id,
+                ModelDataStore {
+                    data: HashMap::default(),
+                    lenses_dedup: HashMap::default(),
+                    lenses_dup: vec![],
+                },
+            )
+            .expect("Failed to insert model data store");
 
         let handle = Handle { entity: id, p: Default::default(), cx };
 

--- a/examples/local_binding.rs
+++ b/examples/local_binding.rs
@@ -1,0 +1,37 @@
+use vizia::*;
+
+#[derive(Lens)]
+pub struct CustomView {
+    some_data: String,
+}
+
+impl CustomView {
+    pub fn new<'a>(cx: &'a mut Context, txt: &str) -> Handle<'a, Self> {
+        Self { some_data: txt.to_owned() }.build2(cx, |cx| {
+            Label::new(cx, CustomView::some_data).on_press(|cx| cx.emit(CustomEvent::ChangeData));
+        })
+    }
+}
+
+pub enum CustomEvent {
+    ChangeData,
+}
+
+impl View for CustomView {
+    fn event(&mut self, _: &mut Context, event: &mut Event) {
+        if let Some(custom_event) = event.message.downcast() {
+            match custom_event {
+                CustomEvent::ChangeData => {
+                    self.some_data = "Something".to_owned();
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    Application::new(WindowDescription::new(), |cx| {
+        CustomView::new(cx, "Test");
+    })
+    .run();
+}


### PR DESCRIPTION
This allows descendant views to bins to data in their anscestors:
```rust
use vizia::*;

#[derive(Lens)]
pub struct CustomView {
    some_data: String,
}

impl CustomView {
    pub fn new<'a>(cx: &'a mut Context, txt: &str) -> Handle<'a, Self> {
        Self {
            some_data: txt.to_owned(),
        }.build2(cx, |cx|{
            Label::new(cx, CustomView::some_data)
                .on_press(|cx| cx.emit(CustomEvent::ChangeData));
        })
    }
}

pub enum CustomEvent {
    ChangeData,
}

impl View for CustomView {
    fn event(&mut self, _: &mut Context, event: &mut Event) {
        if let Some(custom_event) = event.message.downcast() {
            match custom_event {
                CustomEvent::ChangeData => {
                    self.some_data = "Something".to_owned();
                }
            }
        }
    }
}

fn main() {
    Application::new(WindowDescription::new(), |cx|{
        CustomView::new(cx, "Test");
    }).run();
}
```
In the above the `Label` binds to the local data within the `CustomView`.