### PR TITLE
Remove view `build` and rename `build2` to `build`

### DIFF
--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -20,7 +20,7 @@ const KAPPA90: f32 = 0.5522847493;
 pub trait View: 'static + Sized {
     #[allow(unused_variables)]
     fn body(&mut self, cx: &mut Context) {}
-    fn build2<F>(self, cx: &mut Context, builder: F) -> Handle<Self>
+    fn build<F>(self, cx: &mut Context, builder: F) -> Handle<Self>
     where
         F: FnOnce(&mut Context),
     {
@@ -55,20 +55,6 @@ pub trait View: 'static + Sized {
         handle.cx.current = prev;
 
         handle
-    }
-
-    fn build(mut self, cx: &mut Context) -> Handle<Self> {
-        let id = cx.entity_manager.create();
-        cx.tree.add(id, cx.current).expect("Failed to add to tree");
-        cx.cache.add(id).expect("Failed to add to cache");
-        cx.style.add(id);
-        let prev = cx.current;
-        cx.current = id;
-        self.body(cx);
-        cx.current = prev;
-        cx.views.insert(id, Box::new(self));
-
-        Handle { entity: id, p: Default::default(), cx }
     }
 
     fn element(&self) -> Option<String> {

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -15,7 +15,7 @@ impl Button {
         L: 'static + Fn(&mut Context) -> Handle<Label>,
         Label: 'static + View,
     {
-        Self { action: Some(Box::new(action)) }.build2(cx, move |cx| {
+        Self { action: Some(Box::new(action)) }.build(cx, move |cx| {
             (label)(cx).hoverable(false).focusable(false);
         })
     }

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -39,7 +39,7 @@ pub struct Checkbox {
 impl Checkbox {
     pub fn new(cx: &mut Context, checked: impl Lens<Target = bool>) -> Handle<Self> {
         //let checked = checked.get_val_fallible(cx).unwrap_or(false);
-        Self { on_toggle: None }.build2(cx, |_| {}).bind(checked, |handle, checked| {
+        Self { on_toggle: None }.build(cx, |_| {}).bind(checked, |handle, checked| {
             if let Some(flag) = checked.get_val_fallible(handle.cx) {
                 handle.text(if flag { ICON_CHECK } else { "" }).checked(flag);
             }

--- a/core/src/views/dropdown.rs
+++ b/core/src/views/dropdown.rs
@@ -14,7 +14,7 @@ impl Dropdown {
         Label: 'static + View,
     {
         Self {}
-            .build2(cx, move |cx| {
+            .build(cx, move |cx| {
                 if cx.data::<PopupData>().is_none() {
                     PopupData::default().build(cx);
                 }

--- a/core/src/views/element.rs
+++ b/core/src/views/element.rs
@@ -7,7 +7,7 @@ pub struct Element {}
 
 impl Element {
     pub fn new(cx: &mut Context) -> Handle<Self> {
-        Self {}.build(cx)
+        Self {}.build(cx, |_| {})
     }
 }
 

--- a/core/src/views/image.rs
+++ b/core/src/views/image.rs
@@ -4,7 +4,7 @@ pub struct Image {}
 
 impl Image {
     pub fn new<T: ToString>(cx: &mut Context, img: impl Res<T>) -> Handle<'_, Self> {
-        Self {}.build2(cx, |_| {}).image(img)
+        Self {}.build(cx, |_| {}).image(img)
     }
 }
 

--- a/core/src/views/knob.rs
+++ b/core/src/views/knob.rs
@@ -48,7 +48,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
 
             on_changing: None,
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             ZStack::new(cx, move |cx| {
                 ArcTrack::new(
                     cx,
@@ -98,7 +98,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
 
             on_changing: None,
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             ZStack::new(cx, move |cx| {
                 (content)(cx, lens).width(Percentage(100.0)).height(Percentage(100.0));
             });
@@ -251,7 +251,7 @@ impl Ticks {
 
             mode,
         }
-        .build(cx)
+        .build(cx, |_| {})
     }
 }
 impl View for Ticks {
@@ -350,7 +350,7 @@ impl TickKnob {
             normalized_value: 0.5,
             mode,
         }
-        .build(cx)
+        .build(cx, |_| {})
     }
 }
 impl View for TickKnob {
@@ -479,7 +479,7 @@ impl ArcTrack {
             center,
             mode,
         }
-        .build(cx)
+        .build(cx, |_| {})
     }
 }
 

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -7,7 +7,7 @@ impl Label {
     where
         T: ToString,
     {
-        Self {}.build2(cx, |_| {}).text(text)
+        Self {}.build(cx, |_| {}).text(text)
     }
 }
 

--- a/core/src/views/list.rs
+++ b/core/src/views/list.rs
@@ -29,7 +29,7 @@ impl<L: 'static + Lens<Target = Vec<T>>, T> List<L, T> {
             decrement_callback: None,
             clear_callback: None,
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             //let list_lens = lens.clone();
             // Bind to the list data
             Binding::new(cx, lens.clone().map(|lst| lst.len()), move |cx, list_len| {

--- a/core/src/views/menu.rs
+++ b/core/src/views/menu.rs
@@ -109,7 +109,7 @@ impl MenuController {
             panic!("Building a MenuController inside a MenuController. This is illegal.")
         }
 
-        Self {}.build2(cx, move |cx| {
+        Self {}.build(cx, move |cx| {
             MenuControllerData { active }.build(cx);
             if active {
                 cx.capture();
@@ -189,7 +189,7 @@ impl MenuStack {
         if cx.data::<MenuControllerData>().is_none() {
             panic!("MenuStacks must be built inside a MenuController");
         }
-        Self {}.build2(cx, move |cx| {
+        Self {}.build(cx, move |cx| {
             MenuData::default().build(cx);
             builder(cx);
         })
@@ -225,7 +225,7 @@ impl Menu {
         F1: 'static + FnOnce(&mut Context) -> Handle<'_, Lbl>,
         F2: 'static + FnOnce(&mut Context),
     {
-        let result = Self {}.build2(cx, move |cx| {
+        let result = Self {}.build(cx, move |cx| {
             HStack::new(cx, move |cx| {
                 label(cx);
                 Label::new(cx, ICON_ARROW).class("menu_arrow");
@@ -267,7 +267,7 @@ impl MenuButton {
         A: 'static + Fn(&mut Context),
     {
         setup_menu_entry(
-            Self { action: Some(Box::new(action)) }.build2(cx, move |cx| {
+            Self { action: Some(Box::new(action)) }.build(cx, move |cx| {
                 contents(cx);
             }),
             |_| {},

--- a/core/src/views/picker.rs
+++ b/core/src/views/picker.rs
@@ -21,7 +21,7 @@ where
         F: 'static + Fn(&mut Context, L),
     {
         Self { lens: PhantomData::default() }
-            .build2(cx, move |cx| {
+            .build(cx, move |cx| {
                 Binding::new(cx, lens, move |cx, option| {
                     (builder)(cx, option);
                 });
@@ -51,7 +51,7 @@ impl PickerItem {
         value: T,
     ) -> Handle<'a, Self> {
         Self {}
-            .build2(cx, move |cx| {
+            .build(cx, move |cx| {
                 let opt = option.clone();
                 Button::new(
                     cx,

--- a/core/src/views/popup.rs
+++ b/core/src/views/popup.rs
@@ -50,7 +50,7 @@ where
         F: 'static + Fn(&mut Context),
     {
         Self { lens: lens.clone() }
-            .build2(cx, |cx| {
+            .build(cx, |cx| {
                 (builder)(cx);
             })
             .checked(lens)

--- a/core/src/views/radio_buttons.rs
+++ b/core/src/views/radio_buttons.rs
@@ -9,7 +9,7 @@ pub struct RadioButton {
 impl RadioButton {
     pub fn new(cx: &mut Context, checked: impl Lens<Target = bool>) -> Handle<Self> {
         Self { on_select: None }
-            .build2(cx, |cx| {
+            .build(cx, |cx| {
                 Element::new(cx).class("inner").position_type(PositionType::SelfDirected);
             })
             .checked(checked)

--- a/core/src/views/scrollbar.rs
+++ b/core/src/views/scrollbar.rs
@@ -28,7 +28,7 @@ impl<L1: Lens<Target = f32>> Scrollbar<L1> {
             reference_points: None,
             on_changing: Some(Box::new(callback)),
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             Element::new(cx)
                 .class("thumb")
                 .bind(value, move |handle, value| {

--- a/core/src/views/scrollview.rs
+++ b/core/src/views/scrollview.rs
@@ -99,7 +99,7 @@ impl ScrollView<scroll_data_derived_lenses::root> {
     where
         F: 'static + FnOnce(&mut Context),
     {
-        Self { data: ScrollData::root }.build2(cx, move |cx| {
+        Self { data: ScrollData::root }.build(cx, move |cx| {
             ScrollData {
                 scroll_x: initial_x,
                 scroll_y: initial_y,
@@ -130,7 +130,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
             panic!("ScrollView::custom requires a ScrollData to be built into a parent");
         }
 
-        Self { data: data.clone() }.build2(cx, |cx| {
+        Self { data: data.clone() }.build(cx, |cx| {
             Self::common_builder(cx, data, content, scroll_x, scroll_y);
         })
     }

--- a/core/src/views/slider.rs
+++ b/core/src/views/slider.rs
@@ -96,7 +96,7 @@ where
             on_min: None,
             on_max: None,
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             SliderDataInternal { size: 0.0, thumb_size: 0.0, orientation }.build(cx);
 
             // Add the various slider components using bindings to the slider data

--- a/core/src/views/slider.rs
+++ b/core/src/views/slider.rs
@@ -118,7 +118,7 @@ where
 
             on_changing: None,
         }
-        .build2(cx, move |cx| {
+        .build(cx, move |cx| {
             Binding::new(cx, Slider::<L>::internal, move |cx, slider_data| {
                 let lens = lens.clone();
                 ZStack::new(cx, move |cx| {

--- a/core/src/views/stack.rs
+++ b/core/src/views/stack.rs
@@ -13,7 +13,7 @@ impl VStack {
         F: FnOnce(&mut Context),
     {
         Self {}
-            .build2(cx, |cx| {
+            .build(cx, |cx| {
                 (content)(cx);
             })
             .focusable(false)
@@ -35,7 +35,7 @@ impl HStack {
         F: FnOnce(&mut Context),
     {
         Self {}
-            .build2(cx, |cx| {
+            .build(cx, |cx| {
                 (content)(cx);
             })
             .layout_type(LayoutType::Row)
@@ -58,7 +58,7 @@ impl ZStack {
         F: FnOnce(&mut Context),
     {
         Self {}
-            .build2(cx, |cx| {
+            .build(cx, |cx| {
                 (content)(cx);
             })
             .focusable(false)

--- a/core/src/views/table.rs
+++ b/core/src/views/table.rs
@@ -20,7 +20,7 @@ impl<L: 'static + Lens<Target = Vec<T>>, T: Data> Table<L, T> {
         F: 'static + Fn(&mut Context, L),
         <L as Lens>::Source: Model,
     {
-        Self { p: PhantomData::default() }.build2(cx, move |cx| {
+        Self { p: PhantomData::default() }.build(cx, move |cx| {
             HStack::new(cx, move |cx| {
                 (list_builder)(cx, lens);
             });
@@ -65,7 +65,7 @@ where
         Label: 'static + Fn(&mut Context),
         <R as Lens>::Source: Model,
     {
-        Self { p1: PhantomData::default(), p2: PhantomData::default() }.build2(cx, move |cx| {
+        Self { p1: PhantomData::default(), p2: PhantomData::default() }.build(cx, move |cx| {
             //VStack::new(cx, move |cx|{
             (label)(cx);
             //    Element::new(cx).height(Pixels(1.0)).background_color(Color::black());

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -460,7 +460,7 @@ where
     }
 
     fn new_core(cx: &mut Context, lens: L, kind: TextboxKind) -> Handle<Self> {
-        let result = Self { lens: lens.clone(), kind }.build2(cx, move |cx| {
+        let result = Self { lens: lens.clone(), kind }.build(cx, move |cx| {
             Binding::new(cx, lens.clone(), |cx, text| {
                 let text =
                     text.get_fallible(cx).map(|x| x.to_string()).unwrap_or_else(|| "".to_owned());
@@ -498,9 +498,9 @@ where
                 }
             });
             TextboxContainer {}
-                .build2(cx, move |cx| {
+                .build(cx, move |cx| {
                     let lbl = TextboxLabel {}
-                        .build(cx)
+                        .build(cx, |_| {})
                         .hoverable(false)
                         .class("textbox_content")
                         .text(TextboxData::text)

--- a/examples/local_binding.rs
+++ b/examples/local_binding.rs
@@ -7,7 +7,7 @@ pub struct CustomView {
 
 impl CustomView {
     pub fn new<'a>(cx: &'a mut Context, txt: &str) -> Handle<'a, Self> {
-        Self { some_data: txt.to_owned() }.build2(cx, |cx| {
+        Self { some_data: txt.to_owned() }.build(cx, |cx| {
             Label::new(cx, CustomView::some_data).on_press(|cx| cx.emit(CustomEvent::ChangeData));
         })
     }

--- a/examples/local_data.rs
+++ b/examples/local_data.rs
@@ -2,7 +2,7 @@ use vizia::*;
 
 fn main() {
     Application::new(WindowDescription::new().with_title("Local Data"), |cx| {
-        CustomView::new().set_value(3.14).build(cx);
+        CustomView::new().set_value(3.14).build(cx, |_| {});
     })
     .run();
 }

--- a/examples/perf_tests/rebuild.rs
+++ b/examples/perf_tests/rebuild.rs
@@ -11,7 +11,7 @@ impl View for BranchingView { }
 
 impl BranchingView {
     pub fn new(cx: &mut Context, depth: usize) -> Handle<'_, Self> {
-        Self {}.build2(cx, move |cx| {
+        Self {}.build(cx, move |cx| {
             if depth > 0 {
                 Self::new(cx, depth - 1);
                 Self::new(cx, depth - 1);


### PR DESCRIPTION
I'm also open to having another method for building views with no children to avoid the `|_| {}` but I feel that `build` should be the version which allows children as it's used more often.