### PR TITLE
Trigger buttons with keyboard navigation

### DIFF
--- a/core/resources/themes/default_theme.css
+++ b/core/resources/themes/default_theme.css
@@ -185,6 +185,11 @@ radiobutton:hover {
     background-color: #e5e5e5;
 }
 
+radiobutton:focus-visible {
+    border-width: 2px;
+    border-color: blue;
+}
+
 radiobutton:checked {
     border-color: #3c77d2;
 }

--- a/core/resources/themes/default_theme.css
+++ b/core/resources/themes/default_theme.css
@@ -27,11 +27,6 @@ button:over {
     background-color: #f6f6f6;
 }
 
-button:focus-visible {
-    border-width: 2px;
-    border-color: blue;
-}
-
 button:active {
     outer-shadow: 0 1 1 transparent;
     overflow: hidden;
@@ -56,17 +51,17 @@ button.accent:over {
     background-color: #1969a7;
 }
 
-button.accent:focus-visible {
-    border-width: 2px;
-    border-color: blue;
-}
-
 button.accent:active {
     background-color: #3178af;
 }
 
 button.accent:active label {
     color: #c2d7e7;
+}
+
+button:focus-visible {
+    border-width: 2px;
+    border-color: blue;
 }
 
 checkbox {

--- a/core/resources/themes/default_theme.css
+++ b/core/resources/themes/default_theme.css
@@ -27,6 +27,11 @@ button:over {
     background-color: #f6f6f6;
 }
 
+button:focus-visible {
+    border-width: 2px;
+    border-color: blue;
+}
+
 button:active {
     outer-shadow: 0 1 1 transparent;
     overflow: hidden;
@@ -51,6 +56,11 @@ button.accent:over {
     background-color: #1969a7;
 }
 
+button.accent:focus-visible {
+    border-width: 2px;
+    border-color: blue;
+}
+
 button.accent:active {
     background-color: #3178af;
 }
@@ -71,6 +81,11 @@ checkbox {
 
 checkbox:hover {
     background-color: #e5e5e5;
+}
+
+checkbox:focus-visible {
+    border-width: 2px;
+    border-color: #3c77d2;
 }
 
 checkbox:active {
@@ -124,11 +139,11 @@ textbox:hover {
     background-color: #f6f6f6;
 }
 
-textbox:checked {
+textbox:focus {
     border-color: #4c00ff;
 }
 
-textbox:checked .textbox_content {
+textbox:focus .textbox_content {
     caret-color: #ff0000;
     selection-color: #6464c888;
 }
@@ -242,6 +257,11 @@ dropdown .title {
     overflow: visible;
 }
 
+dropdown:focus-within {
+    border-width: 2px;
+    border-color: blue;
+}
+
 dropdown>popup {
     outer-shadow: 0 3 5 #00000055;
 }
@@ -254,6 +274,11 @@ dropdown list label {
     width: 1s;
     height: 30px;
     child-left: 6px;
+}
+
+dropdown list label:focus-visible{
+    border-width: 2px;
+    border-color: blue;
 }
 
 dropdown vstack {

--- a/core/resources/themes/default_theme.css
+++ b/core/resources/themes/default_theme.css
@@ -29,7 +29,6 @@ button:over {
 
 button:active {
     outer-shadow: 0 1 1 transparent;
-    overflow: hidden;
 }
 
 button:active label {
@@ -60,8 +59,8 @@ button.accent:active label {
 }
 
 button:focus-visible {
-    border-width: 2px;
-    border-color: blue;
+    outline-width: 2px;
+    outline-color: blue;
 }
 
 checkbox {
@@ -79,8 +78,8 @@ checkbox:hover {
 }
 
 checkbox:focus-visible {
-    border-width: 2px;
-    border-color: #3c77d2;
+    outline-width: 2px;
+    outline-color: #3c77d2;
 }
 
 checkbox:active {
@@ -186,8 +185,8 @@ radiobutton:hover {
 }
 
 radiobutton:focus-visible {
-    border-width: 2px;
-    border-color: blue;
+    outline-width: 2px;
+    outline-color: blue;
 }
 
 radiobutton:checked {
@@ -258,8 +257,8 @@ dropdown .title {
 }
 
 dropdown:focus-within {
-    border-width: 2px;
-    border-color: blue;
+    outline-width: 2px;
+    outline-color: blue;
 }
 
 dropdown>popup {
@@ -277,8 +276,8 @@ dropdown list label {
 }
 
 dropdown list label:focus-visible{
-    border-width: 2px;
-    border-color: blue;
+    outline-width: 2px;
+    outline-color: blue;
 }
 
 dropdown vstack {

--- a/core/src/context/event.rs
+++ b/core/src/context/event.rs
@@ -27,7 +27,7 @@ pub struct EventContext<'a> {
     pub(crate) focused: &'a mut Entity,
     pub(crate) hovered: &'a Entity,
     pub(crate) style: &'a mut Style,
-    entity_identifiers: &'a HashMap<EntityIdentifier, Entity>,
+    entity_identifiers: &'a HashMap<String, Entity>,
     pub cache: &'a CachedData,
     pub draw_cache: &'a DrawCache,
     pub tree: &'a Tree,
@@ -74,8 +74,8 @@ impl<'a> EventContext<'a> {
     }
 
     /// Finds the entity that identifier identifies
-    pub fn resolve_entity_identifier(&self, identity: EntityIdentifier) -> Option<Entity> {
-        self.entity_identifiers.get(&identity).cloned()
+    pub fn resolve_entity_identifier(&self, identity: &str) -> Option<Entity> {
+        self.entity_identifiers.get(identity).cloned()
     }
 
     pub fn current(&self) -> Entity {

--- a/core/src/context/event.rs
+++ b/core/src/context/event.rs
@@ -27,6 +27,7 @@ pub struct EventContext<'a> {
     pub(crate) focused: &'a mut Entity,
     pub(crate) hovered: &'a Entity,
     pub(crate) style: &'a mut Style,
+    entity_identifiers: &'a HashMap<EntityIdentifier, Entity>,
     pub cache: &'a CachedData,
     pub draw_cache: &'a DrawCache,
     pub tree: &'a Tree,
@@ -52,6 +53,7 @@ impl<'a> EventContext<'a> {
             captured: &mut cx.captured,
             focused: &mut cx.focused,
             hovered: &cx.hovered,
+            entity_identifiers: &cx.entity_identifiers,
             style: &mut cx.style,
             cache: &cx.cache,
             draw_cache: &cx.draw_cache,
@@ -69,6 +71,11 @@ impl<'a> EventContext<'a> {
             clipboard: &mut cx.clipboard,
             event_proxy: &mut cx.event_proxy,
         }
+    }
+
+    /// Finds the entity that identifier identifies
+    pub fn resolve_entity_identifier(&self, identity: EntityIdentifier) -> Option<Entity> {
+        self.entity_identifiers.get(&identity).cloned()
     }
 
     pub fn current(&self) -> Entity {

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -51,8 +51,7 @@ const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 /// This type is part of the prelude.
 pub struct Context {
     pub(crate) entity_manager: IdManager<Entity>,
-    pub(crate) identifier_manager: IdManager<EntityIdentifier>,
-    pub(crate) entity_identifiers: HashMap<EntityIdentifier, Entity>,
+    pub(crate) entity_identifiers: HashMap<String, Entity>,
     pub(crate) tree: Tree,
     current: Entity,
     /// TODO make this private when there's no longer a need to mutate views after building
@@ -99,7 +98,6 @@ impl Context {
 
         let mut result = Self {
             entity_manager: IdManager::new(),
-            identifier_manager: IdManager::new(),
             entity_identifiers: HashMap::new(),
             tree: Tree::new(),
             current: Entity::root(),
@@ -142,11 +140,6 @@ impl Context {
         result.entity_manager.create();
 
         result
-    }
-
-    /// Create a new entity identifier
-    pub fn new_entity_identifier(&mut self) -> EntityIdentifier {
-        self.identifier_manager.create()
     }
 
     /// Access to the tree of entities

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -51,6 +51,8 @@ const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 /// This type is part of the prelude.
 pub struct Context {
     pub(crate) entity_manager: IdManager<Entity>,
+    pub(crate) identifier_manager: IdManager<EntityIdentifier>,
+    pub(crate) entity_identifiers: HashMap<EntityIdentifier, Entity>,
     pub(crate) tree: Tree,
     current: Entity,
     /// TODO make this private when there's no longer a need to mutate views after building
@@ -97,6 +99,8 @@ impl Context {
 
         let mut result = Self {
             entity_manager: IdManager::new(),
+            identifier_manager: IdManager::new(),
+            entity_identifiers: HashMap::new(),
             tree: Tree::new(),
             current: Entity::root(),
             views: FnvHashMap::default(),
@@ -138,6 +142,11 @@ impl Context {
         result.entity_manager.create();
 
         result
+    }
+
+    /// Create a new entity identifier
+    pub fn new_entity_identifier(&mut self) -> EntityIdentifier {
+        self.identifier_manager.create()
     }
 
     /// Access to the tree of entities

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -1117,8 +1117,12 @@ impl Context {
                         self.mouse.left.pos_up = (self.mouse.cursorx, self.mouse.cursory);
                         self.mouse.left.released = self.hovered;
                         self.mouse.left.state = MouseButtonState::Released;
-                        self.with_current(self.mouse.left.pressed, |cx| {
-                            cx.emit(WindowEvent::TriggerUp { mouse: true })
+                        self.with_current(self.hovered, |cx| {
+                            cx.dispatch_direct_or_hovered(
+                                WindowEvent::TriggerUp { mouse: true },
+                                cx.captured,
+                                true,
+                            );
                         });
                     }
                     MouseButton::Right => {

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -1092,7 +1092,7 @@ impl Context {
                             .filter(|abilities| abilities.contains(Abilities::FOCUSABLE))
                             .is_some()
                         {
-                            self.with_current(self.hovered, |cx| cx.focus());
+                            self.with_current(self.hovered, |cx| cx.focus_with_visibility(false));
                         }
                         self.with_current(self.hovered, |cx| {
                             cx.emit(WindowEvent::TriggerDown { mouse: true })

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -60,6 +60,7 @@ pub struct Context {
     pub(crate) modifiers: Modifiers,
 
     pub(crate) captured: Entity,
+    pub(crate) triggered: Entity,
     pub(crate) hovered: Entity,
     pub(crate) focused: Entity,
     pub(crate) cursor_icon_locked: bool,
@@ -104,6 +105,7 @@ impl Context {
             mouse: MouseState::default(),
             modifiers: Modifiers::empty(),
             captured: Entity::null(),
+            triggered: Entity::null(),
             hovered: Entity::root(),
             focused: Entity::root(),
             cursor_icon_locked: false,
@@ -170,6 +172,68 @@ impl Context {
     /// Mark the application as needing to rerun layout computations
     pub fn need_relayout(&mut self) {
         self.style.needs_relayout = true;
+    }
+
+    /// Enables or disables pseudoclasses for the focus of an entity
+    fn set_focus_pseudo_classes(&mut self, focused: Entity, enabled: bool, focus_visible: bool) {
+        #[cfg(debug_assertions)]
+        if enabled {
+            println!(
+            "Focus changed to {:?} parent: {:?}, view: {}, posx: {}, posy: {} width: {} height: {}",
+            focused,
+            self.tree.get_parent(focused),
+            self.views
+                .get(&focused)
+                .map_or("<None>", |view| view.element().unwrap_or("<Unnamed>")),
+            self.cache.get_posx(focused),
+            self.cache.get_posy(focused),
+            self.cache.get_width(focused),
+            self.cache.get_height(focused),
+        );
+        }
+
+        if let Some(pseudo_classes) = self.style.pseudo_classes.get_mut(focused) {
+            pseudo_classes.set(PseudoClass::FOCUS, enabled);
+            if !enabled || focus_visible {
+                pseudo_classes.set(PseudoClass::FOCUS_VISIBLE, enabled);
+            }
+        }
+
+        for ancestor in focused.parent_iter(&self.tree) {
+            let entity = ancestor;
+            if let Some(pseudo_classes) = self.style.pseudo_classes.get_mut(entity) {
+                pseudo_classes.set(PseudoClass::FOCUS_WITHIN, enabled);
+            }
+        }
+    }
+
+    /// Sets application focus to the current entity with the specified focus visiblity
+    pub fn focus_with_visibility(&mut self, focus_visible: bool) {
+        let old_focus = self.focused;
+        let new_focus = self.current;
+        self.set_focus_pseudo_classes(old_focus, false, focus_visible);
+        if self.current != self.focused {
+            self.emit_to(old_focus, WindowEvent::FocusOut);
+            self.emit_to(new_focus, WindowEvent::FocusIn);
+            self.focused = self.current;
+        }
+        self.set_focus_pseudo_classes(new_focus, true, focus_visible);
+
+        self.style.needs_relayout = true;
+        self.style.needs_redraw = true;
+        self.style.needs_restyle = true;
+    }
+
+    /// Sets application focus to the current entity using the previous focus visibility
+    pub fn focus(&mut self) {
+        let focused = self.focused;
+        let old_focus_visible = self
+            .style
+            .pseudo_classes
+            .get_mut(focused)
+            .filter(|class| class.contains(PseudoClass::FOCUS_VISIBLE))
+            .is_some();
+        self.focus_with_visibility(old_focus_visible)
     }
 
     /// Sets the checked flag of the current entity

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -276,6 +276,10 @@ impl Context {
                 image.observers.remove(entity);
             }
 
+            if let Some(identifier) = self.style.ids.get(*entity) {
+                self.entity_identifiers.remove(identifier);
+            }
+
             self.tree.remove(*entity).expect("");
             self.cache.remove(*entity);
             self.draw_cache.remove(*entity);

--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -22,11 +22,3 @@ impl Entity {
 }
 
 impl_generational_id!(Entity);
-
-/// An entity identifier is an identifier that points to an entity (which may change).
-///
-/// This type is part of the prelude.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct EntityIdentifier(u32);
-
-impl_generational_id!(EntityIdentifier);

--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -22,3 +22,11 @@ impl Entity {
 }
 
 impl_generational_id!(Entity);
+
+/// An entity identifier is an identifier that points to an entity (which may change).
+///
+/// This type is part of the prelude.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntityIdentifier(u32);
+
+impl_generational_id!(EntityIdentifier);

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -46,6 +46,11 @@ impl<'a, T> Handle<'a, T> {
         self.focusable(false)
     }
 
+    pub fn identify(self, entity_identifier: EntityIdentifier) -> Self {
+        self.cx.entity_identifiers.insert(entity_identifier, self.entity);
+        self
+    }
+
     pub fn modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut T),

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -46,11 +46,6 @@ impl<'a, T> Handle<'a, T> {
         self.focusable(false)
     }
 
-    pub fn identify(self, entity_identifier: impl Into<String>) -> Self {
-        self.cx.entity_identifiers.insert(entity_identifier.into(), self.entity);
-        self
-    }
-
     pub fn modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut T),
@@ -96,9 +91,12 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
-    pub fn id(self, id: &str) -> Self {
-        self.cx.style().ids.insert(self.entity, id.to_owned()).expect("Could not insert id");
+    pub fn id(self, id: impl Into<String>) -> Self {
+        let id = id.into();
+        self.cx.style().ids.insert(self.entity, id.clone()).expect("Could not insert id");
         self.cx.need_restyle();
+
+        self.cx.entity_identifiers.insert(id, self.entity);
 
         self
     }

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -281,6 +281,8 @@ impl<'a, T> Handle<'a, T> {
     pub fn keyboard_navigatable(self, state: bool) -> Self {
         if let Some(abilities) = self.cx.style().abilities.get_mut(self.entity) {
             abilities.set(Abilities::KEYBOARD_NAVIGATABLE, state);
+            // If an element is keyboard navigatable then it must be focusable
+            abilities.set(Abilities::FOCUSABLE, state);
         }
 
         self.cx.need_restyle();

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -46,8 +46,8 @@ impl<'a, T> Handle<'a, T> {
         self.focusable(false)
     }
 
-    pub fn identify(self, entity_identifier: EntityIdentifier) -> Self {
-        self.cx.entity_identifiers.insert(entity_identifier, self.entity);
+    pub fn identify(self, entity_identifier: impl Into<String>) -> Self {
+        self.cx.entity_identifiers.insert(entity_identifier.into(), self.entity);
         self
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod prelude {
     pub use super::context::{
         Context, ContextProxy, DataContext, DrawContext, EventContext, ProxyEmitError,
     };
-    pub use super::entity::Entity;
+    pub use super::entity::{Entity, EntityIdentifier};
     pub use super::environment::{Environment, EnvironmentEvent};
     pub use super::events::{Event, Message, Propagation};
     pub use super::handle::Handle;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,7 +45,7 @@ pub mod prelude {
     pub use super::context::{
         Context, ContextProxy, DataContext, DrawContext, EventContext, ProxyEmitError,
     };
-    pub use super::entity::{Entity, EntityIdentifier};
+    pub use super::entity::Entity;
     pub use super::environment::{Environment, EnvironmentEvent};
     pub use super::events::{Event, Message, Propagation};
     pub use super::handle::Handle;

--- a/core/src/modifiers/actions.rs
+++ b/core/src/modifiers/actions.rs
@@ -596,14 +596,14 @@ impl<'a, V: View> Actions<'a> for Handle<'a, V> {
     where
         F: 'static + Fn(&mut Context),
     {
-        FocusIn::new(self, action)
+        FocusIn::new(self.keyboard_navigatable(true), action)
     }
 
     fn on_focus_out<F>(self, action: F) -> Handle<'a, FocusOut<Self::View>>
     where
         F: 'static + Fn(&mut Context),
     {
-        FocusOut::new(self, action)
+        FocusOut::new(self.keyboard_navigatable(true), action)
     }
 
     fn on_geo_changed<F>(self, action: F) -> Handle<'a, Geo<Self::View>>

--- a/core/src/modifiers/actions.rs
+++ b/core/src/modifiers/actions.rs
@@ -46,9 +46,7 @@ impl<V: View> View for Press<V> {
         event.map(|window_event, _| match window_event {
             WindowEvent::TriggerDown { mouse } => {
                 let over = if *mouse { cx.hovered() } else { cx.focused() };
-                if cx.current() != over
-                    && !over.is_descendant_of(cx.tree, cx.current())
-                {
+                if cx.current() != over && !over.is_descendant_of(cx.tree, cx.current()) {
                     return;
                 }
                 if let Some(action) = &self.action {

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -70,7 +70,7 @@ bitflags! {
 
 impl Default for Abilities {
     fn default() -> Abilities {
-        Abilities::all()
+        Abilities::HOVERABLE
     }
 }
 

--- a/core/src/style/parser.rs
+++ b/core/src/style/parser.rs
@@ -273,6 +273,8 @@ fn parse_selectors<'i, 't>(
                     "checked" => selector.pseudo_classes.insert(PseudoClass::CHECKED),
                     "selected" => selector.pseudo_classes.insert(PseudoClass::SELECTED),
                     "custom" => selector.pseudo_classes.insert(PseudoClass::CUSTOM),
+                    "focus-within" => selector.pseudo_classes.insert(PseudoClass::FOCUS_WITHIN),
+                    "focus-visible" => selector.pseudo_classes.insert(PseudoClass::FOCUS_VISIBLE),
 
                     _ => {
                         let parse_error = ParseError {

--- a/core/src/style/selector.rs
+++ b/core/src/style/selector.rs
@@ -11,7 +11,7 @@ bitflags! {
     /// A bitflag of possible pseudoclasses.
     ///
     /// This type is part of the prelude.
-    pub struct PseudoClass: u8 {
+    pub struct PseudoClass: u16 {
         const HOVER = 1;
         const OVER = 1 << 1;
         const ACTIVE = 1 << 2;
@@ -20,6 +20,8 @@ bitflags! {
         const CHECKED = 1 << 5;
         const SELECTED = 1 << 6;
         const CUSTOM = 1 << 7;
+        const FOCUS_WITHIN = 1<<8;
+        const FOCUS_VISIBLE = 1 << 9;
     }
 }
 
@@ -51,6 +53,12 @@ impl std::fmt::Display for PseudoClass {
         }
         if self.contains(PseudoClass::SELECTED) {
             write!(f, ":selected")?;
+        }
+        if self.contains(PseudoClass::FOCUS_WITHIN) {
+            write!(f, ":focus-within")?;
+        }
+        if self.contains(PseudoClass::FOCUS_VISIBLE) {
+            write!(f, ":focus-visible")?;
         }
 
         Ok(())

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -3,25 +3,25 @@ use crate::tree::*;
 
 pub fn is_navigatable(cx: &Context, node: Entity) -> bool {
     // Skip invisible widgets
-    if cx.cache_ref().get_visibility(node) == Visibility::Invisible {
+    if cx.cache.get_visibility(node) == Visibility::Invisible {
         return false;
     }
 
     // Skip disabled widgets
-    if cx.style_ref().disabled.get(node).cloned().unwrap_or_default() {
+    if cx.style.disabled.get(node).cloned().unwrap_or_default() {
         return false;
     }
 
     // Skip non-displayed widgets
-    if cx.cache_ref().get_display(node) == Display::None {
+    if cx.cache.get_display(node) == Display::None {
         return false;
     }
 
     // Skip ignored widgets
-    if cx.tree_ref().is_ignored(node) {
+    if cx.tree.is_ignored(node) {
         return false;
     }
-    cx.style_ref()
+    cx.style
         .abilities
         .get(node)
         .and_then(|abilities| Some(abilities.contains(Abilities::KEYBOARD_NAVIGATABLE)))
@@ -30,7 +30,7 @@ pub fn is_navigatable(cx: &Context, node: Entity) -> bool {
 
 pub fn focus_forward<'a>(cx: &Context, node: Entity) -> Option<Entity> {
     TreeIterator {
-        tree: cx.tree_ref(),
+        tree: &cx.tree,
         tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())),
     }
     .skip(1)
@@ -40,7 +40,7 @@ pub fn focus_forward<'a>(cx: &Context, node: Entity) -> Option<Entity> {
 
 pub fn focus_backward<'a>(cx: &Context, node: Entity) -> Option<Entity> {
     let mut iter = TreeIterator {
-        tree: cx.tree_ref(),
+        tree: &cx.tree,
         tours: DoubleEndedTreeTour::new_raw(
             TreeTour::new(Some(Entity::root())),
             TreeTour::with_direction(Some(node), TourDirection::Leaving),

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -7,7 +7,7 @@ pub fn is_navigatable(cx: &Context, node: Entity) -> bool {
         return false;
     }
 
-    // Skip dsabled widgets
+    // Skip disabled widgets
     if cx.style_ref().disabled.get(node).cloned().unwrap_or_default() {
         return false;
     }

--- a/core/src/tree/focus_iter.rs
+++ b/core/src/tree/focus_iter.rs
@@ -1,25 +1,46 @@
 use crate::prelude::*;
-use crate::style::Style;
 use crate::tree::*;
 
-pub fn is_navigatable<'a>(style: &'a Style, node: Entity) -> bool {
-    style
+pub fn is_navigatable(cx: &Context, node: Entity) -> bool {
+    // Skip invisible widgets
+    if cx.cache_ref().get_visibility(node) == Visibility::Invisible {
+        return false;
+    }
+
+    // Skip dsabled widgets
+    if cx.style_ref().disabled.get(node).cloned().unwrap_or_default() {
+        return false;
+    }
+
+    // Skip non-displayed widgets
+    if cx.cache_ref().get_display(node) == Display::None {
+        return false;
+    }
+
+    // Skip ignored widgets
+    if cx.tree_ref().is_ignored(node) {
+        return false;
+    }
+    cx.style_ref()
         .abilities
         .get(node)
         .and_then(|abilities| Some(abilities.contains(Abilities::KEYBOARD_NAVIGATABLE)))
         .unwrap_or(false)
 }
 
-pub fn focus_forward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
-    TreeIterator { tree, tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())) }
-        .skip(1)
-        .filter(|node| is_navigatable(style, *node))
-        .next()
+pub fn focus_forward<'a>(cx: &Context, node: Entity) -> Option<Entity> {
+    TreeIterator {
+        tree: cx.tree_ref(),
+        tours: DoubleEndedTreeTour::new(Some(node), Some(Entity::root())),
+    }
+    .skip(1)
+    .filter(|node| is_navigatable(cx, *node))
+    .next()
 }
 
-pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Option<Entity> {
+pub fn focus_backward<'a>(cx: &Context, node: Entity) -> Option<Entity> {
     let mut iter = TreeIterator {
-        tree,
+        tree: cx.tree_ref(),
         tours: DoubleEndedTreeTour::new_raw(
             TreeTour::new(Some(Entity::root())),
             TreeTour::with_direction(Some(node), TourDirection::Leaving),
@@ -27,5 +48,5 @@ pub fn focus_backward<'a>(tree: &'a Tree, style: &'a Style, node: Entity) -> Opt
         //tours: DoubleEndedTreeTour::new(Some(Entity::root()), Some(node)),
     };
     iter.next_back();
-    iter.filter(|node| is_navigatable(style, *node)).next_back()
+    iter.filter(|node| is_navigatable(cx, *node)).next_back()
 }

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -93,7 +93,7 @@ impl View for Button {
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+            WindowEvent::TriggerDown { .. } => {
                 cx.set_active(true);
                 cx.capture();
                 cx.focus();
@@ -102,7 +102,7 @@ impl View for Button {
                 }
             }
 
-            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+            WindowEvent::TriggerUp { .. } => {
                 if meta.target == cx.current() {
                     cx.release();
                     cx.set_active(false);

--- a/core/src/views/button.rs
+++ b/core/src/views/button.rs
@@ -78,9 +78,11 @@ impl Button {
         F: FnOnce(&mut Context) -> Handle<V>,
         V: 'static + View,
     {
-        Self { action: Some(Box::new(action)) }.build(cx, move |cx| {
-            (content)(cx).hoverable(false).focusable(false);
-        })
+        Self { action: Some(Box::new(action)) }
+            .build(cx, move |cx| {
+                (content)(cx).hoverable(false);
+            })
+            .keyboard_navigatable(true)
     }
 }
 

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -143,6 +143,7 @@ impl Checkbox {
                 }
             })
             .cursor(CursorIcon::Hand)
+            .keyboard_navigatable(true)
     }
 }
 

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -186,9 +186,9 @@ impl View for Checkbox {
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseUp(MouseButton::Left) => {
-                if cx.mouse().left.pressed == cx.current()
-                    && meta.target == cx.current()
+            WindowEvent::TriggerDown { mouse } => {
+                if (!mouse
+                    || (cx.mouse().left.pressed == cx.current()) && meta.target == cx.current())
                     && !cx.is_disabled()
                 {
                     if let Some(callback) = &self.on_toggle {

--- a/core/src/views/checkbox.rs
+++ b/core/src/views/checkbox.rs
@@ -188,10 +188,7 @@ impl View for Checkbox {
         event.map(|window_event, meta| match window_event {
             WindowEvent::TriggerUp { mouse } => {
                 let over = if *mouse { cx.mouse.left.pressed } else { cx.focused() };
-                if over == cx.current()
-                    && meta.target == cx.current()
-                    && !cx.is_disabled()
-                {
+                if over == cx.current() && meta.target == cx.current() && !cx.is_disabled() {
                     if let Some(callback) = &self.on_toggle {
                         (callback)(cx);
                     }

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -147,8 +147,10 @@ impl View for Label {
         event.map(|window_event, meta| match window_event {
             WindowEvent::TriggerDown { .. } | WindowEvent::TriggerUp { .. } => {
                 if cx.current() == cx.mouse.left.pressed && meta.target == cx.current() {
-                    if let Some(describing) =
-                        self.describing.as_ref().and_then(|identity| cx.resolve_entity_identifier(&identity))
+                    if let Some(describing) = self
+                        .describing
+                        .as_ref()
+                        .and_then(|identity| cx.resolve_entity_identifier(&identity))
                     {
                         let old = cx.current;
                         cx.current = describing;

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -143,25 +143,25 @@ impl View for Label {
         Some("label")
     }
 
-    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
             WindowEvent::TriggerDown { .. } | WindowEvent::TriggerUp { .. } => {
-                if cx.current() == cx.mouse().left.pressed
+                if cx.current() == cx.mouse.left.pressed
                     && meta.target == cx.current()
                     && !cx.is_disabled()
                 {
                     if let Some(describing) = self.describing {
-                        cx.with_current(describing, |cx| {
-                            cx.focus_with_visibility(false);
-                            cx.capture();
-                            let message = if matches!(window_event, WindowEvent::TriggerDown { .. })
-                            {
-                                WindowEvent::TriggerDown { mouse: false }
-                            } else {
-                                WindowEvent::TriggerUp { mouse: false }
-                            };
-                            cx.emit_to(describing, message);
-                        });
+                        let old = cx.current;
+                        cx.current = describing;
+                        cx.focus_with_visibility(false);
+                        cx.capture();
+                        let message = if matches!(window_event, WindowEvent::TriggerDown { .. }) {
+                            WindowEvent::TriggerDown { mouse: false }
+                        } else {
+                            WindowEvent::TriggerUp { mouse: false }
+                        };
+                        cx.emit_to(describing, message);
+                        cx.current = old;
                     }
                 }
             }

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -130,7 +130,7 @@ impl Handle<'_, Label> {
     /// #
     /// # AppData { value: false }.build(cx);
     /// #
-    /// Checkbox::new(cx, AppData::value).on_toggle(|cx| cx.emit(AppEvent::ToggleValue)).identify("checkbox_identifier");
+    /// Checkbox::new(cx, AppData::value).on_toggle(|cx| cx.emit(AppEvent::ToggleValue)).id("checkbox_identifier");
     /// Label::new(cx, "hello").describing("checkbox_identifier");
     /// ```
     pub fn describing(self, entity_identifier: impl Into<String>) -> Self {

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -84,7 +84,7 @@ use crate::prelude::*;
 /// Button::new(cx, |_| {}, |cx| Label::new(cx, "Text"));
 /// ```
 pub struct Label {
-    describing: Option<EntityIdentifier>,
+    describing: Option<String>,
 }
 
 impl Label {
@@ -130,12 +130,11 @@ impl Handle<'_, Label> {
     /// #
     /// # AppData { value: false }.build(cx);
     /// #
-    /// let checkbox_identifier = cx.new_entity_identifier();
-    /// Checkbox::new(cx, AppData::value).on_toggle(|cx| cx.emit(AppEvent::ToggleValue)).identify(checkbox_identifier);
-    /// Label::new(cx, "hello").describing(checkbox_identifier);
+    /// Checkbox::new(cx, AppData::value).on_toggle(|cx| cx.emit(AppEvent::ToggleValue)).identify("checkbox_identifier");
+    /// Label::new(cx, "hello").describing("checkbox_identifier");
     /// ```
-    pub fn describing(self, entity_identifier: EntityIdentifier) -> Self {
-        self.modify(|label| label.describing = Some(entity_identifier))
+    pub fn describing(self, entity_identifier: impl Into<String>) -> Self {
+        self.modify(|label| label.describing = Some(entity_identifier.into()))
     }
 }
 
@@ -149,7 +148,7 @@ impl View for Label {
             WindowEvent::TriggerDown { .. } | WindowEvent::TriggerUp { .. } => {
                 if cx.current() == cx.mouse.left.pressed && meta.target == cx.current() {
                     if let Some(describing) =
-                        self.describing.and_then(|identity| cx.resolve_entity_identifier(identity))
+                        self.describing.as_ref().and_then(|identity| cx.resolve_entity_identifier(&identity))
                     {
                         let old = cx.current;
                         cx.current = describing;

--- a/core/src/views/label.rs
+++ b/core/src/views/label.rs
@@ -83,7 +83,9 @@ use crate::prelude::*;
 /// #
 /// Button::new(cx, |_| {}, |cx| Label::new(cx, "Text"));
 /// ```
-pub struct Label;
+pub struct Label {
+    describing: Option<Entity>,
+}
 
 impl Label {
     /// Creates a new label.
@@ -101,12 +103,69 @@ impl Label {
     where
         T: ToString,
     {
-        Self {}.build(cx, |_| {}).text(text).focusable(false)
+        Self { describing: None }.build(cx, |_| {}).text(text)
+    }
+}
+
+impl Handle<'_, Label> {
+    /// Which form element does this label describe.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use vizia_core::prelude::*;
+    /// #
+    /// # #[derive(Lens)]
+    /// # struct AppData {
+    /// #     value: bool,
+    /// # }
+    /// #
+    /// # impl Model for AppData {}
+    /// #
+    /// # enum AppEvent {
+    /// #     ToggleValue,
+    /// # }
+    /// #
+    /// # let cx = &mut Context::new();
+    /// #
+    /// # AppData { value: false }.build(cx);
+    /// #
+    /// let checkbox = Checkbox::new(cx, AppData::value).on_toggle(|cx| cx.emit(AppEvent::ToggleValue)).entity;
+    /// Label::new(cx, "hello").describing(checkbox);
+    /// ```
+    pub fn describing(self, entity: Entity) -> Self {
+        self.modify(|label| label.describing = Some(entity))
     }
 }
 
 impl View for Label {
     fn element(&self) -> Option<&'static str> {
         Some("label")
+    }
+
+    fn event(&mut self, cx: &mut Context, event: &mut Event) {
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::TriggerDown { .. } | WindowEvent::TriggerUp { .. } => {
+                if cx.current() == cx.mouse().left.pressed
+                    && meta.target == cx.current()
+                    && !cx.is_disabled()
+                {
+                    if let Some(describing) = self.describing {
+                        cx.with_current(describing, |cx| {
+                            cx.focus_with_visibility(false);
+                            cx.capture();
+                            let message = if matches!(window_event, WindowEvent::TriggerDown { .. })
+                            {
+                                WindowEvent::TriggerDown { mouse: false }
+                            } else {
+                                WindowEvent::TriggerUp { mouse: false }
+                            };
+                            cx.emit_to(describing, message);
+                        });
+                    }
+                }
+            }
+            _ => {}
+        });
     }
 }

--- a/core/src/views/menu.rs
+++ b/core/src/views/menu.rs
@@ -133,8 +133,8 @@ impl View for MenuController {
                         && matches!(
                             window_event,
                             WindowEvent::MouseMove(_, _)
-                                | WindowEvent::MouseDown(_)
-                                | WindowEvent::MouseUp(_)
+                                | WindowEvent::TriggerDown { .. }
+                                | WindowEvent::TriggerUp { .. }
                                 | WindowEvent::MouseScroll(_, _)
                                 | WindowEvent::MouseDoubleClick(_)
                         ))
@@ -158,7 +158,7 @@ impl View for MenuController {
                     }
                 }
             } else {
-                if let WindowEvent::MouseDown(_) = window_event {
+                if let WindowEvent::TriggerDown { .. } = window_event {
                     // capture focus on click
                     cx.capture();
                     cx.emit(MenuEvent::Activate);
@@ -343,7 +343,7 @@ impl View for MenuButton {
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseDown(MouseButton::Left) => {
+            WindowEvent::TriggerDown { .. } => {
                 if let Some(callback) = &self.action {
                     callback(cx);
                     cx.emit(MenuEvent::Close);

--- a/core/src/views/menu.rs
+++ b/core/src/views/menu.rs
@@ -24,6 +24,7 @@ where
         let i = *data.counter.borrow();
         *data.counter.borrow_mut() += 1;
         handle
+            .keyboard_navigatable(true)
             .bind(MenuData::selected, move |handle, selected| {
                 let selected = selected.get(handle.cx) == Some(i);
                 handle.cx.set_selected(selected);
@@ -261,9 +262,11 @@ impl MenuButton {
         A: 'static + Fn(&mut Context),
     {
         setup_menu_entry(
-            Self { action: Some(Box::new(action)) }.build(cx, move |cx| {
-                contents(cx);
-            }),
+            Self { action: Some(Box::new(action)) }
+                .build(cx, move |cx| {
+                    contents(cx);
+                })
+                .keyboard_navigatable(true),
             |_| {},
             |_| {},
         )

--- a/core/src/views/radio_buttons.rs
+++ b/core/src/views/radio_buttons.rs
@@ -105,8 +105,8 @@ impl View for RadioButton {
 
     fn event(&mut self, cx: &mut Context, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseUp(MouseButton::Left) => {
-                if cx.mouse().left.pressed == cx.current()
+            WindowEvent::TriggerUp { mouse } => {
+                if cx.current() == if *mouse { cx.mouse().left.pressed } else { cx.focused }
                     && meta.target == cx.current()
                     && !cx.is_disabled()
                 {

--- a/core/src/views/radio_buttons.rs
+++ b/core/src/views/radio_buttons.rs
@@ -90,11 +90,11 @@ impl RadioButton {
                 Element::new(cx)
                     .class("inner")
                     .hoverable(false)
-                    .focusable(false)
                     .position_type(PositionType::SelfDirected);
             })
             .checked(checked)
             .cursor(CursorIcon::Hand)
+            .keyboard_navigatable(true)
     }
 }
 

--- a/core/src/views/radio_buttons.rs
+++ b/core/src/views/radio_buttons.rs
@@ -107,10 +107,7 @@ impl View for RadioButton {
         event.map(|window_event, meta| match window_event {
             WindowEvent::TriggerUp { mouse } => {
                 let over = if *mouse { cx.mouse.left.pressed } else { cx.focused() };
-                if over == cx.current()
-                    && meta.target == cx.current()
-                    && !cx.is_disabled()
-                {
+                if over == cx.current() && meta.target == cx.current() && !cx.is_disabled() {
                     if let Some(callback) = &self.on_select {
                         (callback)(cx);
                     }

--- a/core/src/views/stack.rs
+++ b/core/src/views/stack.rs
@@ -12,11 +12,9 @@ impl VStack {
     where
         F: FnOnce(&mut Context),
     {
-        Self {}
-            .build(cx, |cx| {
-                (content)(cx);
-            })
-            .focusable(false)
+        Self {}.build(cx, |cx| {
+            (content)(cx);
+        })
     }
 }
 
@@ -39,7 +37,6 @@ impl HStack {
                 (content)(cx);
             })
             .layout_type(LayoutType::Row)
-            .focusable(false)
     }
 }
 
@@ -57,11 +54,9 @@ impl ZStack {
     where
         F: FnOnce(&mut Context),
     {
-        Self {}
-            .build(cx, |cx| {
-                (content)(cx);
-            })
-            .focusable(false)
+        Self {}.build(cx, |cx| {
+            (content)(cx);
+        })
     }
 }
 

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -558,11 +558,11 @@ where
         //let caret = cx.tree.get_child(cx.current, 1).unwrap();
 
         event.map(|window_event, _| match window_event {
-            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+            WindowEvent::TriggerDown { mouse } => {
                 if cx.is_over() {
                     cx.emit(TextEvent::StartEdit);
 
-                    cx.focus_with_visibility(false);
+                    cx.focus_with_visibility(!mouse);
                     cx.capture();
                     cx.set_checked(true);
                     cx.lock_cursor_icon();
@@ -587,12 +587,12 @@ where
 
                     // Forward event to hovered
                     cx.event_queue.push_back(
-                        Event::new(WindowEvent::MouseDown(MouseButton::Left)).target(cx.hovered()),
+                        Event::new(WindowEvent::TriggerDown { mouse: true }).target(cx.hovered()),
                     );
                 }
             }
 
-            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+            WindowEvent::TriggerUp { .. } => {
                 cx.unlock_cursor_icon();
             }
 
@@ -605,6 +605,7 @@ where
             WindowEvent::CharInput(c) => {
                 if *c != '\u{1b}' && // Escape
                             *c != '\u{8}' && // Backspace
+                            *c != '\u{9}' && // Tab
                             *c != '\u{7f}' && // Delete
                             *c != '\u{0d}' && // Carriage return
                             !cx.modifiers().contains(Modifiers::CTRL)

--- a/core/src/views/textbox.rs
+++ b/core/src/views/textbox.rs
@@ -334,7 +334,7 @@ impl Model for TextboxData {
                 if !cx.is_disabled() {
                     if !self.edit {
                         self.edit = true;
-                        cx.focus();
+                        cx.focus_with_visibility(false);
                         cx.capture();
                         cx.set_checked(true);
                         cx.emit(TextEvent::SelectAll);
@@ -521,6 +521,7 @@ where
                 TextboxKind::MultiLineWrapped => "multi_line_wrapped",
             })
             .cursor(CursorIcon::Text)
+            .keyboard_navigatable(true)
     }
 }
 
@@ -561,7 +562,7 @@ where
                 if cx.is_over() {
                     cx.emit(TextEvent::StartEdit);
 
-                    cx.focus();
+                    cx.focus_with_visibility(false);
                     cx.capture();
                     cx.set_checked(true);
                     cx.lock_cursor_icon();

--- a/core/src/window/window_event.rs
+++ b/core/src/window/window_event.rs
@@ -20,6 +20,14 @@ pub enum WindowEvent {
     MouseDown(MouseButton),
     /// Emitted when a mouse button is released
     MouseUp(MouseButton),
+    /// When an interactable element has started to be triggered with a left mouse click or keyboard
+    TriggerDown {
+        mouse: bool,
+    },
+    /// When an interactable element has stopped being triggered with a left mouse click or keyboard
+    TriggerUp {
+        mouse: bool,
+    },
     /// Emitted when the mouse cursor is moved
     MouseMove(f32, f32),
     /// Emitted when the mouse scroll wheel is scrolled

--- a/examples/accessibility/focus_order.rs
+++ b/examples/accessibility/focus_order.rs
@@ -1,12 +1,5 @@
 use vizia::prelude::*;
 
-const STYLE: &str = r#"
-    button:focus {
-        border-width: 1px;
-        border-color: blue;
-    }
-"#;
-
 #[derive(Lens)]
 pub struct AppData {
     text: String,
@@ -28,8 +21,6 @@ impl Model for AppData {
 
 fn main() {
     Application::new(|cx| {
-        cx.add_theme(STYLE);
-
         AppData { text: "".to_string() }.build(cx);
 
         VStack::new(cx, |cx| {

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -52,24 +52,22 @@ fn main() {
             Label::new(cx, "Checkbox with Label").top(Pixels(20.0));
 
             // Checkboxes with label
-            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
-                    .identify(checkbox_identifier);
-                Label::new(cx, "Checkbox").describing(checkbox_identifier);
+                    .identify("checkbox_1");
+                Label::new(cx, "Checkbox").describing("checkbox_1");
             })
             .size(Auto)
             .col_between(Pixels(5.0))
             .child_top(Stretch(1.0))
             .child_bottom(Stretch(1.0));
 
-            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::option2)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2))
-                    .identify(checkbox_identifier);
-                Label::new(cx, "Disabled").describing(checkbox_identifier);
+                    .identify("checkbox_2");
+                Label::new(cx, "Disabled").describing("checkbox_2");
             })
             .disabled(true)
             .size(Auto)
@@ -79,13 +77,12 @@ fn main() {
 
             Label::new(cx, "Checkbox with Label").top(Pixels(20.0)).top(Pixels(20.0));
 
-            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
                     .text(AppData::option1.map(|flag| if *flag { CANCEL } else { "" }))
-                    .identify(checkbox_identifier);
-                Label::new(cx, "Custom").describing(checkbox_identifier);
+                    .identify("checkbox_3");
+                Label::new(cx, "Custom").describing("checkbox_3");
             })
             .size(Auto)
             .col_between(Pixels(5.0))

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -52,22 +52,24 @@ fn main() {
             Label::new(cx, "Checkbox with Label").top(Pixels(20.0));
 
             // Checkboxes with label
+            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
-                let checkbox = Checkbox::new(cx, AppData::option1)
+                Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
-                    .entity();
-                Label::new(cx, "Checkbox").describing(checkbox);
+                    .identify(checkbox_identifier);
+                Label::new(cx, "Checkbox").describing(checkbox_identifier);
             })
             .size(Auto)
             .col_between(Pixels(5.0))
             .child_top(Stretch(1.0))
             .child_bottom(Stretch(1.0));
 
+            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
-                let checkbox = Checkbox::new(cx, AppData::option2)
+                Checkbox::new(cx, AppData::option2)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2))
-                    .entity();
-                Label::new(cx, "Disabled").describing(checkbox);
+                    .identify(checkbox_identifier);
+                Label::new(cx, "Disabled").describing(checkbox_identifier);
             })
             .disabled(true)
             .size(Auto)
@@ -77,12 +79,13 @@ fn main() {
 
             Label::new(cx, "Checkbox with Label").top(Pixels(20.0)).top(Pixels(20.0));
 
+            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
-                let checkbox = Checkbox::new(cx, AppData::option1)
+                Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
                     .text(AppData::option1.map(|flag| if *flag { CANCEL } else { "" }))
-                    .entity();
-                Label::new(cx, "Custom").describing(checkbox);
+                    .identify(checkbox_identifier);
+                Label::new(cx, "Custom").describing(checkbox_identifier);
             })
             .size(Auto)
             .col_between(Pixels(5.0))

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -55,7 +55,7 @@ fn main() {
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
-                    .identify("checkbox_1");
+                    .id("checkbox_1");
                 Label::new(cx, "Checkbox").describing("checkbox_1");
             })
             .size(Auto)
@@ -66,7 +66,7 @@ fn main() {
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::option2)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2))
-                    .identify("checkbox_2");
+                    .id("checkbox_2");
                 Label::new(cx, "Disabled").describing("checkbox_2");
             })
             .disabled(true)
@@ -81,7 +81,7 @@ fn main() {
                 Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
                     .text(AppData::option1.map(|flag| if *flag { CANCEL } else { "" }))
-                    .identify("checkbox_3");
+                    .id("checkbox_3");
                 Label::new(cx, "Custom").describing("checkbox_3");
             })
             .size(Auto)

--- a/examples/views/checkbox.rs
+++ b/examples/views/checkbox.rs
@@ -53,9 +53,10 @@ fn main() {
 
             // Checkboxes with label
             HStack::new(cx, |cx| {
-                Checkbox::new(cx, AppData::option1)
-                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1));
-                Label::new(cx, "Checkbox");
+                let checkbox = Checkbox::new(cx, AppData::option1)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
+                    .entity();
+                Label::new(cx, "Checkbox").describing(checkbox);
             })
             .size(Auto)
             .col_between(Pixels(5.0))
@@ -63,9 +64,10 @@ fn main() {
             .child_bottom(Stretch(1.0));
 
             HStack::new(cx, |cx| {
-                Checkbox::new(cx, AppData::option2)
-                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2));
-                Label::new(cx, "Disabled");
+                let checkbox = Checkbox::new(cx, AppData::option2)
+                    .on_toggle(|cx| cx.emit(AppEvent::ToggleOption2))
+                    .entity();
+                Label::new(cx, "Disabled").describing(checkbox);
             })
             .disabled(true)
             .size(Auto)
@@ -76,10 +78,11 @@ fn main() {
             Label::new(cx, "Checkbox with Label").top(Pixels(20.0)).top(Pixels(20.0));
 
             HStack::new(cx, |cx| {
-                Checkbox::new(cx, AppData::option1)
+                let checkbox = Checkbox::new(cx, AppData::option1)
                     .on_toggle(|cx| cx.emit(AppEvent::ToggleOption1))
-                    .text(AppData::option1.map(|flag| if *flag { CANCEL } else { "" }));
-                Label::new(cx, "Custom");
+                    .text(AppData::option1.map(|flag| if *flag { CANCEL } else { "" }))
+                    .entity();
+                Label::new(cx, "Custom").describing(checkbox);
             })
             .size(Auto)
             .col_between(Pixels(5.0))

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -48,7 +48,7 @@ fn main() {
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::checked)
                     .on_toggle(|cx| cx.emit(AppEvent::Toggle))
-                    .identify("checkbox_1");
+                    .id("checkbox_1");
 
                 Label::new(cx, "A label that is describing a form element also acts as a trigger")
                     .describing("checkbox_1");

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -45,14 +45,13 @@ fn main() {
                 .width(Pixels(200.0))
                 .text_wrap(false);
 
-            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
                 Checkbox::new(cx, AppData::checked)
                     .on_toggle(|cx| cx.emit(AppEvent::Toggle))
-                    .identify(checkbox_identifier);
+                    .identify("checkbox_1");
 
                 Label::new(cx, "A label that is describing a form element also acts as a trigger")
-                    .describing(checkbox_identifier);
+                    .describing("checkbox_1");
             });
         })
         .child_space(Stretch(1.0))

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -13,7 +13,7 @@ pub enum AppEvent {
 }
 
 impl Model for AppData {
-    fn event(&mut self, _cx: &mut Context, event: &mut Event) {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
             AppEvent::Toggle => {
                 self.checked ^= true;

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -45,13 +45,14 @@ fn main() {
                 .width(Pixels(200.0))
                 .text_wrap(false);
 
+            let checkbox_identifier = cx.new_entity_identifier();
             HStack::new(cx, |cx| {
-                let checkbox = Checkbox::new(cx, AppData::checked)
+                Checkbox::new(cx, AppData::checked)
                     .on_toggle(|cx| cx.emit(AppEvent::Toggle))
-                    .entity;
+                    .identify(checkbox_identifier);
 
                 Label::new(cx, "A label that is describing a form element also acts as a trigger")
-                    .describing(checkbox);
+                    .describing(checkbox_identifier);
             });
         })
         .child_space(Stretch(1.0))

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -4,15 +4,30 @@ use vizia::prelude::*;
 pub struct AppData {
     text: String,
     value: f32,
+    checked: bool,
 }
 
-impl Model for AppData {}
+#[derive(Debug)]
+pub enum AppEvent {
+    Toggle,
+}
+
+impl Model for AppData {
+    fn event(&mut self, _cx: &mut Context, event: &mut Event) {
+        event.map(|app_event, _| match app_event {
+            AppEvent::Toggle => {
+                self.checked ^= true;
+            }
+        });
+    }
+}
 
 fn main() {
     Application::new(|cx| {
         AppData {
             text: String::from("As well as model data which implements ToString:"),
             value: 3.141592,
+            checked: false,
         }
         .build(cx);
 
@@ -29,6 +44,15 @@ fn main() {
             Label::new(cx, "Unless text wrapping is disabled.")
                 .width(Pixels(200.0))
                 .text_wrap(false);
+
+            HStack::new(cx, |cx| {
+                let checkbox = Checkbox::new(cx, AppData::checked)
+                    .on_toggle(|cx| cx.emit(AppEvent::Toggle))
+                    .entity;
+
+                Label::new(cx, "A label that is describing a form element also acts as a trigger")
+                    .describing(checkbox);
+            });
         })
         .child_space(Stretch(1.0))
         .row_between(Pixels(20.0));

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -62,14 +62,15 @@ fn main() {
 
             for i in 0..3 {
                 let current_option = index_to_option(i);
+                let button_identifier = cx.new_entity_identifier();
                 HStack::new(cx, move |cx| {
-                    let button = RadioButton::new(
+                    RadioButton::new(
                         cx,
                         AppData::option.map(move |option| *option == current_option),
                     )
                     .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)))
-                    .entity();
-                    Label::new(cx, &current_option.to_string()).describing(button);
+                    .identify(button_identifier);
+                    Label::new(cx, &current_option.to_string()).describing(button_identifier);
                 })
                 .disabled(if i == 2 { true } else { false })
                 .size(Auto)

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -63,12 +63,13 @@ fn main() {
             for i in 0..3 {
                 let current_option = index_to_option(i);
                 HStack::new(cx, move |cx| {
-                    RadioButton::new(
+                    let button = RadioButton::new(
                         cx,
                         AppData::option.map(move |option| *option == current_option),
                     )
-                    .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)));
-                    Label::new(cx, &current_option.to_string());
+                    .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)))
+                    .entity();
+                    Label::new(cx, &current_option.to_string()).describing(button);
                 })
                 .disabled(if i == 2 { true } else { false })
                 .size(Auto)

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -62,15 +62,14 @@ fn main() {
 
             for i in 0..3 {
                 let current_option = index_to_option(i);
-                let button_identifier = cx.new_entity_identifier();
                 HStack::new(cx, move |cx| {
                     RadioButton::new(
                         cx,
                         AppData::option.map(move |option| *option == current_option),
                     )
                     .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)))
-                    .identify(button_identifier);
-                    Label::new(cx, &current_option.to_string()).describing(button_identifier);
+                    .id(format!("button_{i}"));
+                    Label::new(cx, &current_option.to_string()).describing(format!("button_{i}"));
                 })
                 .disabled(if i == 2 { true } else { false })
                 .size(Auto)


### PR DESCRIPTION
- `:focus-visible` and `focus-within` added
- Add focus styles to the default stylesheet
- TriggerDown and TriggerUp event which is called on left mouse down and on enter/space.
- Labels can describe other elements similar to the html for attribute