### PR TITLE
Reduce `GenerationalId` code duplication

### DIFF
--- a/core/src/animation/animation.rs
+++ b/core/src/animation/animation.rs
@@ -1,13 +1,4 @@
-use std::cmp::{Eq, PartialEq};
-use std::hash::Hash;
-
-use crate::id::GenerationalId;
-
-const ANIMATION_INDEX_BITS: u32 = 24;
-const ANIMATION_INDEX_MASK: u32 = (1 << ANIMATION_INDEX_BITS) - 1;
-
-const ANIMATION_GENERATION_BITS: u32 = 8;
-const ANIMATION_GENERATION_MASK: u32 = (1 << ANIMATION_GENERATION_BITS) - 1;
+use crate::id::impl_generational_id;
 
 /// An id used to reference style animations stored in context.
 ///
@@ -18,63 +9,4 @@ const ANIMATION_GENERATION_MASK: u32 = (1 << ANIMATION_GENERATION_BITS) - 1;
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Animation(u32);
 
-impl Default for Animation {
-    fn default() -> Self {
-        Animation::null()
-    }
-}
-
-impl std::fmt::Display for Animation {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.index())
-    }
-}
-
-impl std::fmt::Debug for Animation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Animation {{index: {}, generation: {}}}", self.index(), self.generation())
-    }
-}
-
-impl Animation {
-    /// Creates a null animation id.
-    ///
-    /// A null animation can be used as a placeholder within a widget struct but cannot be used to
-    /// get/set animation properties or control animation playback.
-    pub fn null() -> Animation {
-        Animation(std::u32::MAX)
-    }
-
-    /// Creates a new animation id with a given index and generation.
-    pub(crate) fn new(index: u32, generation: u32) -> Animation {
-        assert!(index < ANIMATION_INDEX_MASK);
-        assert!(generation < ANIMATION_GENERATION_MASK);
-        Animation(index | generation << ANIMATION_INDEX_BITS)
-    }
-}
-
-impl GenerationalId for Animation {
-    /// Create a new animation id with a given index and generation.
-    fn new(index: usize, generation: usize) -> Self {
-        Animation::new(index as u32, generation as u32)
-    }
-
-    /// Returns the index of the animation.
-    ///
-    /// This is used to retrieve animation data from the style storages in the context.
-    fn index(&self) -> usize {
-        (self.0 & ANIMATION_INDEX_MASK) as usize
-    }
-
-    /// Returns the generation of the animtion.
-    ///
-    /// This is used to determine whether or not the animation referred to by the id is 'alive'.
-    fn generation(&self) -> u8 {
-        ((self.0 >> ANIMATION_INDEX_BITS) & ANIMATION_GENERATION_MASK) as u8
-    }
-
-    /// Returns true if the animation is null.
-    fn is_null(&self) -> bool {
-        self.0 == std::u32::MAX
-    }
-}
+impl_generational_id!(Animation);

--- a/core/src/animation/animation_state.rs
+++ b/core/src/animation/animation_state.rs
@@ -1,4 +1,5 @@
 use crate::animation::Interpolator;
+use crate::id::GenerationalId;
 use instant::{Duration, Instant};
 use std::collections::HashSet;
 

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -23,7 +23,7 @@ use crate::cache::CachedData;
 use crate::environment::Environment;
 use crate::events::ViewHandler;
 use crate::hover_system::apply_hover;
-use crate::id::IdManager;
+use crate::id::{GenerationalId, IdManager};
 use crate::input::{Modifiers, MouseState};
 use crate::layout::geometry_changed;
 use crate::prelude::*;

--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -1,12 +1,4 @@
-use crate::id::GenerationalId;
-use std::cmp::{Eq, PartialEq};
-use std::hash::Hash;
-
-const ENTITY_INDEX_BITS: u32 = 24;
-const ENTITY_INDEX_MASK: u32 = (1 << ENTITY_INDEX_BITS) - 1;
-
-const ENTITY_GENERATION_BITS: u32 = 8;
-const ENTITY_GENERATION_MASK: u32 = (1 << ENTITY_GENERATION_BITS) - 1;
+use crate::id::impl_generational_id;
 
 /// An entity is an identifier used to reference a view; to get/set properties in the context.
 ///
@@ -17,63 +9,16 @@ const ENTITY_GENERATION_MASK: u32 = (1 << ENTITY_GENERATION_BITS) - 1;
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Entity(u32);
 
-impl Default for Entity {
-    fn default() -> Self {
-        Entity::null()
-    }
-}
-
-impl std::fmt::Display for Entity {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.index())
-    }
-}
-
-impl std::fmt::Debug for Entity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Entity {{index: {}, generation: {}}}", self.index(), self.generation())
-    }
-}
-
 impl Entity {
-    /// Creates a null entity
+    /// Creates a new root entity.
     ///
-    /// A null entity can be used as a placeholder within a widget struct but cannot be used to get/set properties
-    pub fn null() -> Entity {
-        Entity(u32::MAX)
-    }
-
-    /// Creates a root entity
-    ///
-    /// The root entity represents the main window and is always valid.
-    /// The root entity can be used to set properties on the primary window, such as background color,
-    /// as well as sending events to the window such as Restyle and Redraw events.
-    pub fn root() -> Entity {
-        Entity(0)
-    }
-
-    /// Creates a new entity with a given index and generation
-    pub(crate) fn new(index: u32, generation: u32) -> Entity {
-        assert!(index < ENTITY_INDEX_MASK);
-        assert!(generation < ENTITY_GENERATION_MASK);
-        Entity(index | generation << ENTITY_INDEX_BITS)
+    /// The root entity represents the main window and is always valid. It can be used to set
+    /// properties on the primary window, such as background color, as well as sending events
+    /// to the window such as [`Restyle`](crate::prelude::WindowEvent::Restyle) and
+    /// [`Redraw`](crate::prelude::WindowEvent::Redraw) events.
+    pub fn root() -> Self {
+        Self(0)
     }
 }
 
-impl GenerationalId for Entity {
-    fn new(index: usize, generation: usize) -> Self {
-        Entity::new(index as u32, generation as u32)
-    }
-
-    fn index(&self) -> usize {
-        (self.0 & ENTITY_INDEX_MASK) as usize
-    }
-
-    fn generation(&self) -> u8 {
-        ((self.0 >> ENTITY_INDEX_BITS) & ENTITY_GENERATION_MASK) as u8
-    }
-
-    fn is_null(&self) -> bool {
-        self.0 == u32::MAX
-    }
-}
+impl_generational_id!(Entity);

--- a/core/src/events/event.rs
+++ b/core/src/events/event.rs
@@ -1,4 +1,5 @@
 use crate::entity::Entity;
+use crate::id::GenerationalId;
 use std::{any::Any, fmt::Debug};
 
 /// Determines how an event propagates through the tree.

--- a/core/src/id/generational_id.rs
+++ b/core/src/id/generational_id.rs
@@ -1,0 +1,92 @@
+/// The bits used for the index.
+pub(crate) const GENERATIONAL_ID_INDEX_BITS: u32 = 24;
+
+/// The mask of the bits used for the index.
+pub(crate) const GENERATIONAL_ID_INDEX_MASK: u32 = (1 << GENERATIONAL_ID_INDEX_BITS) - 1;
+
+/// The bits used for the generation.
+pub(crate) const GENERATIONAL_ID_GENERATION_BITS: u32 = 8;
+
+/// The mask of the bits used for the generation.
+pub(crate) const GENERATIONAL_ID_GENERATION_MASK: u32 = (1 << GENERATIONAL_ID_GENERATION_BITS) - 1;
+
+/// A trait implemented by any generational id.
+///
+/// A generational id has an index and a generation. The index is used for accessing
+/// arrays and the generation is used to check if the id is still valid or alive.
+pub trait GenerationalId: Copy + PartialEq {
+    /// Creates a new generational id from an index and a generation.
+    fn new(index: u32, generation: u32) -> Self;
+
+    /// Returns the index of the generational id.
+    ///
+    /// This is used to access the data of the generational id inside of an array.
+    fn index(&self) -> usize;
+
+    /// Returns the generation of the generational id.
+    ///
+    /// This is used to determine whether this generational id is still valid.
+    fn generation(&self) -> u8;
+
+    /// Creates a null or invalid generational id.
+    ///
+    /// A null id can be used as a place holder.
+    fn null() -> Self;
+
+    /// Returns `true` is the generational id is null.
+    fn is_null(&self) -> bool;
+}
+
+macro_rules! impl_generational_id {
+    ($impl_type: ty) => {
+        impl Default for $impl_type {
+            fn default() -> Self {
+                $crate::id::GenerationalId::null()
+            }
+        }
+
+        impl std::fmt::Display for $impl_type {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", $crate::id::GenerationalId::index(self))
+            }
+        }
+
+        impl std::fmt::Debug for $impl_type {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(
+                    f,
+                    concat!(stringify!($impl_type), " (index: {}, generation: {})"),
+                    $crate::id::GenerationalId::index(self),
+                    $crate::id::GenerationalId::generation(self),
+                )
+            }
+        }
+
+        impl $crate::id::GenerationalId for $impl_type {
+            fn new(index: u32, generation: u32) -> Self {
+                assert!(index < $crate::id::GENERATIONAL_ID_INDEX_MASK);
+                assert!(generation < $crate::id::GENERATIONAL_ID_GENERATION_MASK);
+                Self(index | generation << $crate::id::GENERATIONAL_ID_INDEX_BITS)
+            }
+
+            fn index(&self) -> usize {
+                (self.0 & $crate::id::GENERATIONAL_ID_INDEX_MASK) as usize
+            }
+
+            fn generation(&self) -> u8 {
+                ((self.0 >> $crate::id::GENERATIONAL_ID_INDEX_BITS)
+                    & $crate::id::GENERATIONAL_ID_GENERATION_MASK) as u8
+            }
+
+            fn null() -> Self {
+                Self(u32::MAX)
+            }
+
+            fn is_null(&self) -> bool {
+                *self == Self::null()
+            }
+        }
+    };
+}
+
+pub(crate) use impl_generational_id;

--- a/core/src/id/id_manager.rs
+++ b/core/src/id/id_manager.rs
@@ -1,9 +1,7 @@
+use super::GenerationalId;
 use std::{collections::VecDeque, marker::PhantomData};
 
-use super::GenerationalId;
-
 const MINIMUM_FREE_INDICES: usize = 1024;
-
 const IDX_MAX: u32 = std::u32::MAX >> 8;
 
 /// The IdManager is responsible for allocating generational IDs.
@@ -49,7 +47,7 @@ impl<I: GenerationalId + Copy> IdManager<I> {
             idx
         };
 
-        I::new(index as usize, self.generation[index as usize] as usize)
+        I::new(index, self.generation[index as usize] as u32)
     }
 
     /// Destroys an ID returning false if the ID has already been destroyed.
@@ -59,7 +57,7 @@ impl<I: GenerationalId + Copy> IdManager<I> {
         if self.is_alive(id) {
             let index = id.index();
             assert!(index < self.generation.len(), "ID is invalid");
-            assert!(self.generation[index] != std::u8::MAX, "ID generation is at maximum");
+            assert!(self.generation[index] != u8::MAX, "ID generation is at maximum");
             self.generation[index as usize] += 1;
             self.free_list.push_back(index as u32);
             true

--- a/core/src/id/mod.rs
+++ b/core/src/id/mod.rs
@@ -1,16 +1,5 @@
+mod generational_id;
 mod id_manager;
-pub(crate) use id_manager::IdManager;
 
-/// Trait implemented by any generational ID
-///
-/// A generational id has an index, used for indexing into arrays, and a generation, used to check the alive status of the id
-pub trait GenerationalId: Copy {
-    /// Method for creating an new generational ID from an index and a generation
-    fn new(index: usize, generation: usize) -> Self;
-    /// Method for retrieving the generational id index
-    fn index(&self) -> usize;
-    /// Method for retrieving the generational id generation
-    fn generation(&self) -> u8;
-    /// Returns true is the id is null
-    fn is_null(&self) -> bool;
-}
+pub(crate) use generational_id::*;
+pub(crate) use id_manager::IdManager;

--- a/core/src/input/mouse.rs
+++ b/core/src/input/mouse.rs
@@ -1,4 +1,5 @@
 use crate::entity::Entity;
+use crate::id::GenerationalId;
 
 /// A mouse button.
 ///

--- a/core/src/style/display.rs
+++ b/core/src/style/display.rs
@@ -1,5 +1,6 @@
 use crate::animation::Interpolator;
 use crate::entity::Entity;
+use crate::id::GenerationalId;
 
 /// Display determines whether an entity will be rendered and acted on by the layout system.
 /// To make an entity invisible to rendering but still visible to layout, see [Visibility].

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashMap, HashSet};
-
+use crate::id::GenerationalId;
 use morphorm::{LayoutType, PositionType, Units};
+use std::collections::{HashMap, HashSet};
 
 use cssparser::{Parser, ParserInput};
 
@@ -71,7 +71,7 @@ impl Default for Abilities {
     }
 }
 
-/// Stores the style properties of all entities in the application. To set properties on entities see the [PropSet] trait.
+/// Stores the style properties of all entities in the application.
 #[derive(Default)]
 pub struct Style {
     pub(crate) rule_manager: IdManager<Rule>,

--- a/core/src/style/parser.rs
+++ b/core/src/style/parser.rs
@@ -6,6 +6,7 @@ use cssparser::{
 };
 
 use crate::animation::Transition;
+use crate::id::GenerationalId;
 use crate::style::color::Color;
 use crate::style::property::Property;
 use crate::style::selector::{Selector, SelectorRelation};

--- a/core/src/style/rule.rs
+++ b/core/src/style/rule.rs
@@ -1,18 +1,4 @@
-use std::cmp::{Eq, PartialEq};
-use std::hash::Hash;
-
-// use crate::{Color, PropSet2, Selector, State};
-use crate::id::GenerationalId;
-
-const RULE_INDEX_BITS: u32 = 24;
-const RULE_INDEX_MASK: u32 = (1 << RULE_INDEX_BITS) - 1;
-
-const RULE_GENERATION_BITS: u32 = 8;
-const RULE_GENERATION_MASK: u32 = (1 << RULE_GENERATION_BITS) - 1;
-
-// const RULE_MAX: u32 = std::u32::MAX>>8;
-
-// const MINIMUM_FREE_INDICES: usize = 1024;
+use crate::id::impl_generational_id;
 
 /// A rule is an id used to get/set shared style properties in State.
 ///
@@ -21,68 +7,7 @@ const RULE_GENERATION_MASK: u32 = (1 << RULE_GENERATION_BITS) - 1;
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Rule(u32);
 
-impl Default for Rule {
-    fn default() -> Self {
-        Rule::null()
-    }
-}
-
-impl std::fmt::Display for Rule {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.index())
-    }
-}
-
-impl std::fmt::Debug for Rule {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Rule {{index: {}, generation: {}}}", self.index(), self.generation())
-    }
-}
-
-impl Rule {
-    /// Creates a null rule.
-    ///
-    /// A null rule can be used as a placeholder within a widget struct but cannot be used to get/set properties.
-    pub fn null() -> Rule {
-        Rule(std::u32::MAX)
-    }
-
-    /// Creates a new rule with a given index and generation.
-    pub(crate) fn new(index: u32, generation: u32) -> Rule {
-        assert!(index < RULE_INDEX_MASK);
-        assert!(generation < RULE_GENERATION_MASK);
-        Rule(index | generation << RULE_INDEX_BITS)
-    }
-
-    /// Returns true if the rule is null.
-    pub fn is_null(&self) -> bool {
-        self.0 == std::u32::MAX
-    }
-
-    // Adds a selector to the rule (TODO)
-    // pub fn selector(self, selector: Selector) -> Self {
-    //     self
-    // }
-}
-
-impl GenerationalId for Rule {
-    fn new(index: usize, generation: usize) -> Self {
-        Rule::new(index as u32, generation as u32)
-    }
-
-    fn index(&self) -> usize {
-        (self.0 & RULE_INDEX_MASK) as usize
-    }
-
-    fn generation(&self) -> u8 {
-        ((self.0 >> RULE_INDEX_BITS) & RULE_GENERATION_MASK) as u8
-    }
-
-    /// Returns true if the entity is null
-    fn is_null(&self) -> bool {
-        self.0 == std::u32::MAX
-    }
-}
+impl_generational_id!(Rule);
 
 // impl PropSet2 for Rule {
 

--- a/core/src/tree/tree_ext.rs
+++ b/core/src/tree/tree_ext.rs
@@ -1,8 +1,8 @@
-use crate::prelude::*;
-
 use super::child_iter::ChildIterator;
 use super::parent_iter::ParentIterator;
 use super::tree_iter::TreeIterator;
+use crate::id::GenerationalId;
+use crate::prelude::*;
 
 /// Trait which provides methods for querying the tree.
 pub trait TreeExt {

--- a/core/src/tree/tree_iter.rs
+++ b/core/src/tree/tree_iter.rs
@@ -39,6 +39,7 @@ impl<'a> DoubleEndedIterator for TreeIterator<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::id::GenerationalId;
     use crate::tree::TreeError;
 
     #[test]

--- a/core/src/views/element.rs
+++ b/core/src/views/element.rs
@@ -74,7 +74,7 @@ use crate::prelude::*;
 ///
 /// An element can be used to display an image like this 100 by 100 pixels one. The image can
 /// be set by using a stylesheet or by using a lens. The image has to be loaded manually by
-/// using the [`Context::load_image`](crate::Context::load_image) method.
+/// using the [`Context::load_image`](crate::prelude::Context::load_image) method.
 ///
 /// ```
 /// # use vizia_core::prelude::*;

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -1,15 +1,13 @@
-use std::sync::Arc;
-
 use crate::cache::BoundingBox;
-use keyboard_types::Code;
-
+use crate::id::GenerationalId;
 use crate::prelude::*;
-
 use crate::text::{
     idx_to_pos, measure_text_lines, pos_to_idx, text_layout, text_paint_general, Direction,
     EditableText, Movement, Selection,
 };
 use crate::tree::TreeExt;
+use keyboard_types::Code;
+use std::sync::Arc;
 
 #[derive(Lens)]
 pub struct TextboxData {


### PR DESCRIPTION
- Combined the index and generation constants.
- Made a macro for the duplicated implementation in `Entity`, `Rule` and `Animation`.
- Added `PartialEq` trait bound for `GenerationalId`.
- Added `null` function to `GenerationalId`.
- Added docs.
- Fixed some broken doc links.