### PR TITLE
Remove `Copy` trait bound from `Keymap`

### DIFF
--- a/core/src/input/entry.rs
+++ b/core/src/input/entry.rs
@@ -9,7 +9,7 @@ use crate::context::Context;
 #[derive(Copy, Clone)]
 pub struct KeymapEntry<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     action: T,
     on_action: fn(&mut Context),
@@ -17,7 +17,7 @@ where
 
 impl<T> KeymapEntry<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     /// Creates a new keymap entry.
     ///
@@ -50,7 +50,7 @@ where
 
 impl<T> PartialEq for KeymapEntry<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     fn eq(&self, other: &Self) -> bool {
         self.action == other.action
@@ -59,7 +59,7 @@ where
 
 impl<T> PartialEq<T> for KeymapEntry<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     fn eq(&self, other: &T) -> bool {
         self.action == *other

--- a/core/src/input/keymap.rs
+++ b/core/src/input/keymap.rs
@@ -46,14 +46,14 @@ use std::collections::HashMap;
 /// This type is part of the prelude.
 pub struct Keymap<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     entries: HashMap<KeyChord, Vec<KeymapEntry<T>>>,
 }
 
 impl<T> Keymap<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     /// Creates a new keymap.
     ///
@@ -171,11 +171,11 @@ where
 
 impl<T> Model for Keymap<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|keymap_event, _| match keymap_event {
-            KeymapEvent::InsertAction(chord, entry) => self.insert(*chord, *entry),
+            KeymapEvent::InsertAction(chord, entry) => self.insert(*chord, entry.clone()),
             KeymapEvent::RemoveAction(chord, action) => self.remove(chord, action),
         });
         event.map(|window_event, _| match window_event {
@@ -193,7 +193,7 @@ where
 
 impl<T> From<Vec<(KeyChord, KeymapEntry<T>)>> for Keymap<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     fn from(vec: Vec<(KeyChord, KeymapEntry<T>)>) -> Self {
         let mut keymap = Self::new();
@@ -209,7 +209,7 @@ where
 /// This type is part of the prelude.
 pub enum KeymapEvent<T>
 where
-    T: 'static + Copy + Clone + PartialEq + Send + Sync,
+    T: 'static + Clone + PartialEq + Send + Sync,
 {
     /// Inserts an entry into the [`Keymap`].
     ///


### PR DESCRIPTION
I removed the `Copy` requirement from the `Keymap` because it's not necessary.