### PR TITLE
Focus improvements

### DIFF
--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -1115,7 +1115,7 @@ impl Context {
                             prev_focused
                         } else {
                             TreeIterator::full(&self.tree)
-                                .filter(|node| is_focusable(&self.style, *node))
+                                .filter(|node| is_navigatable(&self.style, *node))
                                 .next_back()
                                 .unwrap_or(Entity::root())
                         };
@@ -1133,7 +1133,10 @@ impl Context {
                         {
                             next_focused
                         } else {
-                            Entity::root()
+                            TreeIterator::full(&self.tree)
+                                .filter(|node| is_navigatable(&self.style, *node))
+                                .next()
+                                .unwrap_or(Entity::root())
                         };
 
                         if next_focused != self.focused {

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -1152,6 +1152,7 @@ impl Context {
 
                     self.style().needs_relayout = true;
                     self.style().needs_redraw = true;
+                    self.style().needs_restyle = true;
                 }
 
                 self.event_queue.push_back(Event::new(event).target(self.focused));

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -264,8 +264,8 @@ impl Context {
             pseudo_classes.set(PseudoClass::FOCUS, false);
         }
         if self.current != self.focused {
-            self.event_queue.push_back(Event::new(WindowEvent::FocusOut).target(old_focus));
-            self.event_queue.push_back(Event::new(WindowEvent::FocusIn).target(new_focus));
+            self.emit_to(old_focus, WindowEvent::FocusOut);
+            self.emit_to(new_focus, WindowEvent::FocusIn);
             self.focused = self.current;
         }
         if let Some(pseudo_classes) = self.style().pseudo_classes.get_mut(new_focus) {

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -36,7 +36,7 @@ use crate::style_system::{
     apply_text_constraints, apply_visibility, apply_z_ordering,
 };
 use crate::tree::{
-    focus_backward, focus_forward, is_focusable, TreeDepthIterator, TreeExt, TreeIterator,
+    focus_backward, focus_forward, is_navigatable, TreeDepthIterator, TreeExt, TreeIterator,
 };
 
 static DEFAULT_THEME: &str = include_str!("../../resources/themes/default_theme.css");
@@ -259,6 +259,8 @@ impl Context {
     /// Sets application focus to the current entity
     pub fn focus(&mut self) {
         self.focused = self.current;
+        self.style().needs_restyle = true;
+        self.style().needs_redraw = true;
     }
 
     /// Sets the active flag of the current entity

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -267,6 +267,20 @@ impl<'a, T> Handle<'a, T> {
     pub fn focusable(self, state: bool) -> Self {
         if let Some(abilities) = self.cx.style().abilities.get_mut(self.entity) {
             abilities.set(Abilities::FOCUSABLE, state);
+            // If an element is not focusable then it can't be keyboard navigatable
+            if !state {
+                abilities.set(Abilities::KEYBOARD_NAVIGATABLE, false);
+            }
+        }
+
+        self.cx.need_restyle();
+
+        self
+    }
+
+    pub fn keyboard_navigatable(self, state: bool) -> Self {
+        if let Some(abilities) = self.cx.style().abilities.get_mut(self.entity) {
+            abilities.set(Abilities::KEYBOARD_NAVIGATABLE, state);
         }
 
         self.cx.need_restyle();

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -885,7 +885,6 @@ impl Style {
             .insert(entity, PseudoClass::default())
             .expect("Failed to add pseudoclasses");
         self.classes.insert(entity, HashSet::new()).expect("Failed to add class list");
-        println!("Add abilities {entity:?}");
         self.abilities.insert(entity, Abilities::default()).expect("Failed to add abilities");
         self.visibility.insert(entity, Default::default());
         self.focus_order.insert(entity, Default::default()).unwrap();

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -62,6 +62,9 @@ bitflags! {
         const FOCUSABLE = 1 << 1;
         const CHECKABLE = 1 << 2;
         const SELECTABLE = 1 << 3;
+        /// The element should be focusable in sequential keyboard navigation -
+        /// allowing the equivilant of a negative tabindex in html.
+        const KEYBOARD_NAVIGATABLE = 1 << 4;
     }
 }
 
@@ -882,6 +885,7 @@ impl Style {
             .insert(entity, PseudoClass::default())
             .expect("Failed to add pseudoclasses");
         self.classes.insert(entity, HashSet::new()).expect("Failed to add class list");
+        println!("Add abilities {entity:?}");
         self.abilities.insert(entity, Abilities::default()).expect("Failed to add abilities");
         self.visibility.insert(entity, Default::default());
         self.focus_order.insert(entity, Default::default()).unwrap();

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -2,17 +2,18 @@ use crate::prelude::*;
 use crate::style::Style;
 use crate::tree::*;
 
-pub fn is_focusable<'a>(style: &'a Style, node: Entity) -> bool {
+pub fn is_navigatable<'a>(style: &'a Style, node: Entity) -> bool {
     style
         .abilities
         .get(node)
-        .and_then(|abilities| Some(abilities.contains(Abilities::FOCUSABLE)))
+        .and_then(|abilities| Some(abilities.contains(Abilities::KEYBOARD_NAVIGATABLE)))
         .unwrap_or(false)
 }
 
 pub fn focus_forward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
     TreeIterator { tree, tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())) }
     .skip(1)    
+    .filter(|node| is_navigatable(style, *node))
     .next()
 }
 
@@ -26,6 +27,6 @@ pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Opt
         //tours: DoubleEndedTreeTour::new(Some(Entity::root()), Some(node)),
     };
     iter.next_back();
-    iter.filter(|node| is_focusable(style, *node))
+    iter.filter(|node| is_navigatable(style, *node))
     .next_back()
 }

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -7,24 +7,25 @@ pub fn is_focusable<'a>(style: &'a Style, node: Entity) -> bool {
         .abilities
         .get(node)
         .and_then(|abilities| Some(abilities.contains(Abilities::FOCUSABLE)))
-        .unwrap_or(true)
+        .unwrap_or(false)
 }
 
 pub fn focus_forward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
     TreeIterator { tree, tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())) }
-        .filter(|node| is_focusable(style, *node))
-        .nth(1)
+    .skip(1)    
+    .next()
 }
 
 pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
-    TreeIterator {
+    let mut iter = TreeIterator {
         tree,
         tours: DoubleEndedTreeTour::new_raw(
             TreeTour::new(Some(Entity::root())),
             TreeTour::with_direction(Some(node), TourDirection::Leaving),
         ),
         //tours: DoubleEndedTreeTour::new(Some(Entity::root()), Some(node)),
-    }
-    .filter(|node| is_focusable(style, *node))
-    .nth_back(1)
+    };
+    iter.next_back();
+    iter.filter(|node| is_focusable(style, *node))
+    .next_back()
 }

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -12,9 +12,9 @@ pub fn is_navigatable<'a>(style: &'a Style, node: Entity) -> bool {
 
 pub fn focus_forward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
     TreeIterator { tree, tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())) }
-    .skip(1)    
-    .filter(|node| is_navigatable(style, *node))
-    .next()
+        .skip(1)
+        .filter(|node| is_navigatable(style, *node))
+        .next()
 }
 
 pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
@@ -27,6 +27,5 @@ pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Opt
         //tours: DoubleEndedTreeTour::new(Some(Entity::root()), Some(node)),
     };
     iter.next_back();
-    iter.filter(|node| is_navigatable(style, *node))
-    .next_back()
+    iter.filter(|node| is_navigatable(style, *node)).next_back()
 }

--- a/core/src/tree/mod.rs
+++ b/core/src/tree/mod.rs
@@ -26,4 +26,4 @@ mod debug_iter;
 pub use debug_iter::TreeDepthIterator;
 
 mod focus_iter;
-pub use focus_iter::{focus_backward, focus_forward, is_focusable};
+pub use focus_iter::{focus_backward, focus_forward, is_navigatable};

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -94,6 +94,7 @@ impl View for Button {
             WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
                 cx.set_active(true);
                 cx.capture();
+                cx.focus();
                 if let Some(callback) = &self.action {
                     (callback)(cx);
                 }

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -101,7 +101,7 @@ impl Label {
     where
         T: ToString,
     {
-        Self {}.build(cx, |_| {}).text(text)
+        Self {}.build(cx, |_| {}).text(text).focusable(false)
     }
 }
 


### PR DESCRIPTION
- Focus style updates displays immediately
- The `focus_order` example always keeps your focus on the buttons
- Add `KEYBOARD_NAVIGATABLE` ability to allow for focusable elements that are not in the tab order (the equivalent of `tabindex="-1"` in html)
- Buttons get focused on click (this triggers the focus pseudo class which equivalent behaviour to html - html also has the `:focus-visible` pseudo class to only show the style when using keyboard navigation which we may also want)