### PR TITLE
Document `mouse.rs` and add `frame_delta` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,10 @@ name = "keymap_change_entries"
 path = "examples/keymap_change_entries.rs"
 
 [[example]]
+name = "mouse_delta"
+path = "examples/mouse_delta.rs"
+
+[[example]]
 name = "window_modifiers"
 path = "examples/window_modifiers.rs"
 

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -985,6 +985,8 @@ impl Context {
     pub fn dispatch_system_event(&mut self, event: WindowEvent) {
         match &event {
             WindowEvent::MouseMove(x, y) => {
+                self.mouse.previous_cursorx = self.mouse.cursorx;
+                self.mouse.previous_cursory = self.mouse.cursory;
                 self.mouse.cursorx = *x;
                 self.mouse.cursory = *y;
 

--- a/core/src/input/mouse.rs
+++ b/core/src/input/mouse.rs
@@ -5,9 +5,13 @@ use crate::entity::Entity;
 /// This type is part of the prelude.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MouseButton {
+    /// The left mouse button.
     Left,
+    /// The right mouse button.
     Right,
+    /// The middle mouse button.
     Middle,
+    /// Another mouse button with the associated button number.
     Other(u16),
 }
 
@@ -16,22 +20,24 @@ pub enum MouseButton {
 /// This type is part of the prelude.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MouseButtonState {
+    /// Represents a pressed mouse button.
     Pressed,
+    /// Represents a released mouse button.
     Released,
 }
 
 /// Data which describes the current state of a mouse button.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MouseButtonData {
-    /// The state of the mouse button (pressed/released)
+    /// The state of the mouse button (pressed/released).
     pub state: MouseButtonState,
-    /// The position of the mouse cursor when the mouse button was last pressed
+    /// The position of the mouse cursor when the mouse button was last pressed.
     pub pos_down: (f32, f32),
-    /// The position of the mouse cursor when the mouse button was last released
+    /// The position of the mouse cursor when the mouse button was last released.
     pub pos_up: (f32, f32),
-    /// The hovered entity when the mouse button was last pressed
+    /// The hovered entity when the mouse button was last pressed.
     pub pressed: Entity,
-    /// The hovered entity when the mouse button was last released
+    /// The hovered entity when the mouse button was last released.
     pub released: Entity,
 }
 
@@ -50,11 +56,19 @@ impl Default for MouseButtonData {
 /// The current state of the mouse cursor and buttons.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MouseState {
+    /// The horizontal mouse cursor position of the frame.
     pub cursorx: f32,
+    /// The vertical mouse cursor position of the frame.
     pub cursory: f32,
-
+    /// The horizontal mouse cursor position of the previous frame.
+    pub previous_cursorx: f32,
+    /// The vertical mouse cursor position of the previous frame.
+    pub previous_cursory: f32,
+    /// The state of the left mouse button.
     pub left: MouseButtonData,
+    /// The state of the right mouse button.
     pub right: MouseButtonData,
+    /// The state of the middle mouse button.
     pub middle: MouseButtonData,
 }
 
@@ -63,6 +77,8 @@ impl Default for MouseState {
         MouseState {
             cursorx: -1.0,
             cursory: -1.0,
+            previous_cursorx: -1.0,
+            previous_cursory: -1.0,
             left: MouseButtonData::default(),
             right: MouseButtonData::default(),
             middle: MouseButtonData::default(),
@@ -71,6 +87,12 @@ impl Default for MouseState {
 }
 
 impl MouseState {
+    /// Returns the delta of the mouse cursor position of the current and previous frame.
+    pub fn frame_delta(&self) -> (f32, f32) {
+        (self.cursorx - self.previous_cursorx, self.cursory - self.previous_cursory)
+    }
+
+    /// Returns the delta of the mouse cursor position of the current frame and the frame the `button` got pressed.
     pub fn delta(&self, button: MouseButton) -> (f32, f32) {
         match button {
             MouseButton::Left => {

--- a/examples/mouse_delta.rs
+++ b/examples/mouse_delta.rs
@@ -1,0 +1,46 @@
+//! This example showcases the different delta values of the mouse state.
+
+use vizia::prelude::*;
+
+fn main() {
+    Application::new(|cx| {
+        MouseDeltaView::new(cx);
+    })
+    .title("Mouse Delta")
+    .run();
+}
+
+pub struct MouseDeltaView;
+
+impl MouseDeltaView {
+    pub fn new(cx: &mut Context) -> Handle<Self> {
+        Self.build(cx, |_| {})
+    }
+}
+
+impl View for MouseDeltaView {
+    fn event(&mut self, cx: &mut Context, _: &mut Event) {
+        println!("                     |            x |            y ");
+        println!("---------------------|--------------|--------------");
+
+        let frame_delta = cx.mouse().frame_delta();
+        println!("Frame delta          | {:>12.4} | {:>12.4}", frame_delta.0, frame_delta.1);
+
+        if cx.mouse().left.state == MouseButtonState::Pressed {
+            let delta = cx.mouse().delta(MouseButton::Left);
+            println!("Pressed left delta   | {:>12.4} | {:>12.4}", delta.0, delta.1);
+        }
+
+        if cx.mouse().right.state == MouseButtonState::Pressed {
+            let delta = cx.mouse().delta(MouseButton::Right);
+            println!("Pressed right delta  | {:>12.4} | {:>12.4}", delta.0, delta.1);
+        }
+
+        if cx.mouse().middle.state == MouseButtonState::Pressed {
+            let delta = cx.mouse().delta(MouseButton::Middle);
+            println!("Pressed middle delta | {:>12.4} | {:>12.4}", delta.0, delta.1);
+        }
+
+        println!("");
+    }
+}


### PR DESCRIPTION
I documented the `mouse.rs` file and also added a `frame_delta` method that returns the delta of the mouse cursor position of the current and previous frame. This is useful if you want to use this as a value that gets added to some other value every frame. 

An example would be dragging the timeline in a `DAW` like `Meadowlark`. The `delta` method wouldn't work in this case, because you would either have to store the previous mouse cursor position or the value you want to increase/decrease which is rather inconvenient.

I also added an example for the usage of both the `frame_delta` and `delta` methods.