### PR TITLE
Add APIs to adjust some femtovg cache sizes

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -37,7 +37,7 @@ where
             on_idle: None,
             ignore_default_theme: false,
             text_shaping_run_cache_size: None,
-            text_shaped_words_cache_size: None
+            text_shaped_words_cache_size: None,
         }
     }
 

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -20,6 +20,8 @@ where
     scale_policy: WindowScalePolicy,
     on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
     ignore_default_theme: bool,
+    text_shaping_run_cache_size: Option<usize>,
+    text_shaped_words_cache_size: Option<usize>,
 }
 
 impl<F> Application<F>
@@ -34,6 +36,8 @@ where
             scale_policy: WindowScalePolicy::SystemScaleFactor,
             on_idle: None,
             ignore_default_theme: false,
+            text_shaping_run_cache_size: None,
+            text_shaped_words_cache_size: None
         }
     }
 
@@ -74,6 +78,8 @@ where
             self.app,
             self.on_idle,
             self.ignore_default_theme,
+            self.text_shaping_run_cache_size,
+            self.text_shaped_words_cache_size,
         )
     }
 
@@ -132,6 +138,18 @@ where
     pub fn on_idle<I: 'static + Fn(&mut Context) + Send>(mut self, callback: I) -> Self {
         self.on_idle = Some(Box::new(callback));
 
+        self
+    }
+
+    /// Resize the cache used for rendering text lines
+    pub fn text_shaping_run_cache(mut self, size: usize) -> Self {
+        self.text_shaping_run_cache_size = Some(size);
+        self
+    }
+
+    /// Resize the cache used for rendering words
+    pub fn text_shaped_words_cache(mut self, size: usize) -> Self {
+        self.text_shaped_words_cache_size = Some(size);
         self
     }
 }

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -158,6 +158,8 @@ impl ViziaWindow {
         app: F,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
         ignore_default_theme: bool,
+        text_shaping_run_cache_size: Option<usize>,
+        text_shaped_words_cache_size: Option<usize>,
     ) where
         F: Fn(&mut Context),
         F: 'static + Send,
@@ -176,6 +178,14 @@ impl ViziaWindow {
             window_settings,
             move |window: &mut baseview::Window<'_>| -> ViziaWindow {
                 let mut context = Context::new();
+                if let Some(size) = text_shaped_words_cache_size {
+                    BackendContext::new(&mut context)
+                        .text_context()
+                        .resize_shaped_words_cache(size);
+                }
+                if let Some(size) = text_shaping_run_cache_size {
+                    BackendContext::new(&mut context).text_context().resize_shaping_run_cache(size);
+                }
 
                 context.ignore_default_theme = ignore_default_theme;
 

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use femtovg::{renderer::OpenGl, Canvas};
+use femtovg::{renderer::OpenGl, Canvas, TextContext};
 use fnv::FnvHashMap;
 use instant::{Duration, Instant};
 
@@ -198,6 +198,10 @@ impl<'a> BackendContext<'a> {
                 }
             }
         }
+    }
+
+    pub fn text_context(&mut self) -> &mut TextContext {
+        &mut self.0.text_context
     }
 
     /// For each binding or data observer, check if its data has changed, and if so, rerun its

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -390,6 +390,18 @@ impl Application {
             *control_flow = *stored_control_flow.borrow();
         });
     }
+
+    /// Resize the cache used for rendering text lines
+    pub fn text_shaping_run_cache(mut self, size: usize) -> Self {
+        BackendContext::new(&mut self.context).text_context().resize_shaping_run_cache(size);
+        self
+    }
+
+    /// Resize the cache used for rendering words
+    pub fn text_shaped_words_cache(mut self, size: usize) -> Self {
+        BackendContext::new(&mut self.context).text_context().resize_shaped_words_cache(size);
+        self
+    }
 }
 
 impl WindowModifiers for Application {


### PR DESCRIPTION
These are necessary for arborio to function performantly :) I was previously accessing text_context directly off of Context, but that was made private in the BackendContext cleanup.