### PR TITLE
Textbox improvements

### DIFF
--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -378,7 +378,7 @@ impl<'a> BackendContext<'a> {
                     if self.0.clicks <= 2 {
                         self.0.clicks += 1;
                         let event = if self.0.clicks == 3 {
-                            WindowEvent::MouseTrippleClick(button)
+                            WindowEvent::MouseTripleClick(button)
                         } else {
                             WindowEvent::MouseDoubleClick(button)
                         };

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -333,9 +333,6 @@ impl<'a> BackendContext<'a> {
                 let click_duration = new_click_time - self.0.click_time;
                 let new_click_pos = (self.0.mouse.cursorx, self.0.mouse.cursory);
 
-                self.0.click_time = new_click_time;
-                self.0.click_pos = new_click_pos;
-
                 match button {
                     MouseButton::Left => {
                         self.0.mouse.left.pos_down = (self.0.mouse.cursorx, self.0.mouse.cursory);
@@ -387,6 +384,9 @@ impl<'a> BackendContext<'a> {
                 } else {
                     self.0.clicks = 1;
                 }
+
+                self.0.click_time = new_click_time;
+                self.0.click_pos = new_click_pos;
             }
             WindowEvent::MouseUp(button) => {
                 match button {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -142,7 +142,9 @@ impl<'a> EventContext<'a> {
 
     /// Release mouse input capture for current entity.
     pub fn release(&mut self) {
-        *self.captured = Entity::null();
+        if self.current == *self.captured {
+            *self.captured = Entity::null();
+        }
     }
 
     /// Enables or disables pseudoclasses for the focus of an entity

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -76,7 +76,7 @@ pub struct Context {
     pub(crate) clipboard: Box<dyn ClipboardProvider>,
 
     pub(crate) click_time: Instant,
-    pub(crate) double_click: bool,
+    pub(crate) clicks: usize,
     pub(crate) click_pos: (f32, f32),
 
     pub ignore_default_theme: bool,
@@ -123,7 +123,7 @@ impl Context {
                 Box::new(NopClipboardContext::new().unwrap())
             },
             click_time: Instant::now(),
-            double_click: false,
+            clicks: 0,
             click_pos: (0.0, 0.0),
 
             ignore_default_theme: false,

--- a/crates/vizia_core/src/text/edit.rs
+++ b/crates/vizia_core/src/text/edit.rs
@@ -18,6 +18,8 @@ pub trait EditableText: Clone {
 
     // fn prev_codepoint_offset(&self, from: usize) -> Option<usize>;
     // fn next_codepoint_offset(&self, from: usize) -> Option<usize>;
+
+    fn paragraph_around(&self, pos: usize) -> core::ops::RangeInclusive<usize>;
 }
 
 impl EditableText for String {
@@ -89,6 +91,24 @@ impl EditableText for String {
             offset += next_grapheme.len();
         }
         Some(self.len())
+    }
+
+    fn paragraph_around(&self, pos: usize) -> core::ops::RangeInclusive<usize> {
+        let mut start = 0;
+        let mut end = self.len() - 1;
+        for prev_grapheme in self[0..pos].graphemes(true).rev() {
+            if prev_grapheme == "\n" {
+                start = pos;
+                break;
+            }
+        }
+        for next_grapheme in self[pos..].graphemes(true) {
+            if next_grapheme == "\n" {
+                end = pos;
+                break;
+            }
+        }
+        start..=end
     }
 }
 

--- a/crates/vizia_core/src/text/edit.rs
+++ b/crates/vizia_core/src/text/edit.rs
@@ -19,6 +19,7 @@ pub trait EditableText: Clone {
     // fn prev_codepoint_offset(&self, from: usize) -> Option<usize>;
     // fn next_codepoint_offset(&self, from: usize) -> Option<usize>;
 
+    fn word_around(&self, pos: usize) -> core::ops::RangeInclusive<usize>;
     fn paragraph_around(&self, pos: usize) -> core::ops::RangeInclusive<usize>;
 }
 
@@ -93,20 +94,57 @@ impl EditableText for String {
         Some(self.len())
     }
 
+    fn word_around(&self, pos: usize) -> core::ops::RangeInclusive<usize> {
+        let mut start = 0;
+        let mut end = self.len();
+        let selecting_whitespace = self[pos..]
+            .chars()
+            .next()
+            .map(char::is_whitespace)
+            .or_else(|| self[..pos].chars().rev().next().map(char::is_whitespace));
+
+        let mut offset = pos;
+        for prev_grapheme in self[0..pos].graphemes(true).rev() {
+            let is_whitespace = prev_grapheme.chars().next().map(char::is_whitespace);
+            if is_whitespace != selecting_whitespace {
+                start = offset;
+                break;
+            }
+            offset -= prev_grapheme.len();
+        }
+
+        let mut offset = pos;
+        for next_grapheme in self[pos..].graphemes(true) {
+            let is_whitespace = next_grapheme.chars().next().map(char::is_whitespace);
+            if is_whitespace != selecting_whitespace {
+                end = offset;
+                break;
+            }
+            offset += next_grapheme.len();
+        }
+        start..=end
+    }
+
     fn paragraph_around(&self, pos: usize) -> core::ops::RangeInclusive<usize> {
         let mut start = 0;
-        let mut end = self.len() - 1;
+        let mut end = self.len();
+
+        let mut offset = pos;
         for prev_grapheme in self[0..pos].graphemes(true).rev() {
             if prev_grapheme == "\n" {
-                start = pos;
+                start = offset;
                 break;
             }
+            offset -= prev_grapheme.len();
         }
+
+        let mut offset = pos;
         for next_grapheme in self[pos..].graphemes(true) {
             if next_grapheme == "\n" {
-                end = pos;
+                end = offset;
                 break;
             }
+            offset += next_grapheme.len();
         }
         start..=end
     }

--- a/crates/vizia_core/src/text/layout.rs
+++ b/crates/vizia_core/src/text/layout.rs
@@ -192,11 +192,12 @@ pub fn pos_to_idx<'a>(
     x: f32,
     y: f32,
     cache: impl Iterator<Item = &'a (Range<usize>, TextMetrics)>,
+    single_line: bool,
 ) -> usize {
     let mut last = 0;
     // first: what line is it?
     for (line_range, line_metrics) in cache {
-        if y < line_metrics.y + line_metrics.height() {
+        if y < line_metrics.y + line_metrics.height() || single_line {
             // it's me!
             for glyph in line_metrics.glyphs.iter() {
                 if x < glyph.x + glyph.advance_x / 2.0 {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -239,7 +239,12 @@ impl TextboxData {
                             Direction::Right => 0.0,
                         };
 
-                    self.selection.active = pos_to_idx(self.sel_x, new_y, lines.iter());
+                    self.selection.active = pos_to_idx(
+                        self.sel_x,
+                        new_y,
+                        lines.iter(),
+                        self.kind == TextboxKind::SingleLine,
+                    );
                 }
             }
 
@@ -388,6 +393,7 @@ impl Model for TextboxData {
                     posx,
                     posy,
                     cx.draw_cache.text_lines.get(self.content_entity).unwrap().iter(),
+                    self.kind == TextboxKind::SingleLine,
                 );
                 self.selection = Selection::new(idx, idx);
                 self.sel_x = posx;
@@ -401,6 +407,7 @@ impl Model for TextboxData {
                     posx,
                     posy,
                     cx.draw_cache.text_lines.get(self.content_entity).unwrap().iter(),
+                    self.kind == TextboxKind::SingleLine,
                 );
                 self.selection = Selection::new(self.selection.anchor, idx);
                 self.sel_x = posx;
@@ -458,7 +465,7 @@ pub struct Textbox<L: Lens> {
     kind: TextboxKind,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum TextboxKind {
     SingleLine,
     MultiLineUnwrapped,

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -351,6 +351,7 @@ impl Model for TextboxData {
             }
 
             TextEvent::EndEdit => {
+                self.selection.active = self.selection.anchor;
                 self.edit = false;
                 cx.set_checked(false);
                 cx.release();
@@ -612,7 +613,11 @@ where
             }
 
             WindowEvent::FocusIn => {
-                cx.emit(TextEvent::StartEdit);
+                if cx.mouse.left.pressed != cx.current()
+                    || cx.mouse.left.state == MouseButtonState::Released
+                {
+                    cx.emit(TextEvent::StartEdit);
+                }
             }
 
             WindowEvent::FocusOut => {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -632,7 +632,7 @@ where
                 cx.emit(TextEvent::SelectWord);
             }
 
-            WindowEvent::MouseTrippleClick(MouseButton::Left) => {
+            WindowEvent::MouseTripleClick(MouseButton::Left) => {
                 cx.emit(TextEvent::SelectParagraph);
             }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -626,7 +626,7 @@ where
 
             WindowEvent::MouseUp(MouseButton::Left) => {
                 cx.unlock_cursor_icon();
-                if cx.is_over() {
+                if cx.mouse.left.pressed == cx.current() {
                     cx.emit(TextEvent::StartEdit);
                 }
             }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -605,6 +605,9 @@ where
                     cx.event_queue.push_back(
                         Event::new(WindowEvent::MouseDown(MouseButton::Left)).target(cx.hovered()),
                     );
+                    cx.event_queue.push_back(
+                        Event::new(WindowEvent::TriggerDown { mouse: true }).target(cx.hovered()),
+                    );
                 }
             }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -274,7 +274,7 @@ impl TextboxData {
     }
 
     pub fn select_range(&mut self, _: &mut EventContext, range: &core::ops::RangeInclusive<usize>) {
-        self.selection = Selection::new(*range.start(), *range.end() + 1);
+        self.selection = Selection::new(*range.start(), *range.end());
     }
 }
 
@@ -371,19 +371,7 @@ impl Model for TextboxData {
             }
 
             TextEvent::SelectWord => {
-                let start = if let Some(offset) = self.text.prev_word_offset(self.selection.active)
-                {
-                    self.selection.active = offset;
-                    offset
-                } else {
-                    self.selection.active
-                };
-                let end = if let Some(offset) = self.text.next_word_offset(self.selection.active) {
-                    offset - 1
-                } else {
-                    self.selection.active
-                };
-                self.select_range(cx, &(start..=end));
+                self.select_range(cx, &self.text.word_around(self.selection.active));
                 self.set_caret(cx);
             }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -343,7 +343,9 @@ impl Model for TextboxData {
                         cx.focus_with_visibility(false);
                         cx.capture();
                         cx.set_checked(true);
-                        cx.emit(TextEvent::SelectAll);
+                        if self.selection.active == self.selection.anchor{
+                            cx.emit(TextEvent::SelectAll);
+                        }
                     }
                 }
             }
@@ -588,8 +590,6 @@ where
         event.map(|window_event, _| match window_event {
             WindowEvent::MouseDown(MouseButton::Left) => {
                 if cx.is_over() {
-                    cx.emit(TextEvent::StartEdit);
-
                     cx.focus_with_visibility(false);
                     cx.capture();
                     cx.set_checked(true);
@@ -638,6 +638,9 @@ where
 
             WindowEvent::MouseUp(MouseButton::Left) => {
                 cx.unlock_cursor_icon();
+                if cx.is_over(){
+                    cx.emit(TextEvent::StartEdit);
+                }
             }
 
             WindowEvent::MouseMove(_, _) => {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -274,7 +274,7 @@ impl TextboxData {
     }
 
     pub fn select_range(&mut self, _: &mut EventContext, range: &core::ops::RangeInclusive<usize>) {
-        self.selection = Selection::new(*range.start(), *range.end()+1);
+        self.selection = Selection::new(*range.start(), *range.end() + 1);
     }
 }
 
@@ -343,7 +343,7 @@ impl Model for TextboxData {
                         cx.focus_with_visibility(false);
                         cx.capture();
                         cx.set_checked(true);
-                        if self.selection.active == self.selection.anchor{
+                        if self.selection.active == self.selection.anchor {
                             cx.emit(TextEvent::SelectAll);
                         }
                     }
@@ -379,7 +379,7 @@ impl Model for TextboxData {
                     self.selection.active
                 };
                 let end = if let Some(offset) = self.text.next_word_offset(self.selection.active) {
-                    offset-1
+                    offset - 1
                 } else {
                     self.selection.active
                 };
@@ -638,7 +638,7 @@ where
 
             WindowEvent::MouseUp(MouseButton::Left) => {
                 cx.unlock_cursor_icon();
-                if cx.is_over(){
+                if cx.is_over() {
                     cx.emit(TextEvent::StartEdit);
                 }
             }

--- a/crates/vizia_window/src/window_event.rs
+++ b/crates/vizia_window/src/window_event.rs
@@ -14,8 +14,8 @@ pub enum WindowEvent {
     WindowResize(f32, f32),
     /// Emitted when a mouse button is double clicked
     MouseDoubleClick(MouseButton),
-    /// Emitted when a mouse button is tripple clicked
-    MouseTrippleClick(MouseButton),
+    /// Emitted when a mouse button is triple clicked
+    MouseTripleClick(MouseButton),
     /// Emitted when a mouse button is pressed
     MouseDown(MouseButton),
     /// Emitted when a mouse button is released

--- a/crates/vizia_window/src/window_event.rs
+++ b/crates/vizia_window/src/window_event.rs
@@ -14,6 +14,8 @@ pub enum WindowEvent {
     WindowResize(f32, f32),
     /// Emitted when a mouse button is double clicked
     MouseDoubleClick(MouseButton),
+    /// Emitted when a mouse button is tripple clicked
+    MouseTrippleClick(MouseButton),
     /// Emitted when a mouse button is pressed
     MouseDown(MouseButton),
     /// Emitted when a mouse button is released


### PR DESCRIPTION
- Double click to select word and triple click to select paragraph
- When editing is false, you can now properly select a range by dragging. If you don't drag, then it will select all as before.
- When you click outside a textbox, it didn't send a triggerdown event, only a mousedown.