### PR TITLE
Fix for keyboard modifiers and cursor icon when releasing capture

### DIFF
--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -203,6 +203,10 @@ impl Context {
         self.modifiers
     }
 
+    pub fn modifiers_mut(&mut self) -> &mut Modifiers {
+        &mut self.modifiers
+    }
+
     /// Mark the application as needing to rerun the draw method
     pub fn need_redraw(&mut self) {
         self.style.needs_redraw = true;
@@ -226,6 +230,9 @@ impl Context {
     /// Releases the mouse events capture
     pub fn release(&mut self) {
         self.captured = Entity::null();
+        let hovered = self.hovered;
+        let cursor = self.style().cursor.get(hovered).cloned().unwrap_or_default();
+        self.emit(WindowEvent::SetCursor(cursor));
     }
 
     /// Sets application focus to the current entity

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -508,11 +508,13 @@ where
                 .class("textbox_container");
         });
 
-        result.class(match kind {
-            TextboxKind::SingleLine => "single_line",
-            TextboxKind::MultiLineUnwrapped => "multi_line_unwrapped",
-            TextboxKind::MultiLineWrapped => "multi_line_wrapped",
-        })
+        result
+            .class(match kind {
+                TextboxKind::SingleLine => "single_line",
+                TextboxKind::MultiLineUnwrapped => "multi_line_unwrapped",
+                TextboxKind::MultiLineWrapped => "multi_line_wrapped",
+            })
+            .cursor(CursorIcon::Text)
     }
 }
 
@@ -571,14 +573,9 @@ where
             }
 
             WindowEvent::MouseMove(_, _) => {
-                cx.emit(WindowEvent::SetCursor(CursorIcon::Text));
                 if cx.mouse().left.state == MouseButtonState::Pressed {
                     cx.emit(TextEvent::Drag(cx.mouse().cursorx, cx.mouse().cursory));
                 }
-            }
-
-            WindowEvent::MouseLeave => {
-                cx.emit(WindowEvent::SetCursor(CursorIcon::Default));
             }
 
             WindowEvent::CharInput(c) => {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -450,10 +450,10 @@ impl Application {
                         }
 
                         winit::event::WindowEvent::ModifiersChanged(modifiers_state) => {
-                            context.modifiers().set(Modifiers::SHIFT, modifiers_state.shift());
-                            context.modifiers().set(Modifiers::ALT, modifiers_state.alt());
-                            context.modifiers().set(Modifiers::CTRL, modifiers_state.ctrl());
-                            context.modifiers().set(Modifiers::LOGO, modifiers_state.logo());
+                            context.modifiers_mut().set(Modifiers::SHIFT, modifiers_state.shift());
+                            context.modifiers_mut().set(Modifiers::ALT, modifiers_state.alt());
+                            context.modifiers_mut().set(Modifiers::CTRL, modifiers_state.ctrl());
+                            context.modifiers_mut().set(Modifiers::LOGO, modifiers_state.logo());
                         }
 
                         _ => {}


### PR DESCRIPTION
This also fixes copy/paste for the textbox as well as the cursor icon not changing when clicking out of the textbox.