### PR TITLE
Improvements to debug tree (i key)

### DIFF
--- a/crates/vizia_core/src/cache.rs
+++ b/crates/vizia_core/src/cache.rs
@@ -42,7 +42,7 @@ pub struct BoundingBox {
 
 impl std::fmt::Display for BoundingBox {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{ x: {}, y: {}, w: {}, h:{} }}", self.x, self.y, self.w, self.h)
+        write!(f, "{{ x: {:?}, y: {:?}, w: {:?}, h:{:?} }}", self.x, self.y, self.w, self.h)
     }
 }
 

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -438,15 +438,15 @@ impl<'a> BackendContext<'a> {
                     };
                     let local_idents =
                         |entity| if has_next_sibling(entity) { "├── " } else { "└── " };
+                    let indents = |entity| root_indents(entity) + local_idents(entity);
 
                     for entity in TreeIterator::full(tree).skip(1) {
                         if let Some(element_name) =
                             views.get(&entity).and_then(|view| view.element())
                         {
                             println!(
-                                "{}{}{} {} {:?} display={:?} bounds={} clip={}",
-                                root_indents(entity),
-                                local_idents(entity),
+                                "{}{} {} {:?} display={:?} bounds={} clip={}",
+                                indents(entity),
                                 entity,
                                 element_name,
                                 cache.get_visibility(entity),
@@ -454,13 +454,25 @@ impl<'a> BackendContext<'a> {
                                 cache.get_bounds(entity),
                                 cache.get_clip_region(entity),
                             );
+                        } else if let Some(binding_name) =
+                            self.0.bindings.get(&entity).and_then(|binding| binding.name())
+                        {
+                            println!(
+                                "{}{} binding observing {}",
+                                indents(entity),
+                                entity,
+                                binding_name
+                            );
                         } else {
                             println!(
-                                "{}{}{} {} view",
-                                root_indents(entity),
-                                local_idents(entity),
+                                "{}{} {}",
+                                indents(entity),
                                 entity,
-                                if views.get(&entity).is_some() { "unnamed" } else { "no" }
+                                if views.get(&entity).is_some() {
+                                    "unnamed view"
+                                } else {
+                                    "no binding or view"
+                                }
                             );
                         }
                     }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -421,7 +421,7 @@ impl<'a> BackendContext<'a> {
                 }
 
                 #[cfg(debug_assertions)]
-                if *code == Code::KeyI {
+                if *code == Code::KeyI && self.0.modifiers.contains(Modifiers::CTRL) {
                     println!("Entity tree");
                     let (tree, views, cache) = (&self.0.tree, &self.0.views, &self.0.cache);
                     let has_next_sibling = |entity| tree.get_next_sibling(entity).is_some();

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use vizia_id::GenerationalId;
 #[cfg(debug_assertions)]
-use vizia_storage::TreeDepthIterator;
+use vizia_storage::TreeExt;
 use vizia_storage::TreeIterator;
 
 pub use crate::systems::animation::has_animations;
@@ -422,19 +422,45 @@ impl<'a> BackendContext<'a> {
 
                 #[cfg(debug_assertions)]
                 if *code == Code::KeyI {
-                    let iter = TreeDepthIterator::full(&self.0.tree);
-                    for (entity, level) in iter {
-                        if let Some(element_name) = self.0.views.get(&entity).unwrap().element() {
+                    println!("Entity tree");
+                    let (tree, views, cache) = (&self.0.tree, &self.0.views, &self.0.cache);
+                    let has_next_sibling = |entity| tree.get_next_sibling(entity).is_some();
+                    let root_indents = |entity: Entity| {
+                        entity
+                            .parent_iter(tree)
+                            .skip(1)
+                            .collect::<Vec<_>>()
+                            .into_iter()
+                            .rev()
+                            .skip(1)
+                            .map(|entity| if has_next_sibling(entity) { "│   " } else { "    " })
+                            .collect::<String>()
+                    };
+                    let local_idents =
+                        |entity| if has_next_sibling(entity) { "├── " } else { "└── " };
+
+                    for entity in TreeIterator::full(tree).skip(1) {
+                        if let Some(element_name) =
+                            views.get(&entity).and_then(|view| view.element())
+                        {
                             println!(
-                                "{:indent$} {} {} {:?} {:?} {:?} {:?}",
-                                "",
+                                "{}{}{} {} {:?} display={:?} bounds={} clip={}",
+                                root_indents(entity),
+                                local_idents(entity),
                                 entity,
                                 element_name,
-                                self.0.cache.get_visibility(entity),
-                                self.0.cache.get_display(entity),
-                                self.0.cache.get_bounds(entity),
-                                self.0.cache.get_clip_region(entity),
-                                indent = level
+                                cache.get_visibility(entity),
+                                cache.get_display(entity),
+                                cache.get_bounds(entity),
+                                cache.get_clip_region(entity),
+                            );
+                        } else {
+                            println!(
+                                "{}{}{} {} view",
+                                root_indents(entity),
+                                local_idents(entity),
+                                entity,
+                                if views.get(&entity).is_some() { "unnamed" } else { "no" }
                             );
                         }
                     }

--- a/crates/vizia_core/src/state/binding.rs
+++ b/crates/vizia_core/src/state/binding.rs
@@ -4,6 +4,30 @@ use std::collections::{HashMap, HashSet};
 use crate::prelude::*;
 use crate::state::{BasicStore, LensCache, ModelOrView, Store, StoreId};
 
+/// A view on a binding to allow for better debugging
+struct BindingView<L: Lens> {
+    lens: L,
+}
+
+impl<L: Lens> View for BindingView<L> {
+    fn build<F>(self, cx: &mut Context, _content: F) -> Handle<Self> {
+        let id = cx.entity_manager.create();
+        let current = cx.current();
+        cx.tree.add(id, current).expect("Failed to add to tree");
+        cx.cache.add(id).expect("Failed to add to cache");
+        cx.style.add(id);
+        cx.views.insert(id, Box::new(self));
+
+        Handle { entity: id, p: Default::default(), cx }
+    }
+
+    fn element(&self) -> Option<&'static str> {
+        self.lens.name()
+    }
+    
+    fn draw(&self, _cx: &mut DrawContext, _canvas: &mut Canvas) {}
+}
+
 /// A binding view which rebuilds its contents when its observed data changes.
 ///
 /// This type is part of the prelude.
@@ -38,11 +62,7 @@ where
     where
         F: 'static + Fn(&mut Context, L),
     {
-        let id = cx.entity_manager.create();
-        let current = cx.current();
-        cx.tree.add(id, current).expect("Failed to add to tree");
-        cx.cache.add(id).expect("Failed to add to cache");
-        cx.style.add(id);
+        let id = BindingView { lens: lens.clone() }.build(cx, |_| {}).ignore().entity;
 
         let binding = Self { entity: id, lens: lens.clone(), content: Some(Box::new(builder)) };
 
@@ -123,8 +143,6 @@ where
                 cx.bindings.insert(id, binding);
             }
         });
-
-        let _: Handle<Self> = Handle { entity: id, p: Default::default(), cx }.ignore();
     }
 }
 

--- a/crates/vizia_core/src/state/binding.rs
+++ b/crates/vizia_core/src/state/binding.rs
@@ -24,7 +24,7 @@ impl<L: Lens> View for BindingView<L> {
     fn element(&self) -> Option<&'static str> {
         self.lens.name()
     }
-    
+
     fn draw(&self, _cx: &mut DrawContext, _canvas: &mut Canvas) {}
 }
 

--- a/crates/vizia_core/src/state/lens.rs
+++ b/crates/vizia_core/src/state/lens.rs
@@ -19,6 +19,10 @@ pub trait Lens: 'static + Clone {
     type Target;
 
     fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O;
+    
+    fn name(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 pub(crate) trait LensCache: Lens {
@@ -35,7 +39,7 @@ impl<T: Lens> LensCache for T {}
 
 /// Helpers for constructing more complex `Lens`es.
 ///
-/// This trait is par tof the prelude.
+/// This trait is part of the prelude.
 pub trait LensExt: Lens {
     /// Retrieve a copy of the lensed data from context.
     ///
@@ -177,6 +181,10 @@ where
 
     fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
         self.a.view(source, |t| if let Some(t) = t { self.b.view(t, map) } else { map(None) })
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        self.a.name()
     }
 }
 

--- a/crates/vizia_core/src/state/lens.rs
+++ b/crates/vizia_core/src/state/lens.rs
@@ -19,7 +19,7 @@ pub trait Lens: 'static + Clone {
     type Target;
 
     fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O;
-    
+
     fn name(&self) -> Option<&'static str> {
         None
     }

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -250,6 +250,10 @@ impl Ticks {
     }
 }
 impl View for Ticks {
+    fn element(&self) -> Option<&'static str> {
+        Some("ticks")
+    }
+
     fn draw(&self, cx: &mut DrawContext, canvas: &mut Canvas) {
         let opacity = cx.opacity();
 
@@ -344,6 +348,10 @@ impl TickKnob {
     }
 }
 impl View for TickKnob {
+    fn element(&self) -> Option<&'static str> {
+        Some("tickknob")
+    }
+
     fn draw(&self, cx: &mut DrawContext, canvas: &mut Canvas) {
         let opacity = cx.opacity();
 
@@ -470,6 +478,10 @@ impl ArcTrack {
 }
 
 impl View for ArcTrack {
+    fn element(&self) -> Option<&'static str> {
+        Some("arctrack")
+    }
+    
     fn draw(&self, cx: &mut DrawContext, canvas: &mut Canvas) {
         let opacity = cx.opacity();
 

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -481,7 +481,7 @@ impl View for ArcTrack {
     fn element(&self) -> Option<&'static str> {
         Some("arctrack")
     }
-    
+
     fn draw(&self, cx: &mut DrawContext, canvas: &mut Canvas) {
         let opacity = cx.opacity();
 

--- a/crates/vizia_core/src/views/table.rs
+++ b/crates/vizia_core/src/views/table.rs
@@ -93,4 +93,7 @@ where
     R: Lens<Target = Vec<T>>,
     L: Lens<Source = T, Target = U>,
 {
+    fn element(&self) -> Option<&'static str> {
+        Some("tablecolumn")
+    }
 }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -781,8 +781,16 @@ where
 
 // can't just be a stack because what if you've styled stacks
 pub struct TextboxContainer {}
-impl View for TextboxContainer {}
+impl View for TextboxContainer {
+    fn element(&self) -> Option<&'static str> {
+        Some("textboxcontainer")
+    }
+}
 
 // can't just be a label because what if you've styled labels
 pub struct TextboxLabel {}
-impl View for TextboxLabel {}
+impl View for TextboxLabel {
+    fn element(&self) -> Option<&'static str> {
+        Some("textboxlabel")
+    }
+}

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -150,6 +150,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     let impls = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
         let field_name = &f.ident.unwrap_named();
         let field_ty = &f.ty;
+        let name = format!("binding={}:{}", struct_type.to_string(), field_name.to_string());
 
         quote! {
 
@@ -160,6 +161,10 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
                 fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &#struct_type#ty_generics, map: F) -> O {
                     map(Some(&source.#field_name))
+                }
+
+                fn name(&self) -> Option<&'static str>{
+                    Some(#name)
                 }
             }
         }
@@ -330,6 +335,7 @@ fn derive_enum(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn
     });
 
     let impls = usable_variants.iter().map(|(variant_name, variant_type)| {
+        let name = format!("binding={}:{}", enum_type.to_string(), variant_name.to_string());
         quote! {
             impl Lens for #twizzled_name::#variant_name {
                 type Source = #enum_type;
@@ -341,6 +347,10 @@ fn derive_enum(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn
                     } else {
                         None
                     })
+                }
+
+                fn name(&self) -> Option<&'static str>{
+                    Some(#name)
                 }
             }
         }

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -150,7 +150,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     let impls = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
         let field_name = &f.ident.unwrap_named();
         let field_ty = &f.ty;
-        let name = format!("binding={}:{}", struct_type.to_string(), field_name.to_string());
+        let name = format!("{}:{}", struct_type.to_string(), field_name.to_string());
 
         quote! {
 
@@ -335,7 +335,7 @@ fn derive_enum(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn
     });
 
     let impls = usable_variants.iter().map(|(variant_name, variant_type)| {
-        let name = format!("binding={}:{}", enum_type.to_string(), variant_name.to_string());
+        let name = format!("{}:{}", enum_type.to_string(), variant_name.to_string());
         quote! {
             impl Lens for #twizzled_name::#variant_name {
                 type Source = #enum_type;


### PR DESCRIPTION
- The tree structure is more clear (using ascii art from the `tree` command)
- Bindings are labelled with what they are binding to
- All views in core are labelled