### PR TITLE
Run all tests in CI: wasm, baseview, and doctests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        backend: [winit, baseview]
+        wasm: [""]
+        include:
+          - os: ubuntu-latest
+            backend: winit
+            wasm: "--target wasm32-unknown-unknown"
     env:
       RUSTFLAGS: '-D warnings'
     steps:
@@ -33,6 +39,6 @@ jobs:
     - name: Check Format
       run: cargo fmt -- --check
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose ${{ matrix.wasm }}
     - name: Run Tests
-      run: cargo test --verbose
+      run: cargo test --verbose ${{ matrix.wasm }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,5 @@ jobs:
     - name: Build
       run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }}
     - name: Run Tests
-      if: 'matrix.wasm == ""'
+      if: "matrix.wasm == ''"
       run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Check Format
       run: cargo fmt -- --check
     - name: Build
-      run: cargo build --verbose ${{ matrix.wasm }}
+      run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }}
     - name: Run Tests
-      run: cargo test --verbose ${{ matrix.wasm }}
+      if: matrix.wasm == ""
+      run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Check Format
       run: cargo fmt -- --check
     - name: Build
-      run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }}
+      run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }} --workspace
     - name: Run Tests
       if: "matrix.wasm == ''"
-      run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }}
+      run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }} --workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - name: Install wasm toolchain
+      if: "matrix.wasm != ''"
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
     - name: Check Format
       run: cargo fmt -- --check
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Check Format
       run: cargo fmt -- --check
     - name: Build
-      run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }} --workspace
+      run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }}
     - name: Run Tests
       if: "matrix.wasm == ''"
       run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }} --workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,5 @@ jobs:
     - name: Build
       run: cargo build --verbose --all-targets ${{ matrix.wasm }} --no-default-features --features clipboard,${{ matrix.backend }}
     - name: Run Tests
-      if: matrix.wasm == ""
+      if: 'matrix.wasm == ""'
       run: cargo test --verbose --no-default-features --features clipboard,${{ matrix.backend }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "A Rust GUI Framework"
+autoexamples = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,9 +12,101 @@ description = "A Rust GUI Framework"
 members = ["core", "winit", "baseview", "derive", "run-wasm"]
 
 [[example]]
+name = "action_modifier"
+path = "examples/action_modifier.rs"
+
+[[example]]
+name = "animation"
+path = "examples/animation.rs"
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[example]]
+name = "binding"
+path = "examples/binding.rs"
+
+[[example]]
+name = "compose"
+path = "examples/compose.rs"
+
+[[example]]
+name = "counter"
+path = "examples/counter.rs"
+
+[[example]]
+name = "cursor_icon"
+path = "examples/cursor_icon.rs"
+
+[[example]]
+name = "l10n"
+path = "examples/l10n.rs"
+
+[[example]]
+name = "local_binding"
+path = "examples/local_binding.rs"
+
+[[example]]
+name = "local_data"
+path = "examples/local_data.rs"
+
+[[example]]
+name = "long_list"
+path = "examples/long_list.rs"
+
+[[example]]
+name = "modal"
+path = "examples/modal.rs"
+
+[[example]]
+name = "more_knobs"
+path = "examples/more_knobs.rs"
+
+[[example]]
+name = "multiple_binding"
+path = "examples/multiple_binding.rs"
+
+[[example]]
+name = "overflow"
+path = "examples/overflow.rs"
+
+[[example]]
+name = "proxy"
+path = "examples/proxy.rs"
+
+[[example]]
+name = "scrollview"
+path = "examples/scrollview.rs"
+
+[[example]]
+name = "state"
+path = "examples/state.rs"
+
+[[example]]
+name = "stylesheet"
+path = "examples/stylesheet.rs"
+
+[[example]]
+name = "styling"
+path = "examples/styling.rs"
+
+[[example]]
+name = "table"
+path = "examples/table.rs"
+
+[[example]]
+name = "textbox_list"
+path = "examples/textbox_list.rs"
+
+[[example]]
+name = "transform"
+path = "examples/transform.rs"
+
+
+[[example]]
 name = "button"
 path = "examples/controls/button.rs"
-
 
 [[example]]
 name = "slider"

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -22,7 +22,7 @@ use crate::{Context, Handle, Res, View};
 ///
 /// ```
 /// # use vizia_core::*;
-/// # use vizia_winit::application::Application;
+/// # let cx = &mut Context::new();
 /// #
 /// #[derive(Lens)]
 /// struct AppData {
@@ -31,13 +31,12 @@ use crate::{Context, Handle, Res, View};
 ///
 /// impl Model for AppData {}
 ///
-/// Application::new(WindowDescription::new(), |cx| {
-///     AppData {
-///         text: String::from("Text"),
-///     }
-///     .build(cx);
-///     Label::new(cx, AppData::text);
-/// });
+/// AppData {
+///     text: String::from("Text"),
+/// }
+/// .build(cx);
+///
+/// Label::new(cx, AppData::text);
 /// ```
 ///
 /// ## Label with text wrapping

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -46,6 +46,7 @@ use crate::{Context, Handle, Res, View};
 ///
 /// ```
 /// # use vizia_core::*;
+/// # let mut cx = &mut Context::new();
 /// #
 /// Label::new(
 ///     cx,
@@ -60,6 +61,7 @@ use crate::{Context, Handle, Res, View};
 ///
 /// ```
 /// # use vizia_core::*;
+/// # let mut cx = &mut Context::new();
 /// #
 /// Label::new(
 ///     cx,
@@ -75,7 +77,6 @@ use crate::{Context, Handle, Res, View};
 ///
 /// ```
 /// # use vizia_core::*;
-/// #
 /// # let cx = &mut Context::new();
 /// #
 /// Button::new(cx, |_| {}, |cx| Label::new(cx, "Text"));
@@ -89,7 +90,6 @@ impl Label {
     ///
     /// ```
     /// # use vizia_core::*;
-    /// #
     /// # let cx = &mut Context::new();
     /// #
     /// let label = Label::new(cx, "Text");

--- a/core/src/views/slider.rs
+++ b/core/src/views/slider.rs
@@ -45,34 +45,37 @@ impl Default for Orientation {
 /// In the following example, a slider is bound to a value. The `on_changing` callback is used to send an event to mutate the
 /// bound value when the slider thumb is moved, or if the track is clicked on.
 /// ```
-/// # use vizia_core;
-/// # use vizia_derive;
+/// # use vizia_core::*;
+/// # use vizia_derive::*;
 /// # let mut cx = &mut Context::new();
-/// # #[derive(Lens)]
+/// # #[derive(Lens, Default)]
 /// # pub struct AppData {
 /// #     value: f32,
 /// # }
+/// # impl Model for AppData {}
+/// # AppData::default().build(cx);
 /// Slider::new(cx, AppData::value)
 ///     .on_changing(|cx, value| {
-///         cx.emit(WindowEvent::Debug(format!("Slider on_changing: {}", value)));
+///         println!("Slider on_changing: {}", value);
 ///     });
 /// ```
 ///
 /// ## Slider with Label
 /// ```
-/// # use vizia_core;
-/// # use vizia_derive;
+/// # use vizia_core::*;
+/// # use vizia_derive::*;
 /// # let mut cx = &mut Context::new();
-/// # #[derive(Lens)]
+/// # #[derive(Lens, Default)]
 /// # pub struct AppData {
 /// #     value: f32,
 /// # }
+/// # impl Model for AppData {}
+/// # AppData::default().build(cx);
 /// HStack::new(cx, |cx|{
 ///     Slider::new(cx, AppData::value)
 ///         .on_changing(|cx, value| {
-///             cx.emit(WindowEvent::Debug(format!("Slider on_changing: {}", value)));
-///         });///
-///     });
+///             println!("Slider on_changing: {}", value);
+///         });
 ///     Label::new(cx, AppData::value.map(|val| format!("{:.2}", val)));
 /// });
 /// ```
@@ -92,16 +95,18 @@ where
     ///
     /// # Example
     /// ```
-    /// # use vizia_core;
-    /// # use vizia_derive;
+    /// # use vizia_core::*;
+    /// # use vizia_derive::*;
     /// # let mut cx = &mut Context::new();
-    /// # #[derive(Lens)]
+    /// # #[derive(Lens, Default)]
     /// # pub struct AppData {
     /// #     value: f32,
     /// # }
+    /// # impl Model for AppData {}
+    /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .on_changing(|cx, value| {
-    ///         cx.emit(WindowEvent::Debug(format!("Slider on_changing: {}", value)));
+    ///         println!("Slider on_changing: {}", value);
     ///     });
     /// ```
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
@@ -318,16 +323,18 @@ impl<'a, L: Lens> Handle<'a, Slider<L>> {
     /// # Example
     ///
     /// ```
-    /// # use vizia_core;
-    /// # use vizia_derive;
+    /// # use vizia_core::*;
+    /// # use vizia_derive::*;
     /// # let mut cx = &mut Context::new();
-    /// # #[derive(Lens)]
+    /// # #[derive(Lens, Default)]
     /// # pub struct AppData {
     /// #     value: f32,
     /// # }
+    /// # impl Model for AppData {}
+    /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .on_changing(|cx, value| {
-    ///         cx.emit(WindowEvent::Debug(format!("Slider on_changing: {}", value)));
+    ///         println!("Slider on_changing: {}", value);
     ///     });
     /// ```
     pub fn on_changing<F>(self, callback: F) -> Self
@@ -349,17 +356,19 @@ impl<'a, L: Lens> Handle<'a, Slider<L>> {
     ///
     /// # Example
     /// ```
-    /// # use vizia_core;
-    /// # use vizia_derive;
+    /// # use vizia_core::*;
+    /// # use vizia_derive::*;
     /// # let mut cx = &mut Context::new();
-    /// # #[derive(Lens)]
+    /// # #[derive(Lens, Default)]
     /// # pub struct AppData {
     /// #     value: f32,
     /// # }
+    /// # impl Model for AppData {}
+    /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .range(-20.0..50.0)
     ///     .on_changing(|cx, value| {
-    ///         cx.emit(WindowEvent::Debug(format!("Slider on_changing: {}", value)));
+    ///         println!("Slider on_changing: {}", value);
     ///     });
     /// ```
     pub fn range(self, range: Range<f32>) -> Self {

--- a/examples/controls/image.rs
+++ b/examples/controls/image.rs
@@ -1,5 +1,7 @@
+#[allow(unused)]
 use vizia::*;
 
+#[allow(unused)]
 const STYLE: &'static str = r#"
 element {
     background-image: "sample.png";
@@ -9,8 +11,11 @@ element {
 "#;
 
 #[cfg(target_arch = "wasm32")]
-compile_error!("This example uses image loading that does not work on the web");
+fn main() {
+    panic!("This example is not supported on wasm - threads are experimental");
+}
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
     Application::new(WindowDescription::default(), |cx| {
         cx.add_theme(STYLE);

--- a/examples/controls/widget_gallery.rs
+++ b/examples/controls/widget_gallery.rs
@@ -15,7 +15,7 @@ fn main() {
         checkbox(cx).space(Pixels(30.0));
         // label(cx);
     })
-    .background_color(Color::rgb(249, 249, 249))
+    //.background_color(Color::rgb(249, 249, 249))
     .run();
 }
 

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,8 +1,17 @@
+#[allow(unused)]
 use vizia::*;
 
 #[cfg(target_arch = "wasm32")]
-compile_error!("This example does not work on wasm - threads are experimental");
+fn main() {
+    panic!("This example is not supported on wasm - threads are experimental");
+}
 
+#[cfg(feature = "baseview")]
+fn main() {
+    panic!("This example is not supported on baseview - proxies are winit only");
+}
+
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "baseview")))]
 fn main() {
     let app =
         Application::new(WindowDescription::new().with_title("Proxy"), |_| {}).on_idle(|_| {

--- a/examples/stylesheet.rs
+++ b/examples/stylesheet.rs
@@ -1,8 +1,12 @@
+#[allow(unused)]
 use vizia::*;
 
 #[cfg(target_arch = "wasm32")]
-compile_error!("This example is not supported on wasm - uses filesystem");
+fn main() {
+    panic!("This example is not supported on wasm - uses filesystem");
+}
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
     Application::new(WindowDescription::new().with_title("External CSS"), |cx| {
         cx.add_stylesheet("examples/resources/test.css").expect("Failed to find file");

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -42,12 +42,13 @@ impl Application {
         #[cfg(all(debug_assertions, target_arch = "wasm32"))]
         console_error_panic_hook::set_once();
 
+        #[allow(unused_mut)]
         let mut context = Context::new();
 
         let event_loop = EventLoop::with_user_event();
-        let event_proxy_obj = event_loop.create_proxy();
         #[cfg(not(target_arch = "wasm32"))]
         {
+            let event_proxy_obj = event_loop.create_proxy();
             context.event_proxy = Some(Box::new(WinitEventProxy(event_proxy_obj)));
         }
 

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -37,8 +37,8 @@ impl Window {
                 document.body().unwrap().insert_adjacent_element("afterbegin", &element).unwrap();
                 element
             }
-                .dyn_into::<web_sys::HtmlCanvasElement>()
-                .unwrap()
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .unwrap()
         };
 
         // Build the femtovg renderer
@@ -79,7 +79,6 @@ impl Window {
         // Intentional no-op
     }
 }
-
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Window {
@@ -167,7 +166,10 @@ impl View for Window {
     }
 }
 
-fn apply_window_description(builder: WindowBuilder, description: &WindowDescription) -> WindowBuilder {
+fn apply_window_description(
+    builder: WindowBuilder,
+    description: &WindowDescription,
+) -> WindowBuilder {
     builder
         .with_title(&description.title)
         .with_inner_size(PhysicalSize::new(
@@ -187,7 +189,7 @@ fn apply_window_description(builder: WindowBuilder, description: &WindowDescript
                     description.icon_width,
                     description.icon_height,
                 )
-                    .unwrap(),
+                .unwrap(),
             )
         } else {
             None
@@ -199,11 +201,5 @@ fn setup_canvas(result: &mut Window) {
     let dpi_factor = result.window().scale_factor();
     let size = result.window().inner_size();
     result.canvas.set_size(size.width as u32, size.height as u32, dpi_factor as f32);
-    result.canvas.clear_rect(
-        0,
-        0,
-        size.width as u32,
-        size.height as u32,
-        Color::rgb(255, 80, 80),
-    );
+    result.canvas.clear_rect(0, 0, size.width as u32, size.height as u32, Color::rgb(255, 80, 80));
 }


### PR DESCRIPTION
Closes #61 

This also entails explicitly enumerating each example in cargo.toml instead of relying on autodiscovery for some.