### PR TITLE
impl res for option

### DIFF
--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -193,7 +193,7 @@ impl<T: Copy> Res<(T, T)> for (T, T) {
 }
 
 impl<T: Clone + Res<T>> Res<Option<T>> for Option<T> {
-    fn get_val(&self, cx: &Context) -> Option<T> {
+    fn get_val(&self, _: &Context) -> Option<T> {
         self.clone()
     }
 

--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -191,3 +191,16 @@ impl<T: Copy> Res<(T, T)> for (T, T) {
         (closure)(cx, entity, *self);
     }
 }
+
+impl<T: Clone + Res<T>> Res<Option<T>> for Option<T> {
+    fn get_val(&self, cx: &Context) -> Option<T> {
+        self.clone()
+    }
+
+    fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F)
+    where
+        F: 'static + Clone + Fn(&mut Context, Entity, Option<T>),
+    {
+        (closure)(cx, entity, self.clone())
+    }
+}


### PR DESCRIPTION
Implements `Res` trait for `Option<T>` as long as `T` also implements `Res`. This allows, for example, for `Some((u32, u32))` to be passed to window modifiers such as `min_inner_size`.