### PR TITLE
Remove `downcast` boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,10 @@ pub enum AppEvent {
 
 impl Model for AppData {
 	fn event(&mut self, cx: &mut Context, event: &mut MyEvent) {
-		if let Some(app_event) = event.message.downcast() {
-			match app_event {
+		event.map(|app_event, _| match app_event {
 				AppEvent::Increment => self.count += 1,	
 				AppEvent::Decrement => self.count -= 1,
-			}
-		}
+		})
 	}
 }
 ```

--- a/core/src/events/event.rs
+++ b/core/src/events/event.rs
@@ -41,7 +41,7 @@ pub struct Event {
     /// The meta data of the event.
     pub meta: EventMeta,
     /// The message of the event.
-    pub message: Box<dyn Message>,
+    message: Box<dyn Message>,
 }
 
 impl Debug for Event {

--- a/core/src/events/event.rs
+++ b/core/src/events/event.rs
@@ -1,9 +1,7 @@
 use crate::Entity;
+use std::{any::Any, fmt::Debug};
 
-use std::any::Any;
-use std::fmt::Debug;
-
-/// Determines how the event propagates through the tree
+/// Determines how the event propagates through the tree.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Propagation {
     // /// Events propagate down the tree to the target entity, e.g. from grand-parent to parent to child (target)
@@ -20,39 +18,29 @@ pub enum Propagation {
 
 /// A message can be any static type.
 pub trait Message: Any + Send {
-    /// An &Any can be cast to a reference to a concrete type.
-    fn as_any_mut(&mut self) -> &mut dyn Any;
+    /// A `&dyn Any` can be cast to a reference to a concrete type.
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl dyn Message {
-    /// Casts a message to the specified type if the message is of that type
-    pub fn downcast<T: Message>(&mut self) -> Option<&mut T> {
-        self.as_any_mut().downcast_mut()
+    /// Casts a message to the specified type if the message is of that type.
+    pub fn downcast<T: Message>(&self) -> Option<&T> {
+        self.as_any().downcast_ref()
     }
 }
 
-// Implements message for any static type that implements Clone
+// Implements message for any static type that implements Send
 impl<S: 'static + Send> Message for S {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 }
 
 /// An event is a wrapper around a message and provides metadata on how the event should be propagated through the tree
 pub struct Event {
-    // The entity that produced the event. Entity::null() for OS events or unspecified.
-    pub origin: Entity,
-    // The entity the event should be sent to. Entity::null() to send to all entities.
-    pub target: Entity,
-    // How the event propagates through the tree.
-    pub propagation: Propagation,
-    // Whether the event can be consumed
-    pub consumable: bool,
-    // Determines whether the event should continue to be propagated
-    pub(crate) consumed: bool,
-    // Specifies an order index which is used to sort the event queue
-    pub order: i32,
-    // The event message
+    /// The meta data of the event.
+    pub meta: EventMeta,
+    /// The message of the event.
     pub message: Box<dyn Message>,
 }
 
@@ -77,52 +65,99 @@ impl Event {
     where
         M: Message,
     {
-        Event {
+        Event { meta: Default::default(), message: Box::new(message) }
+    }
+
+    /// Sets the target of the event.
+    pub fn target(mut self, entity: Entity) -> Self {
+        self.meta.target = entity;
+        self
+    }
+
+    /// Sets the origin of the event.
+    pub fn origin(mut self, entity: Entity) -> Self {
+        self.meta.origin = entity;
+        self
+    }
+
+    /// Sets the propagation of the event.
+    pub fn propagate(mut self, propagation: Propagation) -> Self {
+        self.meta.propagation = propagation;
+        self
+    }
+
+    /// Sets the propagation to directly target the `entity`.
+    pub fn direct(mut self, entity: Entity) -> Self {
+        self.meta.propagation = Propagation::Direct;
+        self.meta.target = entity;
+        self
+    }
+
+    /// Consumes the event to prevent it from continuing on its propagation path.
+    pub fn consume(&mut self) {
+        self.meta.consume();
+    }
+
+    /// Tries to downcast the event message to the specified type. If the downcast was successful,
+    /// the downcasted message and the event meta data get passed into `f`.
+    pub fn map<M, F>(&mut self, f: F)
+    where
+        M: Message,
+        F: FnOnce(&M, &mut EventMeta),
+    {
+        if let Some(message) = self.message.downcast() {
+            (f)(message, &mut self.meta);
+        }
+    }
+}
+
+/// The meta data of an [`Event`].
+pub struct EventMeta {
+    /// The entity that produced the event. Entity::null() for OS events or unspecified.
+    pub origin: Entity,
+    /// The entity the event should be sent to. Entity::null() to send to all entities.
+    pub target: Entity,
+    /// How the event propagates through the tree.
+    pub propagation: Propagation,
+    /// Whether the event can be consumed
+    pub consumable: bool,
+    /// Determines whether the event should continue to be propagated
+    pub(crate) consumed: bool,
+    /// Specifies an order index which is used to sort the event queue
+    pub order: i32,
+}
+
+impl EventMeta {
+    /// Creates a new event meta.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vizia_core::*;
+    /// #
+    /// EventMeta::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EventMeta {
+    /// Consumes the event to prevent it from continuing on its propagation path.
+    pub fn consume(&mut self) {
+        self.consumed = true;
+    }
+}
+
+impl Default for EventMeta {
+    fn default() -> Self {
+        Self {
             origin: Entity::null(),
             target: Entity::root(),
             propagation: Propagation::Up,
             consumable: true,
             consumed: false,
             order: 0,
-            message: Box::new(message),
         }
-    }
-
-    /// Sets the target of the event
-    pub fn target(mut self, entity: Entity) -> Self {
-        self.target = entity;
-        self
-    }
-
-    /// Sets the origin of the event
-    pub fn origin(mut self, entity: Entity) -> Self {
-        self.origin = entity;
-        self
-    }
-
-    /// Sets the propagation of the event
-    pub fn propagate(mut self, propagation: Propagation) -> Self {
-        self.propagation = propagation;
-
-        self
-    }
-
-    pub fn direct(mut self, entity: Entity) -> Self {
-        self.propagation = Propagation::Direct;
-        self.target = entity;
-        self
-    }
-
-    /// Consumes the event
-    /// (prevents the event from continuing on its propagation path)
-    pub fn consume(&mut self) {
-        self.consumed = true;
-    }
-
-    pub fn try_mut<T>(&mut self) -> Option<&mut T>
-    where
-        T: Message,
-    {
-        self.message.downcast::<T>()
     }
 }

--- a/core/src/events/event_manager.rs
+++ b/core/src/events/event_manager.rs
@@ -36,16 +36,14 @@ impl EventManager {
         // Loop over the events in the event queue
         'events: for event in self.event_queue.iter_mut() {
             // handle internal events
-            if let Some(msg) = event.message.downcast() {
-                match msg {
-                    InternalEvent::Redraw => context.style.needs_redraw = true,
-                    InternalEvent::LoadImage { path, image, policy } => {
-                        if let Some(image) = image.lock().unwrap().take() {
-                            context.load_image(path.clone(), image, *policy);
-                        }
+            event.map(|internal_event, _| match internal_event {
+                InternalEvent::Redraw => context.style.needs_redraw = true,
+                InternalEvent::LoadImage { path, image, policy } => {
+                    if let Some(image) = image.lock().unwrap().take() {
+                        context.load_image(path.clone(), image, *policy);
                     }
                 }
-            }
+            });
 
             // if event.trace {
             //     println!("Event: {:?}", event);
@@ -68,18 +66,18 @@ impl EventManager {
                     context.listeners.insert(entity, listener);
                 }
 
-                if event.consumed {
+                if event.meta.consumed {
                     continue 'events;
                 }
             }
 
             // Define the target to prevent multiple mutable borrows error
-            let target = event.target;
+            let target = event.meta.target;
 
             // Send event to target
             visit_entity(context, target, event);
 
-            if event.consumed {
+            if event.meta.consumed {
                 continue 'events;
             }
 
@@ -88,11 +86,11 @@ impl EventManager {
             // }
 
             // Propagate up from target to root (not including target)
-            if event.propagation == Propagation::Up {
+            if event.meta.propagation == Propagation::Up {
                 // Walk up the tree from parent to parent
                 for entity in target.parent_iter(&self.tree) {
                     // Skip the target entity
-                    if entity == event.target {
+                    if entity == event.meta.target {
                         continue;
                     }
 
@@ -100,16 +98,16 @@ impl EventManager {
                     visit_entity(context, entity, event);
 
                     // Skip to the next event if the current event is consumed
-                    if event.consumed {
+                    if event.meta.consumed {
                         continue 'events;
                     }
                 }
             }
 
-            if event.propagation == Propagation::Subtree {
+            if event.meta.propagation == Propagation::Subtree {
                 for entity in target.branch_iter(&self.tree) {
                     // Skip the target entity
-                    if entity == event.target {
+                    if entity == event.meta.target {
                         continue;
                     }
 
@@ -117,7 +115,7 @@ impl EventManager {
                     visit_entity(context, entity, event);
 
                     // Skip to the next event if the current event is consumed
-                    if event.consumed {
+                    if event.meta.consumed {
                         continue 'events;
                     }
                 }

--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -23,17 +23,15 @@
 //! The event message must then be downcast to the right type:
 //! ```compile_fail
 //! fn on_event(&mut self, state: &mut State, entity: Entity, event: &mut Event) {
-//!     if let Some(my_event) = event.message.downcast() {
-//!         match my_event {
-//!             MyEvent::ReadDocs => {
-//!                 // Do something
-//!             }
-//!
-//!             MyEvent::CloseDocs => {
-//!                 // Do something else
-//!             }
+//!     event.map(|my_event, _| match my_event {
+//!         MyEvent::ReadDocs => {
+//!             // Do something
 //!         }
-//!     }
+//!
+//!         MyEvent::CloseDocs => {
+//!             // Do something else
+//!         }
+//!     });
 //! }
 //! ```
 

--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -39,7 +39,7 @@ mod event_manager;
 pub use event_manager::EventManager;
 
 mod event;
-pub use event::{Event, Message, Propagation};
+pub use event::{Event, EventMeta, Message, Propagation};
 
 mod event_handler;
 pub use event_handler::ViewHandler;

--- a/core/src/modifiers/actions.rs
+++ b/core/src/modifiers/actions.rs
@@ -42,19 +42,17 @@ impl<V: View> View for Press<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                    if let Some(action) = self.action.take() {
-                        (action)(cx);
+        event.map(|window_event, _| match window_event {
+            WindowEvent::MouseDown(MouseButton::Left) => {
+                if let Some(action) = self.action.take() {
+                    (action)(cx);
 
-                        self.action = Some(action);
-                    }
+                    self.action = Some(action);
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -100,23 +98,21 @@ impl<V: View> View for Release<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
-                    if event.target == cx.current {
-                        if let Some(action) = self.action.take() {
-                            (action)(cx);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseUp(MouseButton::Left) => {
+                if meta.target == cx.current {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx);
 
-                            self.action = Some(action);
-                        }
-
-                        cx.release();
+                        self.action = Some(action);
                     }
-                }
 
-                _ => {}
+                    cx.release();
+                }
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -162,21 +158,19 @@ impl<V: View> View for Hover<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseEnter => {
-                    if event.target == cx.current {
-                        if let Some(action) = self.action.take() {
-                            (action)(cx);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseEnter => {
+                if meta.target == cx.current {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx);
 
-                            self.action = Some(action);
-                        }
+                        self.action = Some(action);
                     }
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -222,19 +216,17 @@ impl<V: View> View for Over<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseOver => {
-                    if let Some(action) = self.action.take() {
-                        (action)(cx);
+        event.map(|window_event, _| match window_event {
+            WindowEvent::MouseOver => {
+                if let Some(action) = self.action.take() {
+                    (action)(cx);
 
-                        self.action = Some(action);
-                    }
+                    self.action = Some(action);
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -280,21 +272,19 @@ impl<V: View> View for Leave<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseLeave => {
-                    if event.target == cx.current {
-                        if let Some(action) = self.action.take() {
-                            (action)(cx);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseLeave => {
+                if meta.target == cx.current {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx);
 
-                            self.action = Some(action);
-                        }
+                        self.action = Some(action);
                     }
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -340,19 +330,17 @@ impl<V: View> View for Move<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseMove(x, y) => {
-                    if let Some(action) = self.action.take() {
-                        (action)(cx, *x, *y);
+        event.map(|window_event, _| match window_event {
+            WindowEvent::MouseMove(x, y) => {
+                if let Some(action) = self.action.take() {
+                    (action)(cx, *x, *y);
 
-                        self.action = Some(action);
-                    }
+                    self.action = Some(action);
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -398,19 +386,17 @@ impl<V: View> View for FocusIn<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::FocusIn => {
-                    if let Some(action) = self.action.take() {
-                        (action)(cx);
+        event.map(|window_event, _| match window_event {
+            WindowEvent::FocusIn => {
+                if let Some(action) = self.action.take() {
+                    (action)(cx);
 
-                        self.action = Some(action);
-                    }
+                    self.action = Some(action);
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -456,19 +442,17 @@ impl<V: View> View for FocusOut<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::FocusOut => {
-                    if let Some(action) = self.action.take() {
-                        (action)(cx);
+        event.map(|window_event, _| match window_event {
+            WindowEvent::FocusOut => {
+                if let Some(action) = self.action.take() {
+                    (action)(cx);
 
-                        self.action = Some(action);
-                    }
+                    self.action = Some(action);
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {
@@ -514,21 +498,19 @@ impl<V: View> View for Geo<V> {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         self.view.event(cx, event);
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::GeometryChanged(geo) => {
-                    if event.target == cx.current {
-                        if let Some(action) = self.action.take() {
-                            (action)(cx, *geo);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::GeometryChanged(geo) => {
+                if meta.target == cx.current {
+                    if let Some(action) = self.action.take() {
+                        (action)(cx, *geo);
 
-                            self.action = Some(action);
-                        }
+                        self.action = Some(action);
                     }
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 
     fn draw(&self, cx: &mut DrawContext, canvas: &mut crate::Canvas) {

--- a/core/src/state/mod.rs
+++ b/core/src/state/mod.rs
@@ -24,17 +24,15 @@
 //! ```compile_fail
 //! impl Model for AppData {
 //!     fn on_event(&mut self, state: &mut State, entity: Entity, event: &mut Event) {
-//!         if let Some(app_event) = event.message.downcast() {
-//!             match app_event {
-//!                 AppEvent::SetTrue => {
-//!                     self.some_data = true;
-//!                 }
+//!         event.map(|app_event, _| match app_event {
+//!             AppEvent::SetTrue => {
+//!                 self.some_data = true;
+//!             }
 //!
-//!                 AppEvent::SetFalse => {
-//!                     self.some_data = false;
-//!                 }
-//!             }   
-//!         }
+//!             AppEvent::SetFalse => {
+//!                 self.some_data = false;
+//!             }
+//!         });
 //!     }
 //! }
 //! ```

--- a/core/src/state/model.rs
+++ b/core/src/state/model.rs
@@ -7,7 +7,8 @@ use crate::{Context, Event, LensWrap};
 
 /// A trait implemented by application data in order to mutate in response to events.
 ///
-/// Example
+/// # Examples
+///
 /// ```ignore
 /// pub struct AppData {
 ///     some_data: bool,
@@ -20,24 +21,23 @@ use crate::{Context, Event, LensWrap};
 ///
 /// impl Model for AppData {
 ///     fn on_event(&mut self, state: &mut State, entity: Entity, event: &mut Event) {
-///         if let Some(app_event) = event.message.downcast() {
-///             match app_event {
-///                 AppEvent::SetTrue => {
+///         event.map(|app_event, _| match app_event {
+///             AppEvent::SetTrue => {
 ///                     self.some_data = true;
-///                 }
+///             }
 ///
-///                 AppEvent::SetFalse => {
-///                     self.some_data = false;
-///                 }
-///             }   
-///         }
+///             AppEvent::SetFalse => {
+///                 self.some_data = false;
+///             }
+///         });
 ///     }
 /// }
 /// ```
 pub trait Model: 'static + Sized {
     /// Build the model data into the application tree.
     ///
-    /// Example
+    /// # Examples
+    ///
     /// ```ignore
     /// fn main() {
     ///     Application::new(WindowDescription::new(), |cx|{
@@ -70,17 +70,15 @@ pub trait Model: 'static + Sized {
     /// ```ignore
     /// impl Model for AppData {
     ///     fn on_event(&mut self, state: &mut State, entity: Entity, event: &mut Event) {
-    ///         if let Some(app_event) = event.message.downcast() {
-    ///             match app_event {
-    ///                 AppEvent::SetTrue => {
-    ///                     self.some_data = true;
-    ///                 }
+    ///         event.map(|app_event, _| match app_event {
+    ///             AppEvent::SetTrue => {
+    ///                 self.some_data = true;
+    ///             }
     ///
-    ///                 AppEvent::SetFalse => {
-    ///                     self.some_data = false;
-    ///                 }
-    ///             }   
-    ///         }
+    ///             AppEvent::SetFalse => {
+    ///                 self.some_data = false;
+    ///             }
+    ///         });
     ///     }
     /// }
     /// ```

--- a/core/src/style/prop.rs
+++ b/core/src/style/prop.rs
@@ -57,15 +57,13 @@ pub trait PropSet: AsEntity + Sized {
     // Add a listener to a button which changes its background color to red when the mouse enters its bounds
     // ```
     // entity.add_listener(cx, |button: &mut Button, cx, entity, event|{
-    //     if let Some(window_event) = event.message.downcast() {
-    //         match window_event {
-    //             WindowEvent::MouseEnter => {
-    //                 entity.set_background_color(cx, Color::red());
-    //             }
-    //
-    //             _=> {}
+    //     event.map(|window_event, _| match window_event {
+    //         WindowEvent::MouseEnter => {
+    //             entity.set_background_color(cx, Color::red());
     //         }
-    //     }
+    //
+    //         _ => {}
+    //     });
     // });
     // ```
     // fn add_listener<F,W>(&self, cx: &mut Context, listener: F) -> Entity

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -91,27 +91,25 @@ impl View for Button {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                    cx.current.set_active(cx, true);
-                    cx.capture();
-                    if let Some(callback) = self.action.take() {
-                        (callback)(cx);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+                cx.current.set_active(cx, true);
+                cx.capture();
+                if let Some(callback) = self.action.take() {
+                    (callback)(cx);
 
-                        self.action = Some(callback);
-                    }
+                    self.action = Some(callback);
                 }
-
-                WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
-                    if event.target == cx.current {
-                        cx.release();
-                        cx.current.set_active(cx, false);
-                    }
-                }
-
-                _ => {}
             }
-        }
+
+            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+                if meta.target == cx.current {
+                    cx.release();
+                    cx.current.set_active(cx, false);
+                }
+            }
+
+            _ => {}
+        });
     }
 }

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Handle, Lens, MouseButton, Res, View, WindowEvent};
+use crate::{Context, Event, Handle, Lens, MouseButton, Res, View, WindowEvent};
 
 pub const ICON_CHECK: &str = "\u{2713}";
 
@@ -164,21 +164,19 @@ impl View for Checkbox {
         Some(String::from("checkbox"))
     }
 
-    fn event(&mut self, cx: &mut Context, event: &mut crate::Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                    if event.target == cx.current {
-                        if let Some(callback) = self.on_toggle.take() {
-                            (callback)(cx);
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseDown(MouseButton::Left) => {
+                if meta.target == cx.current {
+                    if let Some(callback) = self.on_toggle.take() {
+                        (callback)(cx);
 
-                            self.on_toggle = Some(callback);
-                        }
+                        self.on_toggle = Some(callback);
                     }
                 }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 }

--- a/core/src/views/knob.rs
+++ b/core/src/views/knob.rs
@@ -148,74 +148,72 @@ impl<L: Lens<Target = f32>> View for Knob<L> {
             //Entity::root().redraw(cx);
         };
 
-        if let Some(window_event) = event.message.downcast::<WindowEvent>() {
-            match window_event {
-                WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                    self.is_dragging = true;
-                    self.prev_drag_y = cx.mouse.left.pos_down.1;
+        event.map(|window_event, _| match window_event {
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+                self.is_dragging = true;
+                self.prev_drag_y = cx.mouse.left.pos_down.1;
 
-                    cx.capture();
-                    cx.focused = cx.current;
+                cx.capture();
+                cx.focused = cx.current;
 
-                    self.continuous_normal = self.lens.get(cx);
+                self.continuous_normal = self.lens.get(cx);
 
-                    // if let Some(callback) = self.on_press.take() {
-                    //     (callback)(self, cx, cx.current);
-                    //     self.on_press = Some(callback);
-                    // }
-                }
-
-                WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
-                    self.is_dragging = false;
-                    //self.continuous_normal = self.normalized_value;
-
-                    self.continuous_normal = self.lens.get(cx);
-
-                    cx.release();
-
-                    // if let Some(callback) = self.on_release.take() {
-                    //     (callback)(self, cx, cx.current);
-                    //     self.on_release = Some(callback);
-                    // }
-                }
-
-                WindowEvent::MouseMove(_, y) => {
-                    //if event.target == cx.current {
-                    if self.is_dragging {
-                        let mut delta_normal = (*y - self.prev_drag_y) * self.drag_scalar;
-
-                        self.prev_drag_y = *y;
-
-                        if cx.modifiers.contains(Modifiers::SHIFT) {
-                            delta_normal *= self.modifier_scalar;
-                        }
-
-                        let new_normal = self.continuous_normal - delta_normal;
-
-                        move_virtual_slider(self, cx, new_normal);
-                    }
-                    //}
-                }
-
-                WindowEvent::MouseScroll(_, y) => {
-                    if *y != 0.0 {
-                        let delta_normal = -*y * self.wheel_scalar;
-
-                        let new_normal = self.continuous_normal - delta_normal;
-
-                        move_virtual_slider(self, cx, new_normal);
-                    }
-                }
-
-                WindowEvent::MouseDoubleClick(button) if *button == MouseButton::Left => {
-                    self.is_dragging = false;
-
-                    move_virtual_slider(self, cx, self.default_normal);
-                }
-
-                _ => {}
+                // if let Some(callback) = self.on_press.take() {
+                //     (callback)(self, cx, cx.current);
+                //     self.on_press = Some(callback);
+                // }
             }
-        }
+
+            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+                self.is_dragging = false;
+                //self.continuous_normal = self.normalized_value;
+
+                self.continuous_normal = self.lens.get(cx);
+
+                cx.release();
+
+                // if let Some(callback) = self.on_release.take() {
+                //     (callback)(self, cx, cx.current);
+                //     self.on_release = Some(callback);
+                // }
+            }
+
+            WindowEvent::MouseMove(_, y) => {
+                //if meta.target == cx.current {
+                if self.is_dragging {
+                    let mut delta_normal = (*y - self.prev_drag_y) * self.drag_scalar;
+
+                    self.prev_drag_y = *y;
+
+                    if cx.modifiers.contains(Modifiers::SHIFT) {
+                        delta_normal *= self.modifier_scalar;
+                    }
+
+                    let new_normal = self.continuous_normal - delta_normal;
+
+                    move_virtual_slider(self, cx, new_normal);
+                }
+                //}
+            }
+
+            WindowEvent::MouseScroll(_, y) => {
+                if *y != 0.0 {
+                    let delta_normal = -*y * self.wheel_scalar;
+
+                    let new_normal = self.continuous_normal - delta_normal;
+
+                    move_virtual_slider(self, cx, new_normal);
+                }
+            }
+
+            WindowEvent::MouseDoubleClick(button) if *button == MouseButton::Left => {
+                self.is_dragging = false;
+
+                move_virtual_slider(self, cx, self.default_normal);
+            }
+
+            _ => {}
+        });
     }
 }
 

--- a/core/src/views/list.rs
+++ b/core/src/views/list.rs
@@ -52,42 +52,43 @@ impl<L: 'static + Lens<Target = Vec<T>>, T> View for List<L, T> {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut crate::Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::KeyDown(code, _) => match code {
-                    Code::ArrowDown => {
-                        if let Some(callback) = self.increment_callback.take() {
-                            (callback)(cx);
-                            self.increment_callback = Some(callback);
-                        }
+        event.map(|window_event, _| match window_event {
+            WindowEvent::KeyDown(code, _) => match code {
+                Code::ArrowDown => {
+                    if let Some(callback) = self.increment_callback.take() {
+                        (callback)(cx);
+                        self.increment_callback = Some(callback);
                     }
+                }
 
-                    Code::ArrowUp => {
-                        if let Some(callback) = self.decrement_callback.take() {
-                            (callback)(cx);
-                            self.decrement_callback = Some(callback);
-                        }
+                Code::ArrowUp => {
+                    if let Some(callback) = self.decrement_callback.take() {
+                        (callback)(cx);
+                        self.decrement_callback = Some(callback);
                     }
+                }
 
-                    Code::Escape => {
-                        if let Some(callback) = self.clear_callback.take() {
-                            (callback)(cx);
-                            self.clear_callback = Some(callback);
-                        }
+                Code::Escape => {
+                    if let Some(callback) = self.clear_callback.take() {
+                        (callback)(cx);
+                        self.clear_callback = Some(callback);
                     }
-
-                    _ => {}
-                },
+                }
 
                 _ => {}
-            }
-        }
+            },
 
-        // if let Some(WindowEvent::MouseDown(MouseButton::Left)) = event.message.downcast() {
-        //     if !cx.focused.is_child_of(&cx.tree, cx.current) {
-        //         cx.focused = cx.current;
+            _ => {}
+        });
+
+        // event.map(|window_event, _| match window_event {
+        //     WindowEvent::MouseDown(MouseButton::Left) => {
+        //         if !cx.focused.is_child_of(&cx.tree, cx.current) {
+        //             cx.focused = cx.current;
+        //         }
         //     }
-        // }
+        //     _ => {}
+        // });
     }
 }
 

--- a/core/src/views/menu.rs
+++ b/core/src/views/menu.rs
@@ -67,31 +67,27 @@ pub enum MenuEvent {
 
 impl Model for MenuData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(msg) = event.message.downcast() {
-            match msg {
-                MenuEvent::SetSelected(sel) => {
-                    self.selected = *sel;
-                    event.consume();
-                }
-                MenuEvent::Close => self.selected = None,
-                MenuEvent::Activate => {}
+        event.map(|menu_event, meta| match menu_event {
+            MenuEvent::SetSelected(sel) => {
+                self.selected = *sel;
+                meta.consume();
             }
-        }
+            MenuEvent::Close => self.selected = None,
+            MenuEvent::Activate => {}
+        });
     }
 }
 
 impl Model for MenuControllerData {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(msg) = event.message.downcast() {
-            match msg {
-                MenuEvent::Close => {
-                    self.active = false;
-                    cx.release();
-                }
-                MenuEvent::Activate => self.active = true,
-                _ => {}
+        event.map(|menu_event, _| match menu_event {
+            MenuEvent::Close => {
+                self.active = false;
+                cx.release();
             }
-        }
+            MenuEvent::Activate => self.active = true,
+            _ => {}
+        });
     }
 }
 
@@ -127,33 +123,33 @@ impl View for MenuController {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         let active = cx.data::<MenuControllerData>().unwrap().active;
 
-        if let Some(msg) = event.message.downcast() {
+        event.map(|window_event, meta| {
             if active {
                 let is_child = cx.hovered.is_descendant_of(&cx.tree, cx.current);
                 // we capture focus in order to see clicks outside the menus, but we don't want
                 // to deprive our children of their events.
                 // We also want mouse scroll events to be seen by everyone
-                if event.propagation == Propagation::Direct {
+                if meta.propagation == Propagation::Direct {
                     if (is_child
                         && matches!(
-                            msg,
+                            window_event,
                             WindowEvent::MouseMove(_, _)
                                 | WindowEvent::MouseDown(_)
                                 | WindowEvent::MouseUp(_)
                                 | WindowEvent::MouseScroll(_, _)
                                 | WindowEvent::MouseDoubleClick(_)
                         ))
-                        || (!is_child && matches!(msg, WindowEvent::MouseScroll(_, _)))
+                        || (!is_child && matches!(window_event, WindowEvent::MouseScroll(_, _)))
                     {
                         cx.event_queue.push_back(
-                            Event::new(msg.clone())
+                            Event::new(window_event.clone())
                                 .propagate(Propagation::Up)
                                 .target(cx.hovered)
-                                .origin(event.origin.clone()),
+                                .origin(meta.origin.clone()),
                         );
                     }
                     // if we click outside the menu, close everything
-                    if matches!(msg, WindowEvent::MouseDown(_)) && !is_child {
+                    if matches!(window_event, WindowEvent::MouseDown(_)) && !is_child {
                         cx.event_queue.push_back(
                             Event::new(MenuEvent::Close)
                                 .propagate(Propagation::Subtree)
@@ -163,7 +159,7 @@ impl View for MenuController {
                     }
                 }
             } else {
-                if let WindowEvent::MouseDown(_) = msg {
+                if let WindowEvent::MouseDown(_) = window_event {
                     // capture focus on click
                     cx.capture();
                     cx.emit(MenuEvent::Activate);
@@ -176,7 +172,7 @@ impl View for MenuController {
                     );
                 }
             }
-        }
+        });
     }
 }
 
@@ -345,13 +341,16 @@ impl View for MenuButton {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(WindowEvent::MouseDown(MouseButton::Left)) = event.message.downcast() {
-            if let Some(callback) = self.action.take() {
-                callback(cx);
-                cx.emit(MenuEvent::Close);
-                event.consume();
-                self.action = Some(callback);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseDown(MouseButton::Left) => {
+                if let Some(callback) = self.action.take() {
+                    callback(cx);
+                    cx.emit(MenuEvent::Close);
+                    meta.consume();
+                    self.action = Some(callback);
+                }
             }
-        }
+            _ => {}
+        });
     }
 }

--- a/core/src/views/radio_buttons.rs
+++ b/core/src/views/radio_buttons.rs
@@ -22,13 +22,16 @@ impl View for RadioButton {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(WindowEvent::MouseDown(MouseButton::Left)) = event.message.downcast() {
-            if event.target == cx.current {
-                if let Some(callback) = &self.on_select {
-                    (callback)(cx);
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseDown(MouseButton::Left) => {
+                if meta.target == cx.current {
+                    if let Some(callback) = &self.on_select {
+                        (callback)(cx);
+                    }
                 }
             }
-        }
+            _ => {}
+        });
     }
 }
 

--- a/core/src/views/scrollbar.rs
+++ b/core/src/views/scrollbar.rs
@@ -102,14 +102,14 @@ impl<L1: 'static + Lens<Target = f32>> View for Scrollbar<L1> {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut crate::Event) {
-        if let Some(window_event) = event.message.downcast() {
+        event.map(|window_event, meta| {
             let pos = match &self.orientation {
                 Orientation::Horizontal => cx.mouse.cursorx,
                 Orientation::Vertical => cx.mouse.cursory,
             };
             match window_event {
                 WindowEvent::MouseDown(MouseButton::Left) => {
-                    if event.target != cx.current {
+                    if meta.target != cx.current {
                         self.reference_points = Some((pos, self.value.get(cx)));
                         cx.capture();
                     } else {
@@ -156,6 +156,6 @@ impl<L1: 'static + Lens<Target = f32>> View for Scrollbar<L1> {
 
                 _ => {}
             }
-        }
+        });
     }
 }

--- a/core/src/views/scrollview.rs
+++ b/core/src/views/scrollview.rs
@@ -63,23 +63,21 @@ pub enum ScrollUpdate {
 
 impl Model for ScrollData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(msg) = event.message.downcast() {
-            match msg {
-                ScrollUpdate::ScrollX(f) => self.scroll_x = (self.scroll_x + *f).clamp(0.0, 1.0),
-                ScrollUpdate::ScrollY(f) => self.scroll_y = (self.scroll_y + *f).clamp(0.0, 1.0),
-                ScrollUpdate::SetX(f) => self.scroll_x = *f,
-                ScrollUpdate::SetY(f) => self.scroll_y = *f,
-                ScrollUpdate::ChildGeo(x, y) => {
-                    self.child_x = *x;
-                    self.child_y = *y;
-                }
-                ScrollUpdate::ParentGeo(x, y) => {
-                    self.parent_x = *x;
-                    self.parent_y = *y;
-                }
+        event.map(|scroll_update, _| match scroll_update {
+            ScrollUpdate::ScrollX(f) => self.scroll_x = (self.scroll_x + *f).clamp(0.0, 1.0),
+            ScrollUpdate::ScrollY(f) => self.scroll_y = (self.scroll_y + *f).clamp(0.0, 1.0),
+            ScrollUpdate::SetX(f) => self.scroll_x = *f,
+            ScrollUpdate::SetY(f) => self.scroll_y = *f,
+            ScrollUpdate::ChildGeo(x, y) => {
+                self.child_x = *x;
+                self.child_y = *y;
             }
-            event.consume();
-        }
+            ScrollUpdate::ParentGeo(x, y) => {
+                self.parent_x = *x;
+                self.parent_y = *y;
+            }
+        });
+        event.consume();
     }
 }
 
@@ -190,40 +188,38 @@ impl<L: Lens<Target = ScrollData>> View for ScrollView<L> {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut crate::Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::GeometryChanged(geo) => {
-                    if geo.contains(GeometryChanged::HEIGHT_CHANGED)
-                        || geo.contains(GeometryChanged::WIDTH_CHANGED)
-                    {
-                        cx.emit(ScrollUpdate::ParentGeo(
-                            cx.cache.get_width(cx.current),
-                            cx.cache.get_height(cx.current),
-                        ));
-                    }
+        event.map(|window_event, _| match window_event {
+            WindowEvent::GeometryChanged(geo) => {
+                if geo.contains(GeometryChanged::HEIGHT_CHANGED)
+                    || geo.contains(GeometryChanged::WIDTH_CHANGED)
+                {
+                    cx.emit(ScrollUpdate::ParentGeo(
+                        cx.cache.get_width(cx.current),
+                        cx.cache.get_height(cx.current),
+                    ));
                 }
-
-                WindowEvent::MouseScroll(x, y) => {
-                    let (x, y) =
-                        if cx.modifiers.contains(Modifiers::SHIFT) { (-*y, *x) } else { (*x, -*y) };
-
-                    // what percentage of the negative space does this cross?
-                    let data = self.data.get(cx);
-                    if x != 0.0 {
-                        let negative_space = data.child_x - data.parent_x;
-                        let logical_delta = x * SCROLL_SENSITIVITY / negative_space;
-                        cx.emit(ScrollUpdate::ScrollX(logical_delta));
-                    }
-                    let data = cx.data::<ScrollData>().unwrap();
-                    if y != 0.0 {
-                        let negative_space = data.child_y - data.parent_y;
-                        let logical_delta = y * SCROLL_SENSITIVITY / negative_space;
-                        cx.emit(ScrollUpdate::ScrollY(logical_delta));
-                    }
-                }
-
-                _ => {}
             }
-        }
+
+            WindowEvent::MouseScroll(x, y) => {
+                let (x, y) =
+                    if cx.modifiers.contains(Modifiers::SHIFT) { (-*y, *x) } else { (*x, -*y) };
+
+                // what percentage of the negative space does this cross?
+                let data = self.data.get(cx);
+                if x != 0.0 {
+                    let negative_space = data.child_x - data.parent_x;
+                    let logical_delta = x * SCROLL_SENSITIVITY / negative_space;
+                    cx.emit(ScrollUpdate::ScrollX(logical_delta));
+                }
+                let data = cx.data::<ScrollData>().unwrap();
+                if y != 0.0 {
+                    let negative_space = data.child_y - data.parent_y;
+                    let logical_delta = y * SCROLL_SENSITIVITY / negative_space;
+                    cx.emit(ScrollUpdate::ScrollY(logical_delta));
+                }
+            }
+
+            _ => {}
+        });
     }
 }

--- a/core/src/views/slider.rs
+++ b/core/src/views/slider.rs
@@ -199,60 +199,94 @@ impl<L: Lens> View for Slider<L> {
     }
 
     fn event(&mut self, cx: &mut Context, event: &mut crate::Event) {
-        if let Some(slider_event_internal) = event.message.downcast() {
-            match slider_event_internal {
-                SliderEventInternal::SetThumbSize(width, height) => match self.internal.orientation
-                {
+        event.map(|slider_event_internal, _| match slider_event_internal {
+            SliderEventInternal::SetThumbSize(width, height) => match self.internal.orientation {
+                Orientation::Horizontal => {
+                    self.internal.thumb_size = *width;
+                }
+
+                Orientation::Vertical => {
+                    self.internal.thumb_size = *height;
+                }
+            },
+
+            SliderEventInternal::SetRange(range) => {
+                self.internal.range = range.clone();
+            }
+        });
+
+        event.map(|window_event, _| match window_event {
+            WindowEvent::GeometryChanged(_) => {
+                let width = cx.cache.get_width(cx.current);
+                let height = cx.cache.get_height(cx.current);
+
+                if width >= height {
+                    self.internal.orientation = Orientation::Horizontal;
+                    self.internal.size = width;
+                } else {
+                    self.internal.orientation = Orientation::Vertical;
+                    self.internal.size = height;
+                }
+            }
+
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+                self.is_dragging = true;
+                cx.capture();
+                cx.current.set_active(cx, true);
+
+                let thumb_size = self.internal.thumb_size;
+                let min = self.internal.range.start;
+                let max = self.internal.range.end;
+
+                let mut dx = match self.internal.orientation {
                     Orientation::Horizontal => {
-                        self.internal.thumb_size = *width;
+                        (cx.mouse.left.pos_down.0
+                            - cx.cache.get_posx(cx.current)
+                            - thumb_size / 2.0)
+                            / (cx.cache.get_width(cx.current) - thumb_size)
                     }
 
                     Orientation::Vertical => {
-                        self.internal.thumb_size = *height;
+                        (cx.cache.get_height(cx.current)
+                            - (cx.mouse.left.pos_down.1 - cx.cache.get_posy(cx.current))
+                            - thumb_size / 2.0)
+                            / (cx.cache.get_height(cx.current) - thumb_size)
                     }
-                },
+                };
 
-                SliderEventInternal::SetRange(range) => {
-                    self.internal.range = range.clone();
+                dx = dx.clamp(0.0, 1.0);
+
+                let val = min + dx * (max - min);
+
+                if let Some(callback) = self.on_changing.take() {
+                    (callback)(cx, val);
+
+                    self.on_changing = Some(callback);
                 }
             }
-        }
 
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::GeometryChanged(_) => {
-                    let width = cx.cache.get_width(cx.current);
-                    let height = cx.cache.get_height(cx.current);
+            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+                self.is_dragging = false;
+                cx.release();
+                cx.current.set_active(cx, false);
+            }
 
-                    if width >= height {
-                        self.internal.orientation = Orientation::Horizontal;
-                        self.internal.size = width;
-                    } else {
-                        self.internal.orientation = Orientation::Vertical;
-                        self.internal.size = height;
-                    }
-                }
-
-                WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                    self.is_dragging = true;
-                    cx.capture();
-                    cx.current.set_active(cx, true);
-
+            WindowEvent::MouseMove(x, y) => {
+                if self.is_dragging {
                     let thumb_size = self.internal.thumb_size;
+
                     let min = self.internal.range.start;
                     let max = self.internal.range.end;
 
                     let mut dx = match self.internal.orientation {
                         Orientation::Horizontal => {
-                            (cx.mouse.left.pos_down.0
-                                - cx.cache.get_posx(cx.current)
-                                - thumb_size / 2.0)
+                            (*x - cx.cache.get_posx(cx.current) - thumb_size / 2.0)
                                 / (cx.cache.get_width(cx.current) - thumb_size)
                         }
 
                         Orientation::Vertical => {
                             (cx.cache.get_height(cx.current)
-                                - (cx.mouse.left.pos_down.1 - cx.cache.get_posy(cx.current))
+                                - (*y - cx.cache.get_posy(cx.current))
                                 - thumb_size / 2.0)
                                 / (cx.cache.get_height(cx.current) - thumb_size)
                         }
@@ -268,49 +302,10 @@ impl<L: Lens> View for Slider<L> {
                         self.on_changing = Some(callback);
                     }
                 }
-
-                WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
-                    self.is_dragging = false;
-                    cx.release();
-                    cx.current.set_active(cx, false);
-                }
-
-                WindowEvent::MouseMove(x, y) => {
-                    if self.is_dragging {
-                        let thumb_size = self.internal.thumb_size;
-
-                        let min = self.internal.range.start;
-                        let max = self.internal.range.end;
-
-                        let mut dx = match self.internal.orientation {
-                            Orientation::Horizontal => {
-                                (*x - cx.cache.get_posx(cx.current) - thumb_size / 2.0)
-                                    / (cx.cache.get_width(cx.current) - thumb_size)
-                            }
-
-                            Orientation::Vertical => {
-                                (cx.cache.get_height(cx.current)
-                                    - (*y - cx.cache.get_posy(cx.current))
-                                    - thumb_size / 2.0)
-                                    / (cx.cache.get_height(cx.current) - thumb_size)
-                            }
-                        };
-
-                        dx = dx.clamp(0.0, 1.0);
-
-                        let val = min + dx * (max - min);
-
-                        if let Some(callback) = self.on_changing.take() {
-                            (callback)(cx, val);
-
-                            self.on_changing = Some(callback);
-                        }
-                    }
-                }
-
-                _ => {}
             }
-        }
+
+            _ => {}
+        });
     }
 }
 

--- a/examples/7GUIs/counter.rs
+++ b/examples/7GUIs/counter.rs
@@ -11,13 +11,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::Increment => {
-                    self.count += 1;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::Increment => {
+                self.count += 1;
             }
-        }
+        });
     }
 }
 

--- a/examples/7GUIs/crud.rs
+++ b/examples/7GUIs/crud.rs
@@ -69,50 +69,48 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.try_mut() {
-            match app_event {
-                AppEvent::SetSelected(index) => {
-                    self.selected = Some(*index);
-                    self.name = self.list[*index].0.clone();
-                    self.surname = self.list[*index].1.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetSelected(index) => {
+                self.selected = Some(*index);
+                self.name = self.list[*index].0.clone();
+                self.surname = self.list[*index].1.clone();
+            }
 
-                AppEvent::SetName(name) => {
-                    self.name = name.clone();
-                }
+            AppEvent::SetName(name) => {
+                self.name = name.clone();
+            }
 
-                AppEvent::SetSurname(surname) => {
-                    self.surname = surname.clone();
-                }
+            AppEvent::SetSurname(surname) => {
+                self.surname = surname.clone();
+            }
 
-                AppEvent::Create => {
-                    if !self.name.is_empty() && !self.surname.is_empty() {
-                        self.list.push((self.name.clone(), self.surname.clone()));
-                        self.selected = Some(self.list.len() - 1);
-                    }
+            AppEvent::Create => {
+                if !self.name.is_empty() && !self.surname.is_empty() {
+                    self.list.push((self.name.clone(), self.surname.clone()));
+                    self.selected = Some(self.list.len() - 1);
                 }
+            }
 
-                AppEvent::Update => {
-                    if let Some(selected) = self.selected {
-                        self.list[selected].0 = self.name.clone();
-                        self.list[selected].1 = self.surname.clone();
-                    }
+            AppEvent::Update => {
+                if let Some(selected) = self.selected {
+                    self.list[selected].0 = self.name.clone();
+                    self.list[selected].1 = self.surname.clone();
                 }
+            }
 
-                AppEvent::Delete => {
-                    if let Some(selected) = self.selected {
-                        self.list.remove(selected);
-                        if self.list.is_empty() {
-                            self.selected = None;
-                            self.name = String::new();
-                            self.surname = String::new();
-                        } else {
-                            cx.emit(AppEvent::SetSelected(selected.saturating_sub(1)));
-                        }
+            AppEvent::Delete => {
+                if let Some(selected) = self.selected {
+                    self.list.remove(selected);
+                    if self.list.is_empty() {
+                        self.selected = None;
+                        self.name = String::new();
+                        self.surname = String::new();
+                    } else {
+                        cx.emit(AppEvent::SetSelected(selected.saturating_sub(1)));
                     }
                 }
             }
-        }
+        });
     }
 }
 

--- a/examples/7GUIs/flight_booker.rs
+++ b/examples/7GUIs/flight_booker.rs
@@ -58,21 +58,19 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetChoice(choice) => {
-                    self.choice = choice.clone();
-                }
-
-                AppEvent::SetStartDate(date) => {
-                    self.start_date = date.clone();
-                }
-
-                AppEvent::SetEndDate(date) => {
-                    self.end_date = date.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetChoice(choice) => {
+                self.choice = choice.clone();
             }
-        }
+
+            AppEvent::SetStartDate(date) => {
+                self.start_date = date.clone();
+            }
+
+            AppEvent::SetEndDate(date) => {
+                self.end_date = date.clone();
+            }
+        });
     }
 }
 

--- a/examples/7GUIs/temperature_converter.rs
+++ b/examples/7GUIs/temperature_converter.rs
@@ -19,19 +19,17 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.try_mut() {
-            match app_event {
-                AppEvent::SetTemperatureCelcius(temp) => {
-                    self.temperature_celcius = *temp;
-                    self.temperature_fahrenheit = self.temperature_celcius * (9.0 / 5.0) + 32.0;
-                }
-
-                AppEvent::SetTemperatureFahrenheit(temp) => {
-                    self.temperature_fahrenheit = *temp;
-                    self.temperature_celcius = (self.temperature_fahrenheit - 32.0) * (5.0 / 9.0);
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetTemperatureCelcius(temp) => {
+                self.temperature_celcius = *temp;
+                self.temperature_fahrenheit = self.temperature_celcius * (9.0 / 5.0) + 32.0;
             }
-        }
+
+            AppEvent::SetTemperatureFahrenheit(temp) => {
+                self.temperature_fahrenheit = *temp;
+                self.temperature_celcius = (self.temperature_fahrenheit - 32.0) * (5.0 / 9.0);
+            }
+        });
     }
 }
 

--- a/examples/accessibility/focus_order.rs
+++ b/examples/accessibility/focus_order.rs
@@ -18,13 +18,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetText(text) => {
-                    self.text = text.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetText(text) => {
+                self.text = text.clone();
             }
-        }
+        });
     }
 }
 

--- a/examples/keymap_basic.rs
+++ b/examples/keymap_basic.rs
@@ -58,20 +58,18 @@ impl CustomView {
 
 impl View for CustomView {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::KeyDown(code, _) => {
-                    // Retrieve our keymap data containing all of our key chords.
-                    if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
-                        // Loop through every action that is being pressed.
-                        for action in keymap_data.pressed_actions(cx, *code) {
-                            println!("The action {:?} is being pressed!", action);
-                        }
+        event.map(|window_event, _| match window_event {
+            WindowEvent::KeyDown(code, _) => {
+                // Retrieve our keymap data containing all of our key chords.
+                if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
+                    // Loop through every action that is being pressed.
+                    for action in keymap_data.pressed_actions(cx, *code) {
+                        println!("The action {:?} is being pressed!", action);
                     }
                 }
-                _ => {}
             }
-        }
+            _ => {}
+        });
     }
 }
 

--- a/examples/keymap_change_entries.rs
+++ b/examples/keymap_change_entries.rs
@@ -72,20 +72,18 @@ impl CustomView {
 
 impl View for CustomView {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::KeyDown(code, _) => {
-                    // Retrieve our keymap data containing all of our key chords.
-                    if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
-                        // Loop through every action that is being pressed.
-                        for action in keymap_data.pressed_actions(cx, *code) {
-                            println!("The action {:?} is being pressed!", action);
-                        }
+        event.map(|window_event, _| match window_event {
+            WindowEvent::KeyDown(code, _) => {
+                // Retrieve our keymap data containing all of our key chords.
+                if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
+                    // Loop through every action that is being pressed.
+                    for action in keymap_data.pressed_actions(cx, *code) {
+                        println!("The action {:?} is being pressed!", action);
                     }
                 }
-                _ => {}
             }
-        }
+            _ => {}
+        });
     }
 }
 

--- a/examples/lists/editable_list.rs
+++ b/examples/lists/editable_list.rs
@@ -28,37 +28,35 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::Add(value) => {
-                    self.list.push(*value);
+        event.map(|app_event, _| match app_event {
+            AppEvent::Add(value) => {
+                self.list.push(*value);
+                self.selected = self.selected.clamp(0, self.list.len() - 1);
+            }
+
+            AppEvent::RemoveSelected => {
+                if !self.list.is_empty() {
+                    self.list.remove(self.selected);
+                }
+                if !self.list.is_empty() {
                     self.selected = self.selected.clamp(0, self.list.len() - 1);
                 }
-
-                AppEvent::RemoveSelected => {
-                    if !self.list.is_empty() {
-                        self.list.remove(self.selected);
-                    }
-                    if !self.list.is_empty() {
-                        self.selected = self.selected.clamp(0, self.list.len() - 1);
-                    }
-                }
-
-                AppEvent::Select(idx) => {
-                    self.selected = *idx;
-                }
-
-                AppEvent::IncrementSelection => {
-                    cx.emit(AppEvent::Select(
-                        (self.selected + 1).min(self.list.len().saturating_sub(1)),
-                    ));
-                }
-
-                AppEvent::DecrementSelection => {
-                    cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
-                }
             }
-        }
+
+            AppEvent::Select(idx) => {
+                self.selected = *idx;
+            }
+
+            AppEvent::IncrementSelection => {
+                cx.emit(AppEvent::Select(
+                    (self.selected + 1).min(self.list.len().saturating_sub(1)),
+                ));
+            }
+
+            AppEvent::DecrementSelection => {
+                cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
+            }
+        });
     }
 }
 

--- a/examples/lists/multiselectable_list.rs
+++ b/examples/lists/multiselectable_list.rs
@@ -16,19 +16,17 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(list_event) = event.message.downcast() {
-            match list_event {
-                AppEvent::Select(index) => {
-                    if !self.selected.insert(*index) {
-                        self.selected.remove(index);
-                    }
-                }
-
-                AppEvent::ClearSelection => {
-                    self.selected.clear();
+        event.map(|app_event, _| match app_event {
+            AppEvent::Select(index) => {
+                if !self.selected.insert(*index) {
+                    self.selected.remove(index);
                 }
             }
-        }
+
+            AppEvent::ClearSelection => {
+                self.selected.clear();
+            }
+        });
     }
 }
 

--- a/examples/lists/selectable_list.rs
+++ b/examples/lists/selectable_list.rs
@@ -16,21 +16,19 @@ pub enum AppEvent {
 impl Model for AppData {
     // Intercept list events from the list view to modify the selected index in the model
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(list_event) = event.message.downcast() {
-            match list_event {
-                AppEvent::Select(index) => {
-                    self.selected = *index;
-                }
-
-                AppEvent::IncrementSelection => {
-                    cx.emit(AppEvent::Select((self.selected + 1).min(self.list.len() - 1)));
-                }
-
-                AppEvent::DecrementSelection => {
-                    cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::Select(index) => {
+                self.selected = *index;
             }
-        }
+
+            AppEvent::IncrementSelection => {
+                cx.emit(AppEvent::Select((self.selected + 1).min(self.list.len() - 1)));
+            }
+
+            AppEvent::DecrementSelection => {
+                cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
+            }
+        });
     }
 }
 

--- a/examples/lists/sortable_list.rs
+++ b/examples/lists/sortable_list.rs
@@ -23,13 +23,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::Sort => {
-                    self.list.sort();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::Sort => {
+                self.list.sort();
             }
-        }
+        });
     }
 }
 

--- a/examples/lists/static_list.rs
+++ b/examples/lists/static_list.rs
@@ -21,21 +21,19 @@ pub enum AppEvent {
 impl Model for AppData {
     // Intercept list events from the list view to modify the selected index in the model
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        if let Some(list_event) = event.message.downcast() {
-            match list_event {
-                AppEvent::Select(index) => {
-                    self.selected = *index;
-                }
-
-                AppEvent::IncrementSelection => {
-                    cx.emit(AppEvent::Select((self.selected + 1).min(STATIC_LIST.len() - 1)));
-                }
-
-                AppEvent::DecrementSelection => {
-                    cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::Select(index) => {
+                self.selected = *index;
             }
-        }
+
+            AppEvent::IncrementSelection => {
+                cx.emit(AppEvent::Select((self.selected + 1).min(STATIC_LIST.len() - 1)));
+            }
+
+            AppEvent::DecrementSelection => {
+                cx.emit(AppEvent::Select(self.selected.saturating_sub(1)));
+            }
+        });
     }
 }
 

--- a/examples/localization/l10n.rs
+++ b/examples/localization/l10n.rs
@@ -13,12 +13,10 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(msg) = event.message.downcast() {
-            match msg {
-                AppEvent::SetName(s) => self.name = s.clone(),
-                AppEvent::ReceiveEmail => self.emails += 1,
-            }
-        }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetName(s) => self.name = s.clone(),
+            AppEvent::ReceiveEmail => self.emails += 1,
+        });
     }
 }
 

--- a/examples/modal.rs
+++ b/examples/modal.rs
@@ -74,16 +74,13 @@ pub struct AppData {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::ShowModal => {
-                    self.show_modal = true;
-                }
-
-                AppEvent::HideModal => {
-                    self.show_modal = false;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::ShowModal => {
+                self.show_modal = true;
             }
-        }
+            AppEvent::HideModal => {
+                self.show_modal = false;
+            }
+        });
     }
 }

--- a/examples/more_knobs.rs
+++ b/examples/more_knobs.rs
@@ -184,12 +184,10 @@ pub enum KnobChangeEvent {
 }
 impl Model for KnobData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(param_change_event) = event.message.downcast() {
-            match param_change_event {
-                KnobChangeEvent::SetKnob(idx, new_val) => {
-                    self.knobs[*idx] = *new_val;
-                }
+        event.map(|knob_change_event, _| match knob_change_event {
+            KnobChangeEvent::SetKnob(idx, new_val) => {
+                self.knobs[*idx] = *new_val;
             }
-        }
+        });
     }
 }

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -29,17 +29,15 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetNumber(num) => {
-                    self.number = *num;
-                    self.invalid = false;
-                }
-                AppEvent::SetInvalid => {
-                    self.invalid = true;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetNumber(num) => {
+                self.number = *num;
+                self.invalid = false;
             }
-        }
+            AppEvent::SetInvalid => {
+                self.invalid = true;
+            }
+        });
     }
 }
 

--- a/examples/textbox_list.rs
+++ b/examples/textbox_list.rs
@@ -11,13 +11,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetText(index, text) => {
-                    self.text_list[*index] = text.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetText(index, text) => {
+                self.text_list[*index] = text.clone();
             }
-        }
+        });
     }
 }
 

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -23,37 +23,35 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::ToggleOption(index) => match *index {
-                    0 => self.options.option1 ^= true,
-                    1 => self.options.option2 ^= true,
-                    2 => self.options.option3 ^= true,
-                    _ => {}
-                },
+        event.map(|app_event, _| match app_event {
+            AppEvent::ToggleOption(index) => match *index {
+                0 => self.options.option1 ^= true,
+                1 => self.options.option2 ^= true,
+                2 => self.options.option3 ^= true,
+                _ => {}
+            },
 
-                AppEvent::ToggleExclusiveOption(index) => match *index {
-                    0 => {
-                        self.exclusive_options.option1 = true;
-                        self.exclusive_options.option2 = false;
-                        self.exclusive_options.option3 = false;
-                    }
+            AppEvent::ToggleExclusiveOption(index) => match *index {
+                0 => {
+                    self.exclusive_options.option1 = true;
+                    self.exclusive_options.option2 = false;
+                    self.exclusive_options.option3 = false;
+                }
 
-                    1 => {
-                        self.exclusive_options.option1 = false;
-                        self.exclusive_options.option2 = true;
-                        self.exclusive_options.option3 = false;
-                    }
+                1 => {
+                    self.exclusive_options.option1 = false;
+                    self.exclusive_options.option2 = true;
+                    self.exclusive_options.option3 = false;
+                }
 
-                    2 => {
-                        self.exclusive_options.option1 = false;
-                        self.exclusive_options.option2 = false;
-                        self.exclusive_options.option3 = true;
-                    }
-                    _ => {}
-                },
-            }
-        }
+                2 => {
+                    self.exclusive_options.option1 = false;
+                    self.exclusive_options.option2 = false;
+                    self.exclusive_options.option3 = true;
+                }
+                _ => {}
+            },
+        });
     }
 }
 

--- a/examples/views/dropdown.rs
+++ b/examples/views/dropdown.rs
@@ -13,13 +13,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetChoice(choice) => {
-                    self.choice = choice.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetChoice(choice) => {
+                self.choice = choice.clone();
             }
-        }
+        });
     }
 }
 

--- a/examples/views/knob.rs
+++ b/examples/views/knob.rs
@@ -29,13 +29,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetValue(value) => {
-                    self.value = *value;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetValue(value) => {
+                self.value = *value;
             }
-        }
+        });
     }
 }
 

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -21,30 +21,28 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::ToggleOption(index) => match *index {
-                    0 => {
-                        self.options.option1 = true;
-                        self.options.option2 = false;
-                        self.options.option3 = false;
-                    }
+        event.map(|app_event, _| match app_event {
+            AppEvent::ToggleOption(index) => match *index {
+                0 => {
+                    self.options.option1 = true;
+                    self.options.option2 = false;
+                    self.options.option3 = false;
+                }
 
-                    1 => {
-                        self.options.option1 = false;
-                        self.options.option2 = true;
-                        self.options.option3 = false;
-                    }
+                1 => {
+                    self.options.option1 = false;
+                    self.options.option2 = true;
+                    self.options.option3 = false;
+                }
 
-                    2 => {
-                        self.options.option1 = false;
-                        self.options.option2 = false;
-                        self.options.option3 = true;
-                    }
-                    _ => {}
-                },
-            }
-        }
+                2 => {
+                    self.options.option1 = false;
+                    self.options.option2 = false;
+                    self.options.option3 = true;
+                }
+                _ => {}
+            },
+        });
     }
 }
 

--- a/examples/views/slider.rs
+++ b/examples/views/slider.rs
@@ -65,12 +65,10 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(slider_event) = event.message.downcast() {
-            match slider_event {
-                AppEvent::SetValue(val) => {
-                    self.value = *val;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetValue(val) => {
+                self.value = *val;
             }
-        }
+        });
     }
 }

--- a/examples/views/table.rs
+++ b/examples/views/table.rs
@@ -232,97 +232,95 @@ pub enum Sorted {
 
 impl Model for TableData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetAge(index, age) => {
-                    self.people[*index].last_name = age.clone();
-                }
-
-                AppEvent::Print => {
-                    println!("{:?}", self.people);
-                }
-
-                AppEvent::ToggleSortFirstName => {
-                    match self.first_name_sorted {
-                        Sorted::Forward => {
-                            self.first_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.first_name.clone());
-                                self.people.reverse();
-                                Sorted::Reverse
-                            }
-                        }
-                        Sorted::Reverse => {
-                            self.first_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.first_name.clone());
-                                Sorted::Forward
-                            }
-                        }
-                        Sorted::None => {
-                            self.first_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.first_name.clone());
-                                Sorted::Forward
-                            }
-                        }
-                    }
-
-                    self.last_name_sorted = Sorted::None;
-                    self.age_sorted = Sorted::None;
-                }
-
-                AppEvent::ToggleSortLastName => {
-                    match self.last_name_sorted {
-                        Sorted::Forward => {
-                            self.last_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.last_name.clone());
-                                self.people.reverse();
-                                Sorted::Reverse
-                            }
-                        }
-                        Sorted::Reverse => {
-                            self.last_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.last_name.clone());
-                                Sorted::Forward
-                            }
-                        }
-                        Sorted::None => {
-                            self.last_name_sorted = {
-                                self.people.sort_by_cached_key(|person| person.last_name.clone());
-                                Sorted::Forward
-                            }
-                        }
-                    }
-
-                    self.first_name_sorted = Sorted::None;
-                    self.age_sorted = Sorted::None;
-                }
-
-                AppEvent::ToggleSortAge => {
-                    match self.age_sorted {
-                        Sorted::Forward => {
-                            self.age_sorted = {
-                                self.people.sort_by_cached_key(|person| person.age.clone());
-                                self.people.reverse();
-                                Sorted::Reverse
-                            }
-                        }
-                        Sorted::Reverse => {
-                            self.age_sorted = {
-                                self.people.sort_by_cached_key(|person| person.age.clone());
-                                Sorted::Forward
-                            }
-                        }
-                        Sorted::None => {
-                            self.age_sorted = {
-                                self.people.sort_by_cached_key(|person| person.age.clone());
-                                Sorted::Forward
-                            }
-                        }
-                    }
-
-                    self.first_name_sorted = Sorted::None;
-                    self.last_name_sorted = Sorted::None;
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetAge(index, age) => {
+                self.people[*index].last_name = age.clone();
             }
-        }
+
+            AppEvent::Print => {
+                println!("{:?}", self.people);
+            }
+
+            AppEvent::ToggleSortFirstName => {
+                match self.first_name_sorted {
+                    Sorted::Forward => {
+                        self.first_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.first_name.clone());
+                            self.people.reverse();
+                            Sorted::Reverse
+                        }
+                    }
+                    Sorted::Reverse => {
+                        self.first_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.first_name.clone());
+                            Sorted::Forward
+                        }
+                    }
+                    Sorted::None => {
+                        self.first_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.first_name.clone());
+                            Sorted::Forward
+                        }
+                    }
+                }
+
+                self.last_name_sorted = Sorted::None;
+                self.age_sorted = Sorted::None;
+            }
+
+            AppEvent::ToggleSortLastName => {
+                match self.last_name_sorted {
+                    Sorted::Forward => {
+                        self.last_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.last_name.clone());
+                            self.people.reverse();
+                            Sorted::Reverse
+                        }
+                    }
+                    Sorted::Reverse => {
+                        self.last_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.last_name.clone());
+                            Sorted::Forward
+                        }
+                    }
+                    Sorted::None => {
+                        self.last_name_sorted = {
+                            self.people.sort_by_cached_key(|person| person.last_name.clone());
+                            Sorted::Forward
+                        }
+                    }
+                }
+
+                self.first_name_sorted = Sorted::None;
+                self.age_sorted = Sorted::None;
+            }
+
+            AppEvent::ToggleSortAge => {
+                match self.age_sorted {
+                    Sorted::Forward => {
+                        self.age_sorted = {
+                            self.people.sort_by_cached_key(|person| person.age.clone());
+                            self.people.reverse();
+                            Sorted::Reverse
+                        }
+                    }
+                    Sorted::Reverse => {
+                        self.age_sorted = {
+                            self.people.sort_by_cached_key(|person| person.age.clone());
+                            Sorted::Forward
+                        }
+                    }
+                    Sorted::None => {
+                        self.age_sorted = {
+                            self.people.sort_by_cached_key(|person| person.age.clone());
+                            Sorted::Forward
+                        }
+                    }
+                }
+
+                self.first_name_sorted = Sorted::None;
+                self.last_name_sorted = Sorted::None;
+            }
+        });
     }
 }

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -12,13 +12,11 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(app_event) = event.message.downcast() {
-            match app_event {
-                AppEvent::SetText(text) => {
-                    self.text = text.clone();
-                }
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetText(text) => {
+                self.text = text.clone();
             }
-        }
+        });
     }
 }
 

--- a/examples/widget_gallery.rs
+++ b/examples/widget_gallery.rs
@@ -67,13 +67,11 @@ pub enum CheckboxEvent {
 
 impl Model for CheckboxData {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        if let Some(checkbox_event) = event.message.downcast() {
-            match checkbox_event {
-                CheckboxEvent::Toggle => {
-                    self.check ^= true;
-                }
+        event.map(|checkbox_event, _| match checkbox_event {
+            CheckboxEvent::Toggle => {
+                self.check ^= true;
             }
-        }
+        });
     }
 }
 

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -133,33 +133,30 @@ impl Window {
 
 impl View for Window {
     fn event(&mut self, _: &mut Context, event: &mut Event) {
-        //self.window_widget.on_event(state, entity, event);
-        if let Some(window_event) = event.message.downcast() {
-            match window_event {
-                WindowEvent::GrabCursor(flag) => {
-                    self.window().set_cursor_grab(*flag).expect("Failed to set cursor grab");
-                }
-
-                WindowEvent::SetCursorPosition(x, y) => {
-                    self.window()
-                        .set_cursor_position(winit::dpi::Position::Physical(PhysicalPosition::new(
-                            *x as i32, *y as i32,
-                        )))
-                        .expect("Failed to set cursor position");
-                }
-
-                WindowEvent::SetCursor(cursor) => {
-                    if let Some(icon) = cursor_icon_to_cursor_icon(*cursor) {
-                        self.window().set_cursor_visible(true);
-                        self.window().set_cursor_icon(icon);
-                    } else {
-                        self.window().set_cursor_visible(false);
-                    }
-                }
-
-                _ => {}
+        event.map(|window_event, _| match window_event {
+            WindowEvent::GrabCursor(flag) => {
+                self.window().set_cursor_grab(*flag).expect("Failed to set cursor grab");
             }
-        }
+
+            WindowEvent::SetCursorPosition(x, y) => {
+                self.window()
+                    .set_cursor_position(winit::dpi::Position::Physical(PhysicalPosition::new(
+                        *x as i32, *y as i32,
+                    )))
+                    .expect("Failed to set cursor position");
+            }
+
+            WindowEvent::SetCursor(cursor) => {
+                if let Some(icon) = cursor_icon_to_cursor_icon(*cursor) {
+                    self.window().set_cursor_visible(true);
+                    self.window().set_cursor_icon(icon);
+                } else {
+                    self.window().set_cursor_visible(false);
+                }
+            }
+
+            _ => {}
+        })
     }
 }
 


### PR DESCRIPTION
I removed the `downcast` boilerplate code that was needed to match on an event message. This also allows us to make the `message` field of an `Event` private. The `message` is now only accessed immutably which makes more sense because you don't ever modify it or should be able to modify it.