### PR TITLE
Rename `Button` generic from `Label` to `V`

### DIFF
--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -9,11 +9,11 @@ pub struct Button {
 }
 
 impl Button {
-    pub fn new<A, L, Label>(cx: &mut Context, action: A, label: L) -> Handle<Self>
+    pub fn new<A, L, V>(cx: &mut Context, action: A, label: L) -> Handle<Self>
     where
         A: 'static + Fn(&mut Context),
-        L: FnOnce(&mut Context) -> Handle<Label>,
-        Label: 'static + View,
+        L: FnOnce(&mut Context) -> Handle<V>,
+        V: 'static + View,
     {
         Self { action: Some(Box::new(action)) }.build(cx, move |cx| {
             (label)(cx).hoverable(false).focusable(false);


### PR DESCRIPTION
I renamed the `Button` generic from `Label` to `V`, because it looked like it has to return a `Handle` of a `Label`, even though that is not the case. I called the generic `V` because of `View`.