### PR TITLE
Add a callback to `Keymap`

### DIFF
--- a/core/src/input/entry.rs
+++ b/core/src/input/entry.rs
@@ -1,0 +1,56 @@
+use crate::context::Context;
+
+#[derive(Clone)]
+pub struct KeymapEntry<T>
+where
+    T: 'static + Send + Sync + Copy + Clone,
+{
+    action: T,
+    callback: Box<dyn Fn(&mut Context)>,
+}
+
+impl<T> std::fmt::Debug for KeymapEntry<T>
+where
+    T: 'static + std::fmt::Debug + Send + Sync + Copy + Clone,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.action)
+    }
+}
+
+unsafe impl<T> Send for KeymapEntry<T> where T: 'static + Send + Sync + Copy + Clone {}
+unsafe impl<T> Sync for KeymapEntry<T> where T: 'static + Send + Sync + Copy + Clone {}
+
+impl<T> PartialEq for KeymapEntry<T>
+where
+    T: 'static + Send + Sync + Copy + Clone + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.action == other.action
+    }
+}
+
+impl<T> KeymapEntry<T>
+where
+    T: 'static + Send + Sync + Copy + Clone + PartialEq,
+{
+    pub fn new<F>(action: T, callback: F) -> Self
+    where
+        F: 'static + Fn(&mut Context),
+    {
+        Self { action, callback: Box::new(callback) }
+    }
+
+    pub fn callback(&self) -> &Box<dyn Fn(&mut Context)> {
+        &self.callback
+    }
+}
+
+impl<T> PartialEq<T> for KeymapEntry<T>
+where
+    T: 'static + Send + Sync + Copy + Clone + PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.action == *other
+    }
+}

--- a/core/src/input/entry.rs
+++ b/core/src/input/entry.rs
@@ -1,54 +1,65 @@
 use crate::context::Context;
 
-#[derive(Clone)]
+/// An entry inside of a [`Keymap`](crate::prelude::Keymap).
+///
+/// It consists of an action which is usually just an enum variant
+/// and a callback function that gets called if the action got triggered.
+///
+/// This type is part of the prelude.
+#[derive(Copy, Clone)]
 pub struct KeymapEntry<T>
 where
-    T: 'static + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     action: T,
-    callback: Box<dyn Fn(&mut Context)>,
+    on_action: fn(&mut Context),
 }
 
-impl<T> std::fmt::Debug for KeymapEntry<T>
+impl<T> KeymapEntry<T>
 where
-    T: 'static + std::fmt::Debug + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.action)
+    /// Creates a new keymap entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vizia_core::prelude::*;
+    /// #
+    /// # #[derive(Copy, Clone, PartialEq)]
+    /// # enum Action {
+    /// #     One,
+    /// # }
+    /// #
+    /// KeymapEntry::new(Action::One, |_| println!("Action One"));
+    /// ```
+    pub fn new(action: T, on_action: fn(&mut Context)) -> Self {
+        Self { action, on_action }
+    }
+
+    /// Returns the action of the keymap entry.
+    pub fn action(&self) -> &T {
+        &self.action
+    }
+
+    /// Returns the `on_action` callback function of the keymap entry.
+    pub fn on_action(&self) -> &fn(&mut Context) {
+        &self.on_action
     }
 }
 
-unsafe impl<T> Send for KeymapEntry<T> where T: 'static + Send + Sync + Copy + Clone {}
-unsafe impl<T> Sync for KeymapEntry<T> where T: 'static + Send + Sync + Copy + Clone {}
-
 impl<T> PartialEq for KeymapEntry<T>
 where
-    T: 'static + Send + Sync + Copy + Clone + PartialEq,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     fn eq(&self, other: &Self) -> bool {
         self.action == other.action
     }
 }
 
-impl<T> KeymapEntry<T>
-where
-    T: 'static + Send + Sync + Copy + Clone + PartialEq,
-{
-    pub fn new<F>(action: T, callback: F) -> Self
-    where
-        F: 'static + Fn(&mut Context),
-    {
-        Self { action, callback: Box::new(callback) }
-    }
-
-    pub fn callback(&self) -> &Box<dyn Fn(&mut Context)> {
-        &self.callback
-    }
-}
-
 impl<T> PartialEq<T> for KeymapEntry<T>
 where
-    T: 'static + Send + Sync + Copy + Clone + PartialEq,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     fn eq(&self, other: &T) -> bool {
         self.action == *other

--- a/core/src/input/keymap.rs
+++ b/core/src/input/keymap.rs
@@ -1,4 +1,3 @@
-use super::KeymapEntry;
 use crate::prelude::*;
 use std::collections::HashMap;
 
@@ -24,7 +23,8 @@ use std::collections::HashMap;
 ///
 /// Now we can create a new keymap inside of our application and configure our key chords.
 /// We will bind `Action::One` to the key chord `A`, `Action::Two` to the key chord `CTRL+B`
-/// and `Action::Three` to the key chord `CTRL+SHIFT+C`.
+/// and `Action::Three` to the key chord `CTRL+SHIFT+C`. Every action has an associated callback
+/// function that gets triggered when the key chord is pressed.
 ///
 /// ```
 /// # use vizia_core::prelude::*;
@@ -37,55 +37,23 @@ use std::collections::HashMap;
 /// # }
 /// #
 /// let keymap = Keymap::from(vec![
-///     (Action::One, KeyChord::new(Modifiers::empty(), Code::KeyA)),
-///     (Action::Two, KeyChord::new(Modifiers::CTRL, Code::KeyB)),
-///     (Action::Three, KeyChord::new(Modifiers::CTRL | Modifiers::SHIFT, Code::KeyC)),
+///     (KeyChord::new(Modifiers::empty(), Code::KeyA), KeymapEntry::new(Action::One, |_| println!("Action One"))),
+///     (KeyChord::new(Modifiers::CTRL, Code::KeyB), KeymapEntry::new(Action::Two, |_| println!("Action Two"))),
+///     (KeyChord::new(Modifiers::CTRL | Modifiers::SHIFT, Code::KeyC), KeymapEntry::new(Action::Three, |_| println!("Action Three"))),
 /// ]);
-/// ```
-///
-/// After we've defined our key chords we can now use them inside of a custom view. Here we check if the
-/// action `Action::One` is being pressed. If it is we just print a simple message to the console,
-/// but here you could do whatever you want to.
-///
-/// ```
-/// # use vizia_core::prelude::*;
-/// #
-/// # #[derive(Debug, PartialEq, Copy, Clone)]
-/// # enum Action {
-/// #     One,
-/// #     Two,
-/// #     Three,
-/// # }
-/// #
-/// struct CustomView;
-///
-/// impl View for CustomView {
-///     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-///         event.map(|window_event, _| match window_event {
-///             WindowEvent::KeyDown(code, _) => {
-///                 if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
-///                     for action in keymap_data.pressed_actions(cx, *code) {
-///                         println!("The action {:?} is being pressed!", action);
-///                     }
-///                 }
-///             }
-///             _ => {}
-///         });
-///     }
-/// }
 /// ```
 ///
 /// This type is part of the prelude.
 pub struct Keymap<T>
 where
-    T: 'static + PartialEq + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     entries: HashMap<KeyChord, Vec<KeymapEntry<T>>>,
 }
 
 impl<T> Keymap<T>
 where
-    T: 'static + PartialEq + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     /// Creates a new keymap.
     ///
@@ -137,7 +105,7 @@ where
         }
     }
 
-    /// Returns an iterator over every pressed action or `None` if there are no actions for that key chord.
+    /// Returns an iterator over every pressed keymap entry.
     ///
     /// # Examples
     ///
@@ -152,8 +120,8 @@ where
     /// # let cx = &Context::new();
     /// # let keymap = Keymap::<Action>::new();
     /// #
-    /// for action in keymap.pressed_actions(cx, Code::KeyA) {
-    ///     println!("The action {:?} is being pressed!", action);
+    /// for entry in keymap.pressed_actions(cx, Code::KeyA) {
+    ///     println!("The action {:?} is being pressed!", entry.action());
     /// };
     pub fn pressed_actions(
         &self,
@@ -167,10 +135,10 @@ where
         }
     }
 
-    /// Exports all actions and their associated key chords.
+    /// Exports all keymap entries and their associated key chords.
     ///
-    /// This is useful if you want to have a settings window and need every to access every key chord
-    /// and action of a keymap.
+    /// This is useful if you want to have a settings window and need to access every key chord
+    /// and keymap entry of a keymap.
     ///
     /// # Examples
     ///
@@ -186,8 +154,8 @@ where
     /// #
     /// let actions_chords = keymap.export();
     ///
-    /// for (action, chord) in actions_chords {
-    ///     println!("The key chord {:?} triggers the action {:?}!", chord, action);
+    /// for (chord, entry) in actions_chords {
+    ///     println!("The key chord {:?} triggers the action {:?}!", chord, entry.action());
     /// }
     /// ```
     pub fn export(&self) -> Vec<(&KeyChord, &KeymapEntry<T>)> {
@@ -203,22 +171,18 @@ where
 
 impl<T> Model for Keymap<T>
 where
-    T: 'static + PartialEq + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        event.map(|keymap_event, meta| {
-            match keymap_event {
-                KeymapEvent::InsertAction(chord, entry) => self.insert(*chord, *entry),
-                KeymapEvent::RemoveAction(chord, action) => self.remove(chord, action),
-                _ => {}
-            }
-            meta.consume();
+        event.map(|keymap_event, _| match keymap_event {
+            KeymapEvent::InsertAction(chord, entry) => self.insert(*chord, *entry),
+            KeymapEvent::RemoveAction(chord, action) => self.remove(chord, action),
         });
         event.map(|window_event, _| match window_event {
             WindowEvent::KeyDown(code, _) => {
                 if let Some(entries) = self.entries.get(&KeyChord::new(cx.modifiers(), *code)) {
                     for entry in entries {
-                        (entry.callback())(cx)
+                        (entry.on_action())(cx)
                     }
                 }
             }
@@ -229,7 +193,7 @@ where
 
 impl<T> From<Vec<(KeyChord, KeymapEntry<T>)>> for Keymap<T>
 where
-    T: 'static + PartialEq + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     fn from(vec: Vec<(KeyChord, KeymapEntry<T>)>) -> Self {
         let mut keymap = Self::new();
@@ -245,7 +209,7 @@ where
 /// This type is part of the prelude.
 pub enum KeymapEvent<T>
 where
-    T: 'static + PartialEq + Send + Sync + Copy + Clone,
+    T: 'static + Copy + Clone + PartialEq + Send + Sync,
 {
     /// Inserts an entry into the [`Keymap`].
     ///
@@ -262,8 +226,8 @@ where
     /// # let cx = &mut Context::new();
     /// #
     /// cx.emit(KeymapEvent::InsertAction(
-    ///     Action::One,
     ///     KeyChord::new(Modifiers::empty(), Code::KeyA),
+    ///     KeymapEntry::new(Action::One, |_| println!("Action One")),
     /// ));
     /// ```
     InsertAction(KeyChord, KeymapEntry<T>),
@@ -282,8 +246,8 @@ where
     /// # let cx = &mut Context::new();
     /// #
     /// cx.emit(KeymapEvent::RemoveAction(
-    ///     Action::One,
     ///     KeyChord::new(Modifiers::empty(), Code::KeyA),
+    ///     Action::One,
     /// ));
     /// ```
     RemoveAction(KeyChord, T),

--- a/core/src/input/mod.rs
+++ b/core/src/input/mod.rs
@@ -9,3 +9,6 @@ pub use modifiers::*;
 
 mod mouse;
 pub use mouse::*;
+
+mod entry;
+pub use entry::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     pub use super::events::{Event, Message, Propagation};
     pub use super::handle::Handle;
     pub use super::input::{
-        KeyChord, Keymap, KeymapEvent, Modifiers, MouseButton, MouseButtonState,
+        KeyChord, Keymap, KeymapEntry, KeymapEvent, Modifiers, MouseButton, MouseButtonState,
     };
     pub use super::localization::Localized;
     pub use super::modifiers::Actions;

--- a/examples/keymap_basic.rs
+++ b/examples/keymap_basic.rs
@@ -12,30 +12,36 @@
 //! `CTRL+ALT+SHIFT+Y`      => `Action::OnCtrlAltShiftY`
 //! `CTRL+ALT+SHIFT+LOGO+Z` => `Action::OnCtrlAltShiftLogoZ`
 
-use vizia::prelude::*;
+use vizia::{input::KeymapEntry, prelude::*};
 
 fn main() {
     Application::new(|cx| {
         // Build the keymap.
         Keymap::from(vec![
-            (Action::OnA, KeyChord::new(Modifiers::empty(), Code::KeyA)),
-            (Action::OnB, KeyChord::new(Modifiers::empty(), Code::KeyB)),
-            (Action::OnC, KeyChord::new(Modifiers::empty(), Code::KeyC)),
-            (Action::OnCtrlA, KeyChord::new(Modifiers::CTRL, Code::KeyA)),
-            (Action::OnAltA, KeyChord::new(Modifiers::ALT, Code::KeyA)),
-            (Action::OnShiftA, KeyChord::new(Modifiers::SHIFT, Code::KeyA)),
-            (Action::OnLogoA, KeyChord::new(Modifiers::LOGO, Code::KeyA)),
-            (Action::OnAltShiftX, KeyChord::new(Modifiers::ALT | Modifiers::SHIFT, Code::KeyX)),
+            (KeyChord::new(Modifiers::empty(), Code::KeyA), KeymapEntry::new(Action::OnA, |_| {})),
+            (KeyChord::new(Modifiers::empty(), Code::KeyB), KeymapEntry::new(Action::OnB, |_| {})),
+            (KeyChord::new(Modifiers::empty(), Code::KeyC), KeymapEntry::new(Action::OnC, |_| {})),
+            (KeyChord::new(Modifiers::CTRL, Code::KeyA), KeymapEntry::new(Action::OnCtrlA, |_| {})),
+            (KeyChord::new(Modifiers::ALT, Code::KeyA), KeymapEntry::new(Action::OnAltA, |_| {})),
             (
-                Action::OnCtrlAltShiftY,
-                KeyChord::new(Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT, Code::KeyY),
+                KeyChord::new(Modifiers::SHIFT, Code::KeyA),
+                KeymapEntry::new(Action::OnShiftA, |_| {}),
+            ),
+            (KeyChord::new(Modifiers::LOGO, Code::KeyA), KeymapEntry::new(Action::OnLogoA, |_| {})),
+            (
+                KeyChord::new(Modifiers::ALT | Modifiers::SHIFT, Code::KeyX),
+                KeymapEntry::new(Action::OnAltShiftX, |_| {}),
             ),
             (
-                Action::OnCtrlAltShiftLogoZ,
+                KeyChord::new(Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT, Code::KeyY),
+                KeymapEntry::new(Action::OnCtrlAltShiftY, |_| {}),
+            ),
+            (
                 KeyChord::new(
                     Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT | Modifiers::LOGO,
                     Code::KeyZ,
                 ),
+                KeymapEntry::new(Action::OnCtrlAltShiftLogoZ, |_| {}),
             ),
         ])
         .build(cx);

--- a/examples/keymap_basic.rs
+++ b/examples/keymap_basic.rs
@@ -12,72 +12,62 @@
 //! `CTRL+ALT+SHIFT+Y`      => `Action::OnCtrlAltShiftY`
 //! `CTRL+ALT+SHIFT+LOGO+Z` => `Action::OnCtrlAltShiftLogoZ`
 
-use vizia::{input::KeymapEntry, prelude::*};
+use vizia::prelude::*;
 
 fn main() {
     Application::new(|cx| {
         // Build the keymap.
         Keymap::from(vec![
-            (KeyChord::new(Modifiers::empty(), Code::KeyA), KeymapEntry::new(Action::OnA, |_| {})),
-            (KeyChord::new(Modifiers::empty(), Code::KeyB), KeymapEntry::new(Action::OnB, |_| {})),
-            (KeyChord::new(Modifiers::empty(), Code::KeyC), KeymapEntry::new(Action::OnC, |_| {})),
-            (KeyChord::new(Modifiers::CTRL, Code::KeyA), KeymapEntry::new(Action::OnCtrlA, |_| {})),
-            (KeyChord::new(Modifiers::ALT, Code::KeyA), KeymapEntry::new(Action::OnAltA, |_| {})),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyA),
+                KeymapEntry::new(Action::OnA, |_| println!("Action A")),
+            ),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyB),
+                KeymapEntry::new(Action::OnB, |_| println!("Action B")),
+            ),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyC),
+                KeymapEntry::new(Action::OnC, |_| println!("Action C")),
+            ),
+            (
+                KeyChord::new(Modifiers::CTRL, Code::KeyA),
+                KeymapEntry::new(Action::OnCtrlA, |_| println!("Action OnCtrlA")),
+            ),
+            (
+                KeyChord::new(Modifiers::ALT, Code::KeyA),
+                KeymapEntry::new(Action::OnAltA, |_| println!("Action OnAltA")),
+            ),
             (
                 KeyChord::new(Modifiers::SHIFT, Code::KeyA),
-                KeymapEntry::new(Action::OnShiftA, |_| {}),
+                KeymapEntry::new(Action::OnShiftA, |_| println!("Action OnShiftA")),
             ),
-            (KeyChord::new(Modifiers::LOGO, Code::KeyA), KeymapEntry::new(Action::OnLogoA, |_| {})),
+            (
+                KeyChord::new(Modifiers::LOGO, Code::KeyA),
+                KeymapEntry::new(Action::OnLogoA, |_| println!("Action OnLogoA")),
+            ),
             (
                 KeyChord::new(Modifiers::ALT | Modifiers::SHIFT, Code::KeyX),
-                KeymapEntry::new(Action::OnAltShiftX, |_| {}),
+                KeymapEntry::new(Action::OnAltShiftX, |_| println!("Action OnAltShiftX")),
             ),
             (
                 KeyChord::new(Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT, Code::KeyY),
-                KeymapEntry::new(Action::OnCtrlAltShiftY, |_| {}),
+                KeymapEntry::new(Action::OnCtrlAltShiftY, |_| println!("Action OnCtrlAltShiftY")),
             ),
             (
                 KeyChord::new(
                     Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT | Modifiers::LOGO,
                     Code::KeyZ,
                 ),
-                KeymapEntry::new(Action::OnCtrlAltShiftLogoZ, |_| {}),
+                KeymapEntry::new(Action::OnCtrlAltShiftLogoZ, |_| {
+                    println!("Action OnCtrlAltShiftLogoZ")
+                }),
             ),
         ])
         .build(cx);
-
-        // Create a custom view.
-        CustomView::new(cx);
     })
     .title("Keymap - Basic")
     .run();
-}
-
-struct CustomView;
-
-impl CustomView {
-    fn new(cx: &mut Context) -> Handle<Self> {
-        Self.build(cx, |cx| {
-            cx.focus();
-        })
-    }
-}
-
-impl View for CustomView {
-    fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        event.map(|window_event, _| match window_event {
-            WindowEvent::KeyDown(code, _) => {
-                // Retrieve our keymap data containing all of our key chords.
-                if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
-                    // Loop through every action that is being pressed.
-                    for action in keymap_data.pressed_actions(cx, *code) {
-                        println!("The action {:?} is being pressed!", action);
-                    }
-                }
-            }
-            _ => {}
-        });
-    }
 }
 
 // The actions that are associated with the key chords.

--- a/examples/keymap_change_entries.rs
+++ b/examples/keymap_change_entries.rs
@@ -11,15 +11,23 @@
 //! `Z` => `Action::Three`
 
 use vizia::prelude::*;
-use vizia_core::input::KeymapEvent;
 
 fn main() {
     Application::new(|cx| {
         // Build the keymap.
         Keymap::from(vec![
-            (Action::One, KeyChord::new(Modifiers::empty(), Code::KeyA)),
-            (Action::Two, KeyChord::new(Modifiers::empty(), Code::KeyB)),
-            (Action::Three, KeyChord::new(Modifiers::empty(), Code::KeyC)),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyA),
+                KeymapEntry::new(Action::One, |_| println!("Action One using A")),
+            ),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyB),
+                KeymapEntry::new(Action::Two, |_| println!("Action Two using B")),
+            ),
+            (
+                KeyChord::new(Modifiers::empty(), Code::KeyC),
+                KeymapEntry::new(Action::Three, |_| println!("Action Three using C")),
+            ),
         ])
         .build(cx);
 
@@ -29,64 +37,34 @@ fn main() {
             |cx| {
                 // Insert `Action::One` that triggers on `Code::KeyX`.
                 cx.emit(KeymapEvent::InsertAction(
-                    Action::One,
                     KeyChord::new(Modifiers::empty(), Code::KeyX),
+                    KeymapEntry::new(Action::One, |_| println!("Action One using X")),
                 ));
 
                 // Remove `Action::Two` that triggers on `Code::KeyB`.
                 cx.emit(KeymapEvent::RemoveAction(
-                    Action::Two,
                     KeyChord::new(Modifiers::empty(), Code::KeyB),
+                    Action::Two,
                 ));
 
                 // Remove `Action::Three` that triggers on `Code::KeyC`.
                 cx.emit(KeymapEvent::RemoveAction(
-                    Action::Three,
                     KeyChord::new(Modifiers::empty(), Code::KeyC),
+                    Action::Three,
                 ));
 
                 // Insert `Action::Three` that triggers on `Code::KeyZ`.
                 cx.emit(KeymapEvent::InsertAction(
-                    Action::Three,
                     KeyChord::new(Modifiers::empty(), Code::KeyZ),
+                    KeymapEntry::new(Action::Three, |_| println!("Action Three using Z")),
                 ))
             },
             |cx| Label::new(cx, "Change key chords"),
         )
         .space(Pixels(10.0));
-
-        // Create a custom view that prints a message every time one of our actions is pressed.
-        CustomView::new(cx);
     })
     .title("Keymap - Change Key Chords")
     .run();
-}
-
-struct CustomView;
-
-impl CustomView {
-    fn new(cx: &mut Context) -> Handle<Self> {
-        Self.build(cx, |cx| {
-            cx.focus();
-        })
-    }
-}
-
-impl View for CustomView {
-    fn event(&mut self, cx: &mut Context, event: &mut Event) {
-        event.map(|window_event, _| match window_event {
-            WindowEvent::KeyDown(code, _) => {
-                // Retrieve our keymap data containing all of our key chords.
-                if let Some(keymap_data) = cx.data::<Keymap<Action>>() {
-                    // Loop through every action that is being pressed.
-                    for action in keymap_data.pressed_actions(cx, *code) {
-                        println!("The action {:?} is being pressed!", action);
-                    }
-                }
-            }
-            _ => {}
-        });
-    }
 }
 
 // The actions that are associated with the key chords.


### PR DESCRIPTION
I changed the way the `Keymap` works to make it more ergonomic and easy to use. The changes were made while testing the implementation inside of Meadowlark and this version makes it really easy to work with. Instead of needing a custom view to react to the `KeyDown` event the `Keymap` just does it itself and calls the appropriate callback functions. The examples also got a lot cleaner.