### PR TITLE
Simplify slider view

### DIFF
--- a/core/src/default_theme.css
+++ b/core/src/default_theme.css
@@ -271,11 +271,9 @@ slider.vertical {
     top: auto;
     bottom: auto;
     height: 1s;
-    width: 10px;
+    width: 5px;
 }
 
-slider track {
-}
 
 slider .active {
     background-color: #005a9e;
@@ -288,27 +286,10 @@ slider .thumb {
     bottom: 1s;
     border-radius: 14.5px;
     border-color: #cccccc;
-    border-width: 1px;
+    border-width: 2px;
     width: 26px;
     height: 26px;
     child-space: 1s;
-}
-
-slider .thumb>.inner {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background-color: #005a9e;
-}
-
-slider .thumb:hover>.inner {
-    width: 18px;
-    height: 18px;
-}
-
-slider:active .thumb>.inner {
-    width: 10px;
-    height: 10px;
 }
 
 scrollbar {

--- a/examples/controls/slider.rs
+++ b/examples/controls/slider.rs
@@ -6,28 +6,30 @@ fn main() {
 
         AppData { value: 0.5 }.build(cx);
 
-        for _ in 0..5 {
+        HStack::new(cx, |cx| {
             HStack::new(cx, |cx| {
-                Slider::new(cx, AppData::value, Orientation::Horizontal)
+                Slider::new(cx, AppData::value)
                     .on_changing(move |cx, val| cx.emit(AppEvent::SetValue(val)));
                 Label::new(cx, AppData::value.map(|val| format!("{:.2}", val)));
             })
             .height(Pixels(50.0))
-            .child_space(Pixels(50.0))
-            .col_between(Pixels(50.0));
-        }
+            .child_top(Stretch(1.0))
+            .child_bottom(Stretch(1.0))
+            .col_between(Pixels(10.0));
 
-        // HStack::new(cx, |cx| {
-        //     Binding::new(cx, SliderData::value, |cx, value| {
-        //         Slider::new(cx, *value.get(cx), Orientation::Vertical)
-        //             .class("vertical")
-        //             .on_press(cx, |_| println!("Press"));
-        //         let value = *value.get(cx);
-        //         Label::new(cx, &format!("{:.*}", 2, value));
-        //     });
-        // })
-        // .child_space(Pixels(50.0))
-        // .col_between(Pixels(50.0));
+            VStack::new(cx, |cx| {
+                Slider::new(cx, AppData::value)
+                    .on_changing(move |cx, val| cx.emit(AppEvent::SetValue(val)))
+                    .class("vertical");
+                Label::new(cx, AppData::value.map(|val| format!("{:.2}", val)));
+            })
+            .width(Pixels(50.0))
+            .child_left(Stretch(1.0))
+            .child_right(Stretch(1.0))
+            .row_between(Pixels(10.0));
+        })
+        .child_space(Pixels(50.0))
+        .col_between(Pixels(50.0));
     })
     .run();
 }


### PR DESCRIPTION
This PR simplifies the slider control, making use of the local data binding introduced in #99. The changes also include removing the need to pass an `Orientation` to the slider, instead deriving it from the slider dimensions after layout.

Another thing we should consider as a possible addition to this PR is whether or not the slider should take a specified `min`/`max` instead of  working only with a normalized value.