### PR TITLE
Add Rays and Event::take

### DIFF
--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -83,7 +83,7 @@ impl<'a> EventContext<'a> {
     }
 
     /// Send an event containing a message up the tree from the current entity.
-    pub fn emit<M: Message>(&mut self, message: M) {
+    pub fn emit<M: Any + Send>(&mut self, message: M) {
         self.event_queue.push_back(
             Event::new(message)
                 .target(self.current)
@@ -93,7 +93,7 @@ impl<'a> EventContext<'a> {
     }
 
     /// Send an event containing a message directly to a specified entity.
-    pub fn emit_to<M: Message>(&mut self, target: Entity, message: M) {
+    pub fn emit_to<M: Any + Send>(&mut self, target: Entity, message: M) {
         self.event_queue.push_back(
             Event::new(message).target(target).origin(self.current).propagate(Propagation::Direct),
         );

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -312,7 +312,7 @@ impl Context {
     }
 
     /// Send an event containing a message up the tree from the current entity.
-    pub fn emit<M: Message>(&mut self, message: M) {
+    pub fn emit<M: Any + Send>(&mut self, message: M) {
         self.event_queue.push_back(
             Event::new(message)
                 .target(self.current)
@@ -322,7 +322,7 @@ impl Context {
     }
 
     /// Send an event containing a message directly to a specified entity.
-    pub fn emit_to<M: Message>(&mut self, target: Entity, message: M) {
+    pub fn emit_to<M: Any + Send>(&mut self, target: Entity, message: M) {
         self.event_queue.push_back(
             Event::new(message).target(target).origin(self.current).propagate(Propagation::Direct),
         );

--- a/crates/vizia_core/src/context/proxy.rs
+++ b/crates/vizia_core/src/context/proxy.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::Formatter;
 use std::sync::Mutex;
 
@@ -44,7 +45,7 @@ impl std::fmt::Display for ProxyEmitError {
 impl std::error::Error for ProxyEmitError {}
 
 impl ContextProxy {
-    pub fn emit<M: Message>(&mut self, message: M) -> Result<(), ProxyEmitError> {
+    pub fn emit<M: Any + Send>(&mut self, message: M) -> Result<(), ProxyEmitError> {
         if let Some(proxy) = &self.event_proxy {
             let event = Event::new(message)
                 .target(self.current)
@@ -57,7 +58,7 @@ impl ContextProxy {
         }
     }
 
-    pub fn emit_to<M: Message>(
+    pub fn emit_to<M: Any + Send>(
         &mut self,
         target: Entity,
         message: M,

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -98,22 +98,19 @@ impl Event {
     }
 
     /// Tries to downcast the event message to the specified type. If the downcast was successful,
-    /// the downcasted message gets passed into `f` by value, and the event becomes consumed.
-    pub fn take<M, F>(&mut self, f: F)
-    where
-        M: Any + Send,
-        F: FnOnce(Box<M>, &mut EventMeta),
-    {
+    /// return the message by value and consume the event. Otherwise, do nothing.
+    pub fn take<M: Any + Send>(&mut self) -> Option<M> {
         if let Some(message) = &self.message {
             if message.as_ref().is::<M>() {
                 // Safe to unwrap because we already checked it exists
                 let m = self.message.take().unwrap();
                 // Safe to unwrap because we already checked it can be cast to M
                 let v = m.downcast().unwrap();
-                (f)(v, &mut self.meta);
                 self.meta.consume();
+                return Some(*v);
             }
         }
+        None
     }
 }
 

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -100,9 +100,9 @@ impl Event {
     /// Tries to downcast the event message to the specified type. If the downcast was successful,
     /// the downcasted message gets passed into `f` by value, and the event becomes consumed.
     pub fn take<M, F>(&mut self, f: F)
-        where
-            M: Any + Send,
-            F: FnOnce(Box<M>, &mut EventMeta),
+    where
+        M: Any + Send,
+        F: FnOnce(Box<M>, &mut EventMeta),
     {
         if let Some(message) = &self.message {
             if message.as_ref().is::<M>() {

--- a/crates/vizia_core/src/events/mod.rs
+++ b/crates/vizia_core/src/events/mod.rs
@@ -1,9 +1,9 @@
 //! Events
 //!
-//! Views communicate with each other and model data via events. An [Event] contains a [Message], as well as metadata to describe how events
+//! Views communicate with each other and model data via events. An [Event] contains a message, as well as metadata to describe how events
 //! should propagate through the tree. By default events will propagate up the tree from the target.
 //!
-//! A [Message] can be any static type but is usually an enum. For example:
+//! A message can be any static thread-safe type but is usually an enum. For example:
 //! ```
 //! enum MyEvent {
 //!     ReadDocs,
@@ -39,7 +39,7 @@ mod event_manager;
 pub use event_manager::EventManager;
 
 mod event;
-pub use event::{Event, EventMeta, Message, Propagation};
+pub use event::{Event, EventMeta, Propagation};
 
 mod event_handler;
 pub use event_handler::ViewHandler;

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -49,11 +49,11 @@ pub mod prelude {
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;
     pub use super::modifiers::Actions;
-    pub use super::state::{Binding, Data, Lens, LensExt, Model, Ray, Res};
+    pub use super::state::{Binding, Data, Lens, LensExt, Model, Res, Setter};
     pub use super::view::{Canvas, View};
     pub use super::views::*;
     pub use super::window::WindowModifiers;
-    pub use vizia_derive::{Data, Lens, Ray};
+    pub use vizia_derive::{Data, Lens, Model, Setter};
     pub use vizia_input::{Code, Key, KeyChord, Modifiers, MouseButton, MouseButtonState};
     pub use vizia_storage::{Tree, TreeExt};
     pub use vizia_window::{CursorIcon, WindowDescription, WindowEvent, WindowSize};

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -49,7 +49,7 @@ pub mod prelude {
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;
     pub use super::modifiers::Actions;
-    pub use super::state::{Binding, Data, Lens, Ray, LensExt, Model, Res};
+    pub use super::state::{Binding, Data, Lens, LensExt, Model, Ray, Res};
     pub use super::view::{Canvas, View};
     pub use super::views::*;
     pub use super::window::WindowModifiers;

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -49,11 +49,11 @@ pub mod prelude {
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;
     pub use super::modifiers::Actions;
-    pub use super::state::{Binding, Data, Lens, LensExt, Model, Res};
+    pub use super::state::{Binding, Data, Lens, Ray, LensExt, Model, Res};
     pub use super::view::{Canvas, View};
     pub use super::views::*;
     pub use super::window::WindowModifiers;
-    pub use vizia_derive::{Data, Lens};
+    pub use vizia_derive::{Data, Lens, Ray};
     pub use vizia_input::{Code, Key, KeyChord, Modifiers, MouseButton, MouseButtonState};
     pub use vizia_storage::{Tree, TreeExt};
     pub use vizia_window::{CursorIcon, WindowDescription, WindowEvent, WindowSize};

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -44,7 +44,7 @@ pub mod prelude {
     };
     pub use super::entity::Entity;
     pub use super::environment::{Environment, EnvironmentEvent};
-    pub use super::events::{Event, Message, Propagation};
+    pub use super::events::{Event, Propagation};
     pub use super::handle::Handle;
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;

--- a/crates/vizia_core/src/state/mod.rs
+++ b/crates/vizia_core/src/state/mod.rs
@@ -145,3 +145,6 @@ pub use binding::*;
 
 mod res;
 pub use res::*;
+
+mod ray;
+pub use ray::*;

--- a/crates/vizia_core/src/state/ray.rs
+++ b/crates/vizia_core/src/state/ray.rs
@@ -1,4 +1,4 @@
-pub trait Ray {
+pub trait Setter {
     type Source;
 
     fn apply(self, source: &mut Self::Source);

--- a/crates/vizia_core/src/state/ray.rs
+++ b/crates/vizia_core/src/state/ray.rs
@@ -1,0 +1,5 @@
+pub trait Ray {
+    type Source;
+
+    fn strike(&mut self, source: &mut Self::Source);
+}

--- a/crates/vizia_core/src/state/ray.rs
+++ b/crates/vizia_core/src/state/ray.rs
@@ -1,5 +1,6 @@
 pub trait Ray {
     type Source;
 
-    fn strike(&mut self, source: &mut Self::Source);
+    fn apply(self, source: &mut Self::Source);
+    fn swap(&mut self, source: &mut Self::Source);
 }

--- a/crates/vizia_derive/src/attr.rs
+++ b/crates/vizia_derive/src/attr.rs
@@ -24,7 +24,7 @@ use quote::{quote, quote_spanned};
 const BASE_DRUID_DEPRECATED_ATTR_PATH: &str = "druid";
 const BASE_DATA_ATTR_PATH: &str = "data";
 const BASE_LENS_ATTR_PATH: &str = "lens";
-const BASE_RAY_ATTR_PATH: &str = "ray";
+const BASE_RAY_ATTR_PATH: &str = "setter";
 const IGNORE_ATTR_PATH: &str = "ignore";
 const DATA_SAME_FN_ATTR_PATH: &str = "same_fn";
 const DATA_EQ_ATTR_PATH: &str = "eq";

--- a/crates/vizia_derive/src/attr.rs
+++ b/crates/vizia_derive/src/attr.rs
@@ -24,10 +24,12 @@ use quote::{quote, quote_spanned};
 const BASE_DRUID_DEPRECATED_ATTR_PATH: &str = "druid";
 const BASE_DATA_ATTR_PATH: &str = "data";
 const BASE_LENS_ATTR_PATH: &str = "lens";
+const BASE_RAY_ATTR_PATH: &str = "ray";
 const IGNORE_ATTR_PATH: &str = "ignore";
 const DATA_SAME_FN_ATTR_PATH: &str = "same_fn";
 const DATA_EQ_ATTR_PATH: &str = "eq";
 const LENS_NAME_OVERRIDE_ATTR_PATH: &str = "name";
+const RAY_NAME_OVERRIDE_ATTR_PATH: &str = "name";
 
 /// The fields for a struct or an enum variant.
 #[derive(Debug)]
@@ -83,6 +85,12 @@ pub struct LensAttrs {
     pub lens_name_override: Option<Ident>,
 }
 
+#[derive(Debug)]
+pub struct RayAttrs {
+    pub ignore: bool,
+    pub ray_name_override: Option<Ident>,
+}
+
 impl Fields<DataAttr> {
     pub fn parse_ast(fields: &syn::Fields) -> Result<Self, Error> {
         let kind = match fields {
@@ -111,6 +119,23 @@ impl Fields<LensAttrs> {
             .iter()
             .enumerate()
             .map(|(i, field)| Field::<LensAttrs>::parse_ast(field, i))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Fields { kind, fields })
+    }
+}
+
+impl Fields<RayAttrs> {
+    pub fn parse_ast(fields: &syn::Fields) -> Result<Self, Error> {
+        let kind = match fields {
+            syn::Fields::Named(_) => FieldKind::Named,
+            syn::Fields::Unnamed(_) | syn::Fields::Unit => FieldKind::Unnamed,
+        };
+
+        let fields = fields
+            .iter()
+            .enumerate()
+            .map(|(i, field)| Field::<RayAttrs>::parse_ast(field, i))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Fields { kind, fields })
@@ -258,6 +283,69 @@ impl Field<LensAttrs> {
             }
         }
         Ok(Field { ident, ty, vis, attrs: LensAttrs { ignore, lens_name_override } })
+    }
+}
+
+impl Field<RayAttrs> {
+    pub fn parse_ast(field: &syn::Field, index: usize) -> Result<Self, Error> {
+        let ident = match field.ident.as_ref() {
+            Some(ident) => FieldIdent::Named(ident.to_string().trim_start_matches("r#").to_owned()),
+            None => FieldIdent::Unnamed(index),
+        };
+
+        let ty = field.ty.clone();
+
+        let vis = field.vis.clone();
+
+        let mut ignore = false;
+        let mut ray_name_override = None;
+
+        for attr in field.attrs.iter() {
+            if attr.path.is_ident(BASE_DRUID_DEPRECATED_ATTR_PATH) {
+                panic!(
+                    "The 'druid' attribute has been replaced with separate \
+                    'lens' and 'data' attributes.",
+                );
+            } else if attr.path.is_ident(BASE_RAY_ATTR_PATH) {
+                match attr.parse_meta()? {
+                    Meta::List(meta) => {
+                        for nested in meta.nested.iter() {
+                            match nested {
+                                NestedMeta::Meta(Meta::Path(path))
+                                if path.is_ident(IGNORE_ATTR_PATH) =>
+                                    {
+                                        if ignore {
+                                            return Err(Error::new(
+                                                nested.span(),
+                                                "Duplicate attribute",
+                                            ));
+                                        }
+                                        ignore = true;
+                                    }
+                                NestedMeta::Meta(Meta::NameValue(meta))
+                                if meta.path.is_ident(RAY_NAME_OVERRIDE_ATTR_PATH) =>
+                                    {
+                                        if ray_name_override.is_some() {
+                                            return Err(Error::new(meta.span(), "Duplicate attribute"));
+                                        }
+
+                                        let ident = parse_lit_into_ident(&meta.lit)?;
+                                        ray_name_override = Some(ident);
+                                    }
+                                other => return Err(Error::new(other.span(), "Unknown attribute")),
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(Error::new(
+                            other.span(),
+                            "Expected attribute list (the form #[lens(one, two)])",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(Field { ident, ty, vis, attrs: RayAttrs { ignore, ray_name_override } })
     }
 }
 

--- a/crates/vizia_derive/src/attr.rs
+++ b/crates/vizia_derive/src/attr.rs
@@ -312,26 +312,26 @@ impl Field<RayAttrs> {
                         for nested in meta.nested.iter() {
                             match nested {
                                 NestedMeta::Meta(Meta::Path(path))
-                                if path.is_ident(IGNORE_ATTR_PATH) =>
-                                    {
-                                        if ignore {
-                                            return Err(Error::new(
-                                                nested.span(),
-                                                "Duplicate attribute",
-                                            ));
-                                        }
-                                        ignore = true;
+                                    if path.is_ident(IGNORE_ATTR_PATH) =>
+                                {
+                                    if ignore {
+                                        return Err(Error::new(
+                                            nested.span(),
+                                            "Duplicate attribute",
+                                        ));
                                     }
+                                    ignore = true;
+                                }
                                 NestedMeta::Meta(Meta::NameValue(meta))
-                                if meta.path.is_ident(RAY_NAME_OVERRIDE_ATTR_PATH) =>
-                                    {
-                                        if ray_name_override.is_some() {
-                                            return Err(Error::new(meta.span(), "Duplicate attribute"));
-                                        }
-
-                                        let ident = parse_lit_into_ident(&meta.lit)?;
-                                        ray_name_override = Some(ident);
+                                    if meta.path.is_ident(RAY_NAME_OVERRIDE_ATTR_PATH) =>
+                                {
+                                    if ray_name_override.is_some() {
+                                        return Err(Error::new(meta.span(), "Duplicate attribute"));
                                     }
+
+                                    let ident = parse_lit_into_ident(&meta.lit)?;
+                                    ray_name_override = Some(ident);
+                                }
                                 other => return Err(Error::new(other.span(), "Unknown attribute")),
                             }
                         }

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -220,7 +220,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 }
 
 //I stole these from rustc!
-fn char_has_case(c: char) -> bool {
+pub(crate) fn char_has_case(c: char) -> bool {
     c.is_lowercase() || c.is_uppercase()
 }
 
@@ -382,7 +382,7 @@ fn derive_enum(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn
 
 /// Increase privite/inherited visiblity to `pub(super)`, `pub(super)` or anything else relative to
 /// `super` to one module higher than that, and leave everything else as is.
-fn increase_visibility(vis: &Visibility) -> Visibility {
+pub(crate) fn increase_visibility(vis: &Visibility) -> Visibility {
     match vis {
         // Private structs are promoted to `pub(super)`
         Visibility::Inherited => Visibility::Restricted(VisRestricted {

--- a/crates/vizia_derive/src/lib.rs
+++ b/crates/vizia_derive/src/lib.rs
@@ -19,6 +19,7 @@
 mod attr;
 mod data;
 mod lens;
+mod model;
 mod ray;
 
 use proc_macro::TokenStream;
@@ -36,8 +37,14 @@ pub fn derive_lens(input: TokenStream) -> TokenStream {
     lens::derive_lens_impl(input).unwrap_or_else(|err| err.to_compile_error()).into()
 }
 
-#[proc_macro_derive(Ray, attributes(ray))]
+#[proc_macro_derive(Setter, attributes(setter))]
 pub fn derive_ray(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     ray::derive_ray_impl(input).unwrap_or_else(|err| err.to_compile_error()).into()
+}
+
+#[proc_macro_derive(Model, attributes(model))]
+pub fn derive_model(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    model::derive_model_impl(input).unwrap_or_else(|err| err.to_compile_error()).into()
 }

--- a/crates/vizia_derive/src/lib.rs
+++ b/crates/vizia_derive/src/lib.rs
@@ -19,6 +19,7 @@
 mod attr;
 mod data;
 mod lens;
+mod ray;
 
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
@@ -33,4 +34,10 @@ pub fn derive_data(input: TokenStream) -> TokenStream {
 pub fn derive_lens(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as syn::DeriveInput);
     lens::derive_lens_impl(input).unwrap_or_else(|err| err.to_compile_error()).into()
+}
+
+#[proc_macro_derive(Ray, attributes(ray))]
+pub fn derive_ray(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    ray::derive_ray_impl(input).unwrap_or_else(|err| err.to_compile_error()).into()
 }

--- a/crates/vizia_derive/src/model.rs
+++ b/crates/vizia_derive/src/model.rs
@@ -1,0 +1,33 @@
+use proc_macro2::Ident;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::Data;
+
+pub(crate) fn derive_model_impl(
+    input: syn::DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    match &input.data {
+        Data::Struct(_) => derive_struct(&input),
+        Data::Enum(e) => Err(syn::Error::new(
+            e.enum_token.span(),
+            "Model implementations cannot be derived from enums",
+        )),
+        Data::Union(u) => Err(syn::Error::new(
+            u.union_token.span(),
+            "Model implementations cannot be derived from unions",
+        )),
+    }
+}
+
+fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let struct_type = &input.ident;
+    let ray_type = Ident::new(&(struct_type.to_string() + "Setter"), input.ident.span());
+
+    Ok(quote! {
+        impl Model for #struct_type {
+            fn event(&mut self, _: &mut EventContext, event: &mut Event) {
+                event.take::<#ray_type>().map(|setter| setter.apply(self));
+            }
+        }
+    })
+}

--- a/crates/vizia_derive/src/ray.rs
+++ b/crates/vizia_derive/src/ray.rs
@@ -12,18 +12,18 @@ pub(crate) fn derive_ray_impl(
         Data::Struct(_) => derive_struct(&input),
         Data::Enum(e) => Err(syn::Error::new(
             e.enum_token.span(),
-            "Ray implementations cannot be derived from enums",
+            "Setter implementations cannot be derived from enums",
         )),
         Data::Union(u) => Err(syn::Error::new(
             u.union_token.span(),
-            "Ray implementations cannot be derived from unions",
+            "Setter implementations cannot be derived from unions",
         )),
     }
 }
 
 fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
     let enum_type = &input.ident;
-    let ray_name = Ident::new(&(enum_type.to_string() + "Ray"), enum_type.span());
+    let ray_name = Ident::new(&(enum_type.to_string() + "Setter"), enum_type.span());
 
     let module_vis = &input.vis;
     let enum_vis = increase_visibility(module_vis);
@@ -33,14 +33,14 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
     } else {
         return Err(syn::Error::new(
             input.span(),
-            "Ray implementations can only be derived from structs with named fields",
+            "Setter implementations can only be derived from structs with named fields",
         ));
     };
 
     if fields.kind != FieldKind::Named {
         return Err(syn::Error::new(
             input.span(),
-            "Ray implementations can only be derived from structs with named fields",
+            "Setter implementations can only be derived from structs with named fields",
         ));
     }
 
@@ -63,7 +63,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         apply_arms.push(quote! { #ray_name::#variant_name(v) => source.#field_name = v });
     }
 
-    let enum_docs = format!("Ray enum for [`{ty}`](super::{ty}).", ty = enum_type,);
+    let enum_docs = format!("Setter enum for [`{ty}`](super::{ty}).", ty = enum_type,);
 
     let expanded = quote! {
         #[doc = #enum_docs]
@@ -73,7 +73,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
             #(#variants),*
         }
 
-        impl #impl_generics Ray for #ray_name #ty_generics #where_clause {
+        impl #impl_generics Setter for #ray_name #ty_generics #where_clause {
             type Source = #enum_type;
 
             fn swap(&mut self, source: &mut Self::Source) {

--- a/crates/vizia_derive/src/ray.rs
+++ b/crates/vizia_derive/src/ray.rs
@@ -1,9 +1,9 @@
-use proc_macro2::Ident;
-use quote::quote;
-use syn::{Data};
-use syn::spanned::Spanned;
 use crate::attr::{FieldKind, Fields, RayAttrs};
 use crate::lens::{char_has_case, increase_visibility};
+use proc_macro2::Ident;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::Data;
 
 pub(crate) fn derive_ray_impl(
     input: syn::DeriveInput,
@@ -65,10 +65,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         }
     });
 
-    let enum_docs = format!(
-        "Ray enum for [`{ty}`](super::{ty}).",
-        ty = enum_type,
-    );
+    let enum_docs = format!("Ray enum for [`{ty}`](super::{ty}).", ty = enum_type,);
 
     let expanded = quote! {
         #[doc = #enum_docs]

--- a/crates/vizia_derive/src/ray.rs
+++ b/crates/vizia_derive/src/ray.rs
@@ -1,0 +1,160 @@
+use proc_macro2::Ident;
+use quote::quote;
+use syn::{Data};
+use syn::spanned::Spanned;
+use crate::attr::{FieldKind, Fields, RayAttrs};
+use crate::lens::{char_has_case, increase_visibility};
+
+pub(crate) fn derive_ray_impl(
+    input: syn::DeriveInput,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
+    match &input.data {
+        Data::Struct(_) => derive_struct(&input),
+        Data::Enum(e) => Err(syn::Error::new(
+            e.enum_token.span(),
+            "Ray implementations cannot be derived from enums",
+        )),
+        Data::Union(u) => Err(syn::Error::new(
+            u.union_token.span(),
+            "Ray implementations cannot be derived from unions",
+        )),
+    }
+}
+
+fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
+    let enum_type = &input.ident;
+    let ray_name = Ident::new(&(enum_type.to_string() + "Ray"), enum_type.span());
+
+    let module_vis = &input.vis;
+    let enum_vis = increase_visibility(module_vis);
+
+    let fields = if let syn::Data::Struct(syn::DataStruct { fields, .. }) = &input.data {
+        Fields::<RayAttrs>::parse_ast(fields)?
+    } else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Ray implementations can only be derived from structs with named fields",
+        ));
+    };
+
+    if fields.kind != FieldKind::Named {
+        return Err(syn::Error::new(
+            input.span(),
+            "Ray implementations can only be derived from structs with named fields",
+        ));
+    }
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    // Define ray types for each field
+    let variants = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
+        let field_name = &f.ident.unwrap_named();
+        let field_ty = &f.ty;
+        let variant_name = Ident::new(&to_camel_case(&field_name.to_string()), field_name.span());
+        quote! {
+            #variant_name(#field_ty)
+        }
+    });
+
+    // Define ray match arms for each field
+    let match_arms = fields.iter().filter(|f| !f.attrs.ignore).map(|f| {
+        let field_name = &f.ident.unwrap_named();
+        let variant_name = Ident::new(&to_camel_case(&field_name.to_string()), field_name.span());
+        quote! {
+            #ray_name::#variant_name(v) => std::mem::swap(v, &mut source.#field_name)
+        }
+    });
+
+    let enum_docs = format!(
+        "Ray enum for [`{ty}`](super::{ty}).",
+        ty = enum_type,
+    );
+
+    let expanded = quote! {
+        #[doc = #enum_docs]
+        #[allow(non_camel_case_types)]
+        #[derive(Debug)]
+        #enum_vis enum #ray_name #ty_generics #where_clause {
+            #(#variants),*
+        }
+
+        impl #impl_generics Ray for #ray_name #ty_generics #where_clause {
+            type Source = #enum_type;
+
+            fn strike(&mut self, source: &mut Self::Source) {
+                match self {
+                    #(#match_arms),*
+                }
+            }
+        }
+    };
+    println!("{}", expanded);
+
+    Ok(expanded)
+}
+
+// once again, stolen from rustc
+fn to_camel_case(s: &str) -> String {
+    s.trim_matches('_')
+        .split('_')
+        .filter(|component| !component.is_empty())
+        .map(|component| {
+            let mut camel_cased_component = String::new();
+
+            let mut new_word = true;
+            let mut prev_is_lower_case = true;
+
+            for c in component.chars() {
+                // Preserve the case if an uppercase letter follows a lowercase letter, so that
+                // `camelCase` is converted to `CamelCase`.
+                if prev_is_lower_case && c.is_uppercase() {
+                    new_word = true;
+                }
+
+                if new_word {
+                    camel_cased_component.extend(c.to_uppercase());
+                } else {
+                    camel_cased_component.extend(c.to_lowercase());
+                }
+
+                prev_is_lower_case = c.is_lowercase();
+                new_word = false;
+            }
+
+            camel_cased_component
+        })
+        .fold((String::new(), None), |(acc, prev): (String, Option<String>), next| {
+            // separate two components with an underscore if their boundary cannot
+            // be distinguished using an uppercase/lowercase case distinction
+            let join = if let Some(prev) = prev {
+                let l = prev.chars().last().unwrap();
+                let f = next.chars().next().unwrap();
+                !char_has_case(l) && !char_has_case(f)
+            } else {
+                false
+            };
+            (acc + if join { "_" } else { "" } + &next, Some(next))
+        })
+        .0
+}
+
+fn is_snake_case(ident: &str) -> bool {
+    if ident.is_empty() {
+        return true;
+    }
+    let ident = ident.trim_start_matches('\'');
+    let ident = ident.trim_matches('_');
+
+    let mut allow_underscore = true;
+    ident.chars().all(|c| {
+        allow_underscore = match c {
+            '_' if !allow_underscore => return false,
+            '_' => false,
+            // It would be more obvious to use `c.is_lowercase()`,
+            // but some characters do not have a lowercase form
+            c if !c.is_uppercase() => true,
+            _ => return false,
+        };
+        true
+    })
+}

--- a/examples/views/dropdown.rs
+++ b/examples/views/dropdown.rs
@@ -1,25 +1,10 @@
 use vizia::fonts::icons_names::DOWN;
 use vizia::prelude::*;
 
-#[derive(Lens)]
+#[derive(Lens, Model, Setter)]
 pub struct AppData {
     list: Vec<String>,
     choice: String,
-}
-
-#[derive(Debug)]
-pub enum AppEvent {
-    SetChoice(String),
-}
-
-impl Model for AppData {
-    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.map(|app_event, _| match app_event {
-            AppEvent::SetChoice(choice) => {
-                self.choice = choice.clone();
-            }
-        });
-    }
 }
 
 fn main() {
@@ -57,7 +42,7 @@ fn main() {
                                 }
                             })
                             .on_press(move |cx| {
-                                cx.emit(AppEvent::SetChoice(item.get(cx).clone()));
+                                cx.emit(AppDataSetter::Choice(item.get(cx).clone()));
                                 cx.emit(PopupEvent::Close);
                             });
                     });

--- a/examples/views/knob.rs
+++ b/examples/views/knob.rs
@@ -17,24 +17,9 @@ const STYLE: &str = r#"
 
 "#;
 
-#[derive(Lens)]
+#[derive(Lens, Model, Setter)]
 pub struct AppData {
     value: f32,
-}
-
-#[derive(Debug)]
-pub enum AppEvent {
-    SetValue(f32),
-}
-
-impl Model for AppData {
-    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.map(|app_event, _| match app_event {
-            AppEvent::SetValue(value) => {
-                self.value = *value;
-            }
-        });
-    }
 }
 
 fn main() {
@@ -44,10 +29,10 @@ fn main() {
         AppData { value: 0.2 }.build(cx);
 
         Knob::new(cx, 0.5, AppData::value, false).on_changing(|cx, val| {
-            cx.emit(AppEvent::SetValue(val));
+            cx.emit(AppDataSetter::Value(val));
         });
         Knob::new(cx, 0.5, AppData::value, true).on_changing(|cx, val| {
-            cx.emit(AppEvent::SetValue(val));
+            cx.emit(AppDataSetter::Value(val));
         });
 
         //ArcTrack::new(cx).width(Pixels(50.0)).height(Pixels(50.0)).space(Pixels(20.0));

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -1,6 +1,6 @@
 use vizia::prelude::*;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Options {
     First,
     Second,
@@ -18,23 +18,9 @@ impl std::fmt::Display for Options {
     }
 }
 
-#[derive(Lens)]
+#[derive(Lens, Model, Setter)]
 pub struct AppData {
     pub option: Options,
-}
-
-pub enum AppEvent {
-    ToggleOption(Options),
-}
-
-impl Model for AppData {
-    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
-        event.map(|app_event, _| match app_event {
-            AppEvent::ToggleOption(option) => {
-                self.option = *option;
-            }
-        });
-    }
 }
 
 fn main() {
@@ -53,7 +39,7 @@ fn main() {
                         AppData::option.map(move |option| *option == current_option),
                     )
                     .disabled(if i == 2 { true } else { false })
-                    .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)));
+                    .on_select(move |cx| cx.emit(AppDataSetter::Option(current_option)));
                 }
             })
             .col_between(Pixels(20.0));
@@ -67,7 +53,7 @@ fn main() {
                         cx,
                         AppData::option.map(move |option| *option == current_option),
                     )
-                    .on_select(move |cx| cx.emit(AppEvent::ToggleOption(current_option)))
+                    .on_select(move |cx| cx.emit(AppDataSetter::Option(current_option)))
                     .id(format!("button_{i}"));
                     Label::new(cx, &current_option.to_string()).describing(format!("button_{i}"));
                 })

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -1,14 +1,8 @@
 use vizia::prelude::*;
 
-#[derive(Lens, Ray)]
+#[derive(Lens, Setter, Model)]
 pub struct AppData {
     text: String,
-}
-
-impl Model for AppData {
-    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.take::<AppDataRay>().map(|ray| ray.apply(self));
-    }
 }
 
 fn main() {
@@ -16,7 +10,7 @@ fn main() {
         AppData { text: "This text is editable!".to_string() }.build(cx);
 
         Textbox::new(cx, AppData::text)
-            .on_edit(|cx, text| cx.emit(AppDataRay::Text(text)))
+            .on_edit(|cx, text| cx.emit(AppDataSetter::Text(text)))
             .width(Pixels(200.0))
             .on_build(|cx| {
                 cx.emit(TextEvent::StartEdit);

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -7,9 +7,6 @@ pub struct AppData {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.map::<AppDataRay, _>(|_, _| {
-            println!("now");
-        });
         event.take::<AppDataRay, _>(|mut app_event, _| app_event.strike(self));
     }
 }

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -1,6 +1,6 @@
 use vizia::prelude::*;
 
-#[derive(Lens)]
+#[derive(Lens, Ray)]
 pub struct AppData {
     text: String,
 }
@@ -12,11 +12,7 @@ pub enum AppEvent {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.map(|app_event, _| match app_event {
-            AppEvent::SetText(text) => {
-                self.text = text.clone();
-            }
-        });
+        event.take::<AppDataRay, _>(|mut app_event, _| app_event.strike(self));
     }
 }
 

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -7,7 +7,7 @@ pub struct AppData {
 
 impl Model for AppData {
     fn event(&mut self, _: &mut EventContext, event: &mut Event) {
-        event.take::<AppDataRay, _>(|mut app_event, _| app_event.strike(self));
+        event.take::<AppDataRay>().map(|ray| ray.apply(self));
     }
 }
 

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -5,13 +5,11 @@ pub struct AppData {
     text: String,
 }
 
-#[derive(Debug)]
-pub enum AppEvent {
-    SetText(String),
-}
-
 impl Model for AppData {
     fn event(&mut self, _: &mut EventContext, event: &mut Event) {
+        event.map::<AppDataRay, _>(|_, _| {
+            println!("now");
+        });
         event.take::<AppDataRay, _>(|mut app_event, _| app_event.strike(self));
     }
 }
@@ -21,7 +19,7 @@ fn main() {
         AppData { text: "This text is editable!".to_string() }.build(cx);
 
         Textbox::new(cx, AppData::text)
-            .on_edit(|cx, text| cx.emit(AppEvent::SetText(text)))
+            .on_edit(|cx, text| cx.emit(AppDataRay::Text(text)))
             .width(Pixels(200.0))
             .on_build(|cx| {
                 cx.emit(TextEvent::StartEdit);


### PR DESCRIPTION
A Ray is a new concept which is just a value pending application to a struct. Deriving Ray on `MyStruct` produces a `MyStructRay` enum, which has a variant for each field of the struct. You can call Ray::apply or Ray::swap to apply a ray to the relevant struct.

I've been programming with a prototype of this paradigm in arborio for a few weeks, and the thing I found is that sometimes you want the strike operation to actually be a swap between the struct and the enum - this allows you to inspect the result of the operation post-facto and also gets you an inverse of the event for free - perfect for implementing undo-redo. In order to facilitate this, I had to put RefCells in all of my events, so to smooth that over I introduced Event::take. This required getting rid of the Message type because [mumble mumble something vtables]. Everywhere that previously said Message now says Any + Send.