### PR TITLE
Fix bugs with textbox introduced by #187

### DIFF
--- a/crates/vizia_core/resources/themes/default_theme.css
+++ b/crates/vizia_core/resources/themes/default_theme.css
@@ -133,11 +133,10 @@ textbox:hover {
     background-color: #f6f6f6;
 }
 
-textbox:focus {
+textbox:checked {
     border-color: #4c00ff;
 }
-
-textbox:focus .textbox_content {
+textbox:checked .textbox_content {
     caret-color: #ff0000;
     selection-color: #6464c888;
 }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -360,9 +360,13 @@ impl<'a> BackendContext<'a> {
                         {
                             self.with_current(self.0.hovered, |cx| cx.focus_with_visibility(false));
                         }
-                        self.with_current(self.0.hovered, |cx| {
-                            cx.emit(WindowEvent::TriggerDown { mouse: true })
-                        });
+
+                        self.dispatch_direct_or_up(
+                            WindowEvent::TriggerDown { mouse: true },
+                            self.0.captured,
+                            self.0.triggered,
+                            true,
+                        );
                     }
                     MouseButton::Right => {
                         self.0.mouse.right.pos_down = (self.0.mouse.cursorx, self.0.mouse.cursory);

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -491,7 +491,7 @@ impl<'a> BackendContext<'a> {
                     self.style().needs_restyle = true;
                 }
 
-                if matches!(*code, Code::Enter | Code::NumpadEnter | Code::Space) {
+                if matches!(*code, Code::Space) {
                     self.0.triggered = self.0.focused;
                     self.0.with_current(self.0.focused, |cx| {
                         cx.emit(WindowEvent::TriggerDown { mouse: false })
@@ -501,10 +501,7 @@ impl<'a> BackendContext<'a> {
                 self.0.event_queue.push_back(Event::new(event).target(self.0.focused));
             }
             WindowEvent::KeyUp(_, _) | WindowEvent::CharInput(_) => {
-                if matches!(
-                    event,
-                    WindowEvent::KeyUp(Code::Enter | Code::NumpadEnter | Code::Space, _)
-                ) {
+                if matches!(event, WindowEvent::KeyUp(Code::Space, _)) {
                     self.0.with_current(self.0.triggered, |cx| {
                         cx.emit(WindowEvent::TriggerUp { mouse: false })
                     });

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -592,6 +592,39 @@ where
                 }
             }
 
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+                if !cx.is_over() {
+                    cx.emit(TextEvent::Submit(false));
+                    if let Some(source) = cx.data::<L::Source>() {
+                        let text = self.lens.view(source, |t| {
+                            if let Some(t) = t {
+                                t.to_string()
+                            } else {
+                                "".to_owned()
+                            }
+                        });
+
+                        cx.emit(TextEvent::SelectAll);
+                        cx.emit(TextEvent::InsertText(text));
+                    };
+                    cx.release();
+                    cx.set_checked(false);
+
+                    // Forward event to hovered
+                    cx.event_queue.push_back(
+                        Event::new(WindowEvent::MouseDown(*button)).target(cx.hovered()),
+                    );
+                }
+            }
+
+            WindowEvent::FocusIn => {
+                cx.emit(TextEvent::StartEdit);
+            }
+
+            WindowEvent::FocusOut => {
+                cx.emit(TextEvent::EndEdit);
+            }
+
             WindowEvent::TriggerUp { .. } => {
                 cx.unlock_cursor_icon();
             }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -592,31 +592,6 @@ where
                 }
             }
 
-            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                if !cx.is_over() {
-                    cx.emit(TextEvent::Submit(false));
-                    if let Some(source) = cx.data::<L::Source>() {
-                        let text = self.lens.view(source, |t| {
-                            if let Some(t) = t {
-                                t.to_string()
-                            } else {
-                                "".to_owned()
-                            }
-                        });
-
-                        cx.emit(TextEvent::SelectAll);
-                        cx.emit(TextEvent::InsertText(text));
-                    };
-                    cx.release();
-                    cx.set_checked(false);
-
-                    // Forward event to hovered
-                    cx.event_queue.push_back(
-                        Event::new(WindowEvent::MouseDown(*button)).target(cx.hovered()),
-                    );
-                }
-            }
-
             WindowEvent::FocusIn => {
                 cx.emit(TextEvent::StartEdit);
             }


### PR DESCRIPTION
Fix bugs with textbox introduced by #187.

- The textbox can remain focused but not in an edit state. The `:check` pseudoselector is used to show the cursor and border when the textbox is in an edit state.

- The `TriggerDown` event was not being sent to the captured entity which meant that the textbox could not be set to non edit by clicking away from it.

- The `Enter` key used for the Trigger event was not working correctly with the submit event of the textbox which is also triggered with the `Enter` key so I removed the `Enter` key causing a Trigger event.