### PR TITLE
Restyle, relayout, and redraw when a new view is created

### DIFF
--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -857,6 +857,9 @@ impl Style {
         self.abilities.insert(entity, Abilities::default()).expect("Failed to add abilities");
         self.visibility.insert(entity, Default::default());
         self.focus_order.insert(entity, Default::default()).unwrap();
+        self.needs_restyle = true;
+        self.needs_relayout = true;
+        self.needs_redraw = true;
     }
 
     pub fn remove(&mut self, entity: Entity) {

--- a/core/src/view.rs
+++ b/core/src/view.rs
@@ -24,8 +24,6 @@ pub trait View: 'static + Sized {
     where
         F: FnOnce(&mut Context),
     {
-        // Add the instance to context even if it already exists
-
         let id = cx.entity_manager.create();
         cx.tree.add(id, cx.current).expect("Failed to add to tree");
         cx.cache.add(id).expect("Failed to add to cache");
@@ -45,13 +43,11 @@ pub trait View: 'static + Sized {
 
         let handle = Handle { entity: id, p: Default::default(), cx };
 
-        // ...and this part
         let prev = handle.cx.current;
         handle.cx.current = handle.entity;
 
         (builder)(handle.cx);
 
-        // This part will also be moved somewhere else
         handle.cx.current = prev;
 
         handle


### PR DESCRIPTION
Fixes a bug where views which are added in bindings wouldn't be styled correctly until something triggered a restyle.