### PR TITLE
Re-export the image crate

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -78,6 +78,12 @@ pub use modifiers::*;
 mod enviroment;
 pub use enviroment::*;
 
-pub mod vg;
+// Re-export femtovg through a vg module
+pub mod vg {
+    pub use femtovg;
+}
+
+// Re-export the image crate
+pub use image;
 
 pub use keyboard_types::{Code, Key};

--- a/core/src/vg.rs
+++ b/core/src/vg.rs
@@ -1,1 +1,0 @@
-pub use femtovg::*;


### PR DESCRIPTION
As suggested in #106.

Also moves vg module to lib.rs and removes unnecessary vg file.