### PR TITLE
Default to first available fluent bundle

### DIFF
--- a/core/src/resource.rs
+++ b/core/src/resource.rs
@@ -127,7 +127,11 @@ impl ResourceManager {
         &self,
         locale: &LanguageIdentifier,
     ) -> &FluentBundle<FluentResource> {
-        self.translations.get(locale).unwrap()
+        if let Some(bundle) = self.translations.get(locale) {
+            bundle
+        } else {
+            self.translations.get(&self.language).unwrap()
+        }
     }
 
     pub(crate) fn add_font(&mut self, _name: &str, _path: &str) {}


### PR DESCRIPTION
I noticed that the l10n example wasn't working for me then realised that my system locale is en-GB so it's failing to find a suitable translation bundle. This fixes it by defaulting to the resource manager language determined by the `renegotiate_language` function. 