### PR TITLE
Fix ignore_default_theme + add_theme

### DIFF
--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -9,9 +9,6 @@ use crate::proxy::BaseviewProxy;
 use vizia_core::context::backend::*;
 use vizia_core::prelude::*;
 
-static DEFAULT_THEME: &str = include_str!("../../vizia_core/resources/themes/default_theme.css");
-static DEFAULT_LAYOUT: &str = include_str!("../../vizia_core/resources/themes/default_layout.css");
-
 /// Handles a vizia_baseview application
 pub(crate) struct ViziaWindow {
     application: ApplicationRunner,
@@ -75,12 +72,7 @@ impl ViziaWindow {
                 let mut context = Context::new();
 
                 context.ignore_default_theme = ignore_default_theme;
-
-                context.add_theme(DEFAULT_LAYOUT);
-
-                if !ignore_default_theme {
-                    context.add_theme(DEFAULT_THEME);
-                }
+                context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
 

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -119,12 +119,7 @@ impl ViziaWindow {
                 let mut context = Context::new();
 
                 context.ignore_default_theme = ignore_default_theme;
-
-                context.add_theme(DEFAULT_LAYOUT);
-
-                if !ignore_default_theme {
-                    context.add_theme(DEFAULT_THEME);
-                }
+                context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
 
@@ -180,12 +175,7 @@ impl ViziaWindow {
                 }
 
                 context.ignore_default_theme = ignore_default_theme;
-
-                context.add_theme(DEFAULT_LAYOUT);
-
-                if !ignore_default_theme {
-                    context.add_theme(DEFAULT_THEME);
-                }
+                context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
 

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -389,7 +389,9 @@ impl Context {
         self.resource_manager.themes.clear();
 
         self.add_theme(DEFAULT_LAYOUT);
-        self.add_theme(DEFAULT_THEME);
+        if !self.ignore_default_theme {
+            self.add_theme(DEFAULT_THEME);
+        }
     }
 
     pub fn add_stylesheet(&mut self, path: &str) -> Result<(), std::io::Error> {
@@ -430,12 +432,7 @@ impl Context {
         let mut overall_theme = String::new();
 
         // Reload the stored themes
-        for (index, theme) in self.resource_manager.themes.iter().enumerate() {
-            if self.ignore_default_theme && index == 1 {
-                continue;
-            }
-
-            //self.style.parse_theme(theme);
+        for theme in self.resource_manager.themes.iter() {
             overall_theme += theme;
         }
 

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -17,9 +17,6 @@ use winit::{
     event_loop::{ControlFlow, EventLoop, EventLoopProxy},
 };
 
-static DEFAULT_THEME: &str = include_str!("../../vizia_core/resources/themes/default_theme.css");
-static DEFAULT_LAYOUT: &str = include_str!("../../vizia_core/resources/themes/default_layout.css");
-
 pub struct Application {
     context: Context,
     event_loop: EventLoop<Event>,
@@ -143,10 +140,7 @@ impl Application {
 
         let mut event_manager = EventManager::new();
 
-        context.add_theme(DEFAULT_LAYOUT);
-        if !context.ignore_default_theme {
-            context.add_theme(DEFAULT_THEME);
-        }
+        context.remove_user_themes();
         if let Some(builder) = self.builder.take() {
             (builder)(&mut context);
         }


### PR DESCRIPTION
The logic to skip index 1 of themes if ignoring the default theme was a hack, this does it properly (?). As a consequence, this lets us remove the theme includes from the backends.