### PR TITLE
Rename `tuix` to `vizia`

### DIFF
--- a/baseview/src/application.rs
+++ b/baseview/src/application.rs
@@ -48,7 +48,7 @@ where
     /// Do **not** use this in the context of audio plugins, unless it is compiled as a
     /// standalone application.
     ///
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn run(self) {
         ViziaWindow::open_blocking(
             self.window_description,
@@ -64,7 +64,7 @@ where
     /// used in the context of audio plugins.
     ///
     /// * `parent` - The parent window.
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn open_parented<P: HasRawWindowHandle>(self, parent: &P) -> WindowHandle {
         ViziaWindow::open_parented(
             parent,
@@ -80,7 +80,7 @@ where
     /// This function does **not** block the current thread. This is only to be
     /// used in the context of audio plugins.
     ///
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn open_as_if_parented(self) -> WindowHandle {
         ViziaWindow::open_as_if_parented(
             self.window_description,
@@ -104,7 +104,7 @@ where
     ///     // Build application here
     /// })
     /// .on_idle(|cx|{
-    ///     // Code here runs at the end of every event loop after OS and tuix events have been handled
+    ///     // Code here runs at the end of every event loop after OS and vizia events have been handled
     /// })
     /// .run();
     /// ```

--- a/baseview/src/window.rs
+++ b/baseview/src/window.rs
@@ -36,7 +36,7 @@ impl ViziaWindow {
     /// Open a new child window.
     ///
     /// * `parent` - The parent window.
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn open_parented<P, F>(
         parent: &P,
         win_desc: WindowDescription,
@@ -78,7 +78,7 @@ impl ViziaWindow {
 
     /// Open a new window as if it had a parent window.
     ///
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn open_as_if_parented<F>(
         win_desc: WindowDescription,
         scale_policy: WindowScalePolicy,
@@ -117,7 +117,7 @@ impl ViziaWindow {
 
     /// Open a new window that blocks the current thread until the window is destroyed.
     ///
-    /// * `app` - The Tuix application builder.
+    /// * `app` - The Vizia application builder.
     pub fn open_blocking<F>(
         win_desc: WindowDescription,
         scale_policy: WindowScalePolicy,

--- a/core/src/style/prop.rs
+++ b/core/src/style/prop.rs
@@ -213,7 +213,7 @@ pub trait PropSet: AsEntity + Sized {
     /// }
     /// ```
     /// This style rule will apply a red background to any disabled buttons.
-    /// While css has an `enabled` pseudoclass, this is not used in tuix.
+    /// While css has an `enabled` pseudoclass, this is not used in vizia.
     ///
     /// # Example
     /// Sets the entity to disabled:

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -83,7 +83,7 @@ impl Application {
     ///     // Build application here
     /// })
     /// .on_idle(|cx|{
-    ///     // Code here runs at the end of every event loop after OS and tuix events have been handled
+    ///     // Code here runs at the end of every event loop after OS and vizia events have been handled
     /// })
     /// .run();
     /// ```


### PR DESCRIPTION
I found some references to `tuix` that were still left in the code and changed them to represent the current name `vizia` instead.