### PR TITLE
Fix key input event propagation and add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ name = "proxy"
 path = "examples/proxy.rs"
 
 [[example]]
+name = "key_input_propagation"
+path = "examples/key_input_propagation.rs"
+
+[[example]]
 name = "scrollview"
 path = "examples/views/scrollview.rs"
 

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -1048,8 +1048,7 @@ impl Context {
                 self.dispatch_direct_or_hovered(event, self.captured, true);
             }
             WindowEvent::MouseScroll(_, _) => {
-                self.event_queue
-                    .push_back(Event::new(event).target(self.hovered).propagate(Propagation::Up));
+                self.event_queue.push_back(Event::new(event).target(self.hovered));
             }
             WindowEvent::KeyDown(code, _) => {
                 #[cfg(debug_assertions)]
@@ -1135,10 +1134,10 @@ impl Context {
                     self.style().needs_redraw = true;
                 }
 
-                self.dispatch_direct_or_hovered(event, self.focused, true);
+                self.event_queue.push_back(Event::new(event).target(self.focused));
             }
             WindowEvent::KeyUp(_, _) | WindowEvent::CharInput(_) => {
-                self.dispatch_direct_or_hovered(event, self.focused, true);
+                self.event_queue.push_back(Event::new(event).target(self.focused));
             }
             _ => {}
         }

--- a/examples/key_input_propagation.rs
+++ b/examples/key_input_propagation.rs
@@ -75,7 +75,7 @@ impl InputView {
 }
 
 impl View for InputView {
-    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+    fn event(&mut self, _: &mut Context, event: &mut Event) {
         event.map(|window_event, _| match window_event {
             WindowEvent::KeyDown(code, _) => {
                 println!("The key {:?} got pressed!", code);

--- a/examples/key_input_propagation.rs
+++ b/examples/key_input_propagation.rs
@@ -1,0 +1,89 @@
+//! This example showcases how keyboard inputs are propagated up the tree.
+//!
+//! Pressing on either a child or a sibling focuses it. If the focus is on a
+//! child then the keyboard inputs get propagated up to the `InputView` which
+//! prints the pressed key to the console. If the focus is on a sibling then the
+//! keyboard inputs also go up the tree, but the `InputView` doesn't receive them
+//! because it is not the parent of the siblings.
+
+use vizia::prelude::*;
+
+const STYLE: &str = r#"
+    .input_view {
+        width: auto;
+        height: auto;
+    }
+
+    vstack {
+        width: auto;
+        height: auto;
+    }
+
+    .border {
+        border-color: black;
+        border-width: 1px;
+    }
+"#;
+
+fn main() {
+    Application::new(|cx| {
+        cx.add_theme(STYLE);
+
+        HStack::new(cx, |cx| {
+            // View receiving keyboard events
+            InputView::new(cx, |cx| {
+                VStack::new(cx, |cx| {
+                    Label::new(cx, "Child 1");
+                    VStack::new(cx, |cx| {
+                        Label::new(cx, "Child 2");
+                        VStack::new(cx, |cx| {
+                            Label::new(cx, "Child 3");
+                        })
+                        .class("border")
+                        .on_press(|cx| cx.focus());
+                    })
+                    .class("border")
+                    .on_press(|cx| cx.focus());
+                })
+                .class("border")
+                .on_press(|cx| cx.focus());
+            })
+            .class("input_view");
+
+            // Siblings
+            Label::new(cx, "Sibling 1").on_press(|cx| cx.focus()).class("border");
+            Label::new(cx, "Sibling 2").on_press(|cx| cx.focus()).class("border");
+            Label::new(cx, "Sibling 3").on_press(|cx| cx.focus()).class("border");
+        })
+        .height(Pixels(150.0));
+    })
+    .title("Key input propagation")
+    .run();
+}
+
+struct InputView;
+
+impl InputView {
+    pub fn new<F>(cx: &mut Context, content: F) -> Handle<Self>
+    where
+        F: FnOnce(&mut Context),
+    {
+        Self {}.build(cx, |cx| {
+            (content)(cx);
+        })
+    }
+}
+
+impl View for InputView {
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        event.map(|window_event, _| match window_event {
+            WindowEvent::KeyDown(code, _) => {
+                println!("The key {:?} got pressed!", code);
+            }
+            WindowEvent::KeyUp(code, _) => {
+                println!("The key {:?} got released!", code);
+            }
+            _ => {}
+        });
+    }
+}


### PR DESCRIPTION
I fixed the key input event propagation and added an example to test this change. Once #129 lands we should definitely add a test for this instead of having it be an example. 