### PR TITLE
Fix broken doc links

### DIFF
--- a/core/src/animation/animation.rs
+++ b/core/src/animation/animation.rs
@@ -12,7 +12,7 @@ const ANIMATION_GENERATION_MASK: u32 = (1 << ANIMATION_GENERATION_BITS) - 1;
 /// An id used to reference style animations stored in context.
 ///
 /// An animation id is returned by `cx.add_animation()` and can be used to configure animations
-/// as well as to play, pause, and stop animations on entities (see [`AnimExt`]).
+/// as well as to play, pause, and stop animations on entities (see [`AnimExt`](crate::AnimExt)).
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Animation(u32);
 

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -38,7 +38,7 @@
 //!     }
 //! }
 //! ```
-//! This trait also allows data to be built into the [Tree]:
+//! This trait also allows data to be built into the [Tree](crate::Tree):
 //! ```compile_fail
 //! fn main() {
 //!     Application::new(WindowDescription::new(), |cx|{
@@ -60,7 +60,7 @@
 //! ```
 //! The second parameter to the [Binding] view is a [Lens], allowing us to bind to some field of the application data.
 //! The third parameter is a closure which provides the context and the lens, which can be used to retrieve the bound data using the `.get()`
-//! method, which takes the [Context] as an argument.
+//! method, which takes the [Context](crate::Context) as an argument.
 //!
 //! Now when the data is modified by another widget, the label will update, for example:
 //! ```compile_fail

--- a/core/src/style/prop.rs
+++ b/core/src/style/prop.rs
@@ -8,7 +8,7 @@ use crate::tree::TreeExt;
 
 use morphorm::{LayoutType, PositionType, Units};
 
-/// To be replaced by [PropSet2]
+/// To be replaced by `PropSet2`
 pub trait PropSet: AsEntity + Sized {
     /// Helper method for sending an event to self with upward propagation
     ///


### PR DESCRIPTION
Fixed some broken doc links I noticed when running `cargo doc`. Might be worth adding a `cargo doc` run to the CI.