### PR TITLE
Fallback when unable to initialize the clipboard

### DIFF
--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-#[cfg(feature = "clipboard")]
-use copypasta::ClipboardProvider;
-
 use keyboard_types::Code;
 
 use crate::style::PropGet;


### PR DESCRIPTION
Currently vizia will crash if it is unable to create a ClipboardProvider
using the default provider for the platform. On Linux that is X11, so if
the display is using Wayland then the application will crash on startup.
This patch falls back to `NopClipboardContext` which does nothing.
The clipboard will not work but the application will not crash.

Fully implementing Wayland support will take more work as we need need a
`RawWidnowHandle` to request a proxy, which is not available until after
the `Context` is created.