### PR TITLE
Reset scroll position when parent and child size are equal

### DIFF
--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -6,7 +6,7 @@ use crate::views::Orientation;
 
 const SCROLL_SENSITIVITY: f32 = 35.0;
 
-#[derive(Lens, Data, Clone)]
+#[derive(Lens, Data, Clone, Debug)]
 pub struct ScrollData {
     pub scroll_x: f32,
     pub scroll_y: f32,
@@ -25,6 +25,18 @@ pub enum ScrollEvent {
     ParentGeo(f32, f32),
 }
 
+impl ScrollData {
+    fn reset(&mut self) {
+        if self.child_x == self.parent_x {
+            self.scroll_x = 0.0;
+        }
+
+        if self.child_y == self.parent_y {
+            self.scroll_y = 0.0;
+        }
+    }
+}
+
 impl Model for ScrollData {
     fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
         event.map(|scroll_update, meta| {
@@ -36,10 +48,12 @@ impl Model for ScrollData {
                 ScrollEvent::ChildGeo(x, y) => {
                     self.child_x = *x;
                     self.child_y = *y;
+                    self.reset();
                 }
                 ScrollEvent::ParentGeo(x, y) => {
                     self.parent_x = *x;
                     self.parent_y = *y;
+                    self.reset();
                 }
             }
 


### PR DESCRIPTION
For a scrollview which grows/shrinks with the parent (e.g. the window), scrolling to the end and then resizing the parent so that the scroll is no longer required, then resizing the parent again so that the scroll *is* required, causes the scoll container to 'stick' to the bottom of the scrollview. This is because the scroll_y (or scroll_x) value is 1.0 when scrolled to the end but resizing the child/parent until the scoll is no longer required should reset this back to 0.0, which is what this PR implements.