### PR TITLE
Use operator overloading for lens entension methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,9 +186,15 @@ path = "examples/keymap_change_entries.rs"
 name = "window_modifiers"
 path = "examples/window_modifiers.rs"
 
+# Binding Examples
+
 [[example]]
 name = "then"
 path = "examples/binding/then.rs"
+
+[[example]]
+name = "index"
+path = "examples/binding/index.rs"
 
 [features]
 default = ["winit", "clipboard", "x11", "wayland"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,10 @@ path = "examples/keymap_change_entries.rs"
 name = "window_modifiers"
 path = "examples/window_modifiers.rs"
 
+[[example]]
+name = "then"
+path = "examples/binding/then.rs"
+
 [features]
 default = ["winit", "clipboard", "x11", "wayland"]
 clipboard = ["vizia_core/clipboard"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod prelude {
     };
     pub use super::localization::Localized;
     pub use super::modifiers::Actions;
-    pub use super::state::{Binding, Data, Lens, LensExt, Model, Res};
+    pub use super::state::{Binding, Data, Lens, LensExt, Model, Res, Then};
     pub use super::tree::{Tree, TreeExt};
     pub use super::view::{Canvas, View};
     pub use super::views::*;

--- a/derive/src/lens.rs
+++ b/derive/src/lens.rs
@@ -162,6 +162,17 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
                     map(Some(&source.#field_name))
                 }
             }
+
+            impl <L1, #(#lens_ty_idents),*> std::ops::Shr<L1> for #twizzled_name::#field_name#lens_ty_generics where
+                L1: Lens<Source = <Self as Lens>::Target>,
+                Self: Lens,
+            {
+                type Output = Then<Self, L1>;
+
+                fn shr(self, rhs: L1) -> Self::Output {
+                    self.then(rhs)
+                }
+            }
         }
     });
 

--- a/examples/binding/index.rs
+++ b/examples/binding/index.rs
@@ -1,0 +1,20 @@
+use vizia::prelude::*;
+
+#[derive(Lens)]
+pub struct AppData {
+    pub data: Vec<String>,
+}
+
+impl Model for AppData {}
+
+fn main() {
+    Application::new(|cx| {
+        AppData {
+            data: vec![String::from("First"), String::from("Second"), String::from("Third")],
+        }
+        .build(cx);
+
+        Label::new(cx, AppData::data.index(1));
+    })
+    .run();
+}

--- a/examples/binding/then.rs
+++ b/examples/binding/then.rs
@@ -1,0 +1,23 @@
+use vizia::prelude::*;
+
+#[derive(Lens)]
+pub struct AppData {
+    pub subdata: SubData,
+}
+
+impl Model for AppData {}
+
+#[derive(Lens, Clone, Data)]
+pub struct SubData {
+    pub name: String,
+}
+
+fn main() {
+    Application::new(|cx| {
+        AppData { subdata: SubData { name: String::from("test") } }.build(cx);
+
+        Label::new(cx, AppData::subdata.then(SubData::name));
+        Label::new(cx, AppData::subdata >> SubData::name);
+    })
+    .run();
+}


### PR DESCRIPTION
Allow this:
```rust
AppData::subdata.then(Subdata::field)
```
To be expressed like this:
```rust
AppData::subdata >> Subdata::field
```