### PR TITLE
Fix for disabled state style matching

### DIFF
--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -68,7 +68,14 @@ fn entity_selector(cx: &Context, entity: Entity) -> Selector {
         id: cx.style.ids.get(entity).cloned(),
         element: cx.style.elements.get(entity).cloned(),
         classes: cx.style.classes.get(entity).cloned().unwrap_or_default(),
-        pseudo_classes: cx.style.pseudo_classes.get(entity).cloned().unwrap_or_default(),
+        pseudo_classes: {
+            let mut pseudo_classes =
+                cx.style.pseudo_classes.get(entity).cloned().unwrap_or_default();
+            if let Some(disabled) = cx.style.disabled.get(entity) {
+                pseudo_classes.set(PseudoClass::DISABLED, *disabled);
+            }
+            pseudo_classes
+        },
         relation: SelectorRelation::None,
     }
 }


### PR DESCRIPTION
The disabled state was being ignored when performing the optimization which skips style matching when siblings have the same selector. This resulted in disabled siblings being ignored. Fixed by applying the disabled state to the selector.