### PR TITLE
Update checkbox style and example

### DIFF
--- a/core/resources/themes/default_theme.css
+++ b/core/resources/themes/default_theme.css
@@ -62,11 +62,9 @@ button.accent:active label {
 checkbox {
     width: 20px;
     height: 20px;
-    border-radius: 3px;
+    border-radius: 1px;
     border-width: 1px;
-    border-color: #838383;
-    color: #ffffff00;
-    background-color: #ffffff00;
+    border-color: #666666;
     child-space: 1s;
 }
 
@@ -80,10 +78,36 @@ checkbox:active {
 }
 
 checkbox:checked {
+    background-color: #3c77d2;
+    border-color: #3c77d2;
+    color: #f5f5f5;
+}
+
+checkbox:disabled {
+    border-color: #bdbdbd;
+}
+
+checkbox:hover:disabled {
+    background-color: #00000000;
+}
+
+checkbox:checked:hover {
+    background-color: #0082e6;
+    border-color: #0082e6;
+    color: #f5f5f5;
+}
+
+checkbox:checked:disabled {
+    background-color: #bdbdbd;
+    border-color: #bdbdbd;
+    color: #f5f5f5;
+}
+
+/* checkbox:checked {
     background-color: #005a9e;
     border-color: #005a9e;
     color: #f5f5f5;
-}
+} */
 
 textbox {
     width: auto;

--- a/core/src/hover_system.rs
+++ b/core/src/hover_system.rs
@@ -121,7 +121,10 @@ pub fn apply_hover(cx: &mut Context) {
         );
 
         let cursor = cx.style().cursor.get(hovered_widget).cloned().unwrap_or_default();
-        if !cx.is_cursor_icon_locked() {
+        // TODO: Decide if not changing the cursor when the view is disabled is the correct thing to do
+        if !cx.is_cursor_icon_locked()
+            && !cx.style().disabled.get(hovered_widget).cloned().unwrap_or_default()
+        {
             cx.emit(WindowEvent::SetCursor(cursor));
         }
 

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -111,11 +111,14 @@ impl Checkbox {
     /// ```
     pub fn new(cx: &mut Context, checked: impl Lens<Target = bool>) -> Handle<Self> {
         //let checked = checked.get_val_fallible(cx).unwrap_or(false);
-        Self { on_toggle: None }.build(cx, |_| {}).bind(checked, |handle, checked| {
-            if let Some(flag) = checked.get_val_fallible(handle.cx) {
-                handle.text(if flag { CHECK } else { "" }).checked(flag);
-            }
-        })
+        Self { on_toggle: None }
+            .build(cx, |_| {})
+            .bind(checked, |handle, checked| {
+                if let Some(flag) = checked.get_val_fallible(handle.cx) {
+                    handle.text(if flag { CHECK } else { "" }).checked(flag);
+                }
+            })
+            .cursor(CursorIcon::Hand)
     }
 }
 
@@ -159,14 +162,29 @@ impl View for Checkbox {
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseDown(MouseButton::Left) => {
-                if meta.target == cx.current() {
+            WindowEvent::MouseUp(MouseButton::Left) => {
+                if cx.mouse().left.pressed == cx.current()
+                    && meta.target == cx.current()
+                    && !cx.is_disabled()
+                {
                     if let Some(callback) = &self.on_toggle {
                         (callback)(cx);
                     }
                 }
             }
 
+            // TODO: Should this be done manually like this or should disabled controls always revert to default cursor icon?
+            // TODO: This doesn't work in it's current form. Commented out in favour of setting mouse cursor in hover system.
+            // WindowEvent::MouseEnter => {
+            //     if meta.target == cx.current() && cx.is_disabled() {
+            //         println!("Enter: {}", cx.current());
+            //         // After context and modifiers change this will become:
+            //         // cx.cursor(CursorIcon::Default);
+            //         let current = cx.current();
+            //         cx.style().cursor.insert(current, CursorIcon::Default);
+            //         cx.need_redraw();
+            //     }
+            // }
             _ => {}
         });
     }

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -2,19 +2,25 @@ use vizia::prelude::*;
 
 #[derive(Debug, Lens)]
 pub struct AppData {
-    pub option: bool,
+    pub option1: bool,
+    pub option2: bool,
 }
 
 #[derive(Debug)]
 pub enum AppEvent {
-    ToggleOption,
+    ToggleOption1,
+    ToggleOption2,
 }
 
 impl Model for AppData {
     fn event(&mut self, _cx: &mut Context, event: &mut Event) {
         event.map(|app_event, _| match app_event {
-            AppEvent::ToggleOption => {
-                self.option ^= true;
+            AppEvent::ToggleOption1 => {
+                self.option1 ^= true;
+            }
+
+            AppEvent::ToggleOption2 => {
+                self.option2 ^= true;
             }
         });
     }
@@ -22,17 +28,45 @@ impl Model for AppData {
 
 fn main() {
     Application::new(|cx| {
-        AppData { option: false }.build(cx);
+        AppData { option1: true, option2: false }.build(cx);
 
         VStack::new(cx, |cx| {
-            // Checkbox
-            Checkbox::new(cx, AppData::option).on_toggle(|cx| cx.emit(AppEvent::ToggleOption));
+            Label::new(cx, "Basic Checkboxes");
 
-            // Checkboxe with label
             HStack::new(cx, |cx| {
-                Checkbox::new(cx, AppData::option).on_toggle(|cx| cx.emit(AppEvent::ToggleOption));
+                // CBasic Checkboxes
+                Checkbox::new(cx, AppData::option1)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1));
+                Checkbox::new(cx, AppData::option2)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2));
+                Checkbox::new(cx, AppData::option2)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2))
+                    .disabled(true);
+                Checkbox::new(cx, AppData::option1)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
+                    .disabled(true);
+            })
+            .col_between(Pixels(4.0));
+
+            Label::new(cx, "Checkbox with Label").top(Pixels(20.0));
+
+            // Checkboxes with label
+            HStack::new(cx, |cx| {
+                Checkbox::new(cx, AppData::option1)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1));
                 Label::new(cx, "Checkbox");
             })
+            .size(Auto)
+            .col_between(Pixels(5.0))
+            .child_top(Stretch(1.0))
+            .child_bottom(Stretch(1.0));
+
+            HStack::new(cx, |cx| {
+                Checkbox::new(cx, AppData::option2)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2));
+                Label::new(cx, "Disabled");
+            })
+            .disabled(true)
             .size(Auto)
             .col_between(Pixels(5.0))
             .child_top(Stretch(1.0))
@@ -42,6 +76,7 @@ fn main() {
         .row_between(Pixels(10.0))
         .space(Stretch(1.0));
     })
+    //.ignore_default_theme()
     .title("Checkbox")
     .run();
 }


### PR DESCRIPTION
- Update checkbox styling.
- Update the checkbox example to show off new styling.
- Fix a bug where multiple pseudoclass selectors weren't matching correctly. For example:

This rule...
```css
checkbox:checked:hover {
    background-color: red;
}
```
should have a higher specificity than this rule...
```css
checkbox:hover {
    background-color: green;
}
```
but previously the former rule wasn't matching at all on the element, causing the latter rule to be selected in error. This is now fixed.