### PR TITLE
Add demo to docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! # Demo
+//! <iframe frameBorder="0" width = "100%" height = "420px" src="https://demo.vizia.dev/" title="Vizia Demo"></iframe>
 #[cfg(all(not(feature = "baseview"), feature = "winit"))]
 pub use vizia_winit::application::Application;
 


### PR DESCRIPTION
This is an experiment to see if adding the demo to the documentation using an embedded iframe will work when the docs are published externally (and eventually to docs.rs)