### PR TITLE
Make window events not read or write state until it is their turn in line

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -240,15 +240,15 @@ impl ApplicationRunner {
                     let physical_posy = position.y * cx.style().dpi_factor;
                     let cursorx = (physical_posx) as f32;
                     let cursory = (physical_posy) as f32;
-                    cx.dispatch_system_event(WindowEvent::MouseMove(cursorx, cursory));
+                    cx.emit_origin(WindowEvent::MouseMove(cursorx, cursory));
                 }
                 baseview::MouseEvent::ButtonPressed(button) => {
                     let b = translate_mouse_button(button);
-                    cx.dispatch_system_event(WindowEvent::MouseDown(b));
+                    cx.emit_origin(WindowEvent::MouseDown(b));
                 }
                 baseview::MouseEvent::ButtonReleased(button) => {
                     let b = translate_mouse_button(button);
-                    cx.dispatch_system_event(WindowEvent::MouseUp(b));
+                    cx.emit_origin(WindowEvent::MouseUp(b));
                 }
                 baseview::MouseEvent::WheelScrolled(scroll_delta) => {
                     let (lines_x, lines_y) = match scroll_delta {
@@ -271,7 +271,7 @@ impl ApplicationRunner {
                         ),
                     };
 
-                    cx.dispatch_system_event(WindowEvent::MouseScroll(lines_x, lines_y));
+                    cx.emit_origin(WindowEvent::MouseScroll(lines_x, lines_y));
                 }
                 _ => {}
             },
@@ -297,23 +297,17 @@ impl ApplicationRunner {
 
                 match s {
                     MouseButtonState::Pressed => {
-                        cx.dispatch_system_event(WindowEvent::KeyDown(
-                            event.code,
-                            Some(event.key.clone()),
-                        ));
+                        cx.emit_origin(WindowEvent::KeyDown(event.code, Some(event.key.clone())));
 
                         if let vizia_input::Key::Character(written) = &event.key {
                             for chr in written.chars() {
-                                cx.dispatch_system_event(WindowEvent::CharInput(chr));
+                                cx.emit_origin(WindowEvent::CharInput(chr));
                             }
                         }
                     }
 
                     MouseButtonState::Released => {
-                        cx.dispatch_system_event(WindowEvent::KeyUp(
-                            event.code,
-                            Some(event.key.clone()),
-                        ));
+                        cx.emit_origin(WindowEvent::KeyUp(event.code, Some(event.key.clone())));
                     }
                 }
             }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -1,8 +1,8 @@
+use std::any::Any;
 use std::collections::HashSet;
 
 use femtovg::{renderer::OpenGl, Canvas, TextContext};
 use fnv::FnvHashMap;
-use instant::{Duration, Instant};
 
 use super::EventProxy;
 use crate::{
@@ -16,19 +16,13 @@ use crate::{
     state::ModelOrView,
     style::Style,
     systems::*,
-    tree::{focus_backward, focus_forward, is_navigatable},
 };
 use vizia_id::GenerationalId;
-#[cfg(debug_assertions)]
-use vizia_storage::TreeExt;
-use vizia_storage::TreeIterator;
 
 pub use crate::systems::animation::has_animations;
 
 #[cfg(feature = "clipboard")]
 use copypasta::ClipboardProvider;
-
-const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 
 pub struct BackendContext<'a>(pub &'a mut Context);
 
@@ -307,279 +301,12 @@ impl<'a> BackendContext<'a> {
         geometry_changed(self.0, &tree);
     }
 
-    /// This method is in charge of receiving raw WindowEvents and dispatching them to the
-    /// appropriate points in the tree.
-    pub fn dispatch_system_event(&mut self, event: WindowEvent) {
-        match &event {
-            WindowEvent::MouseMove(x, y) => {
-                self.0.mouse.previous_cursorx = self.0.mouse.cursorx;
-                self.0.mouse.previous_cursory = self.0.mouse.cursory;
-                self.0.mouse.cursorx = *x;
-                self.0.mouse.cursory = *y;
-
-                hover_system(self.0);
-
-                self.dispatch_direct_or_up(event, self.0.captured, self.0.hovered, false);
-            }
-            &WindowEvent::MouseDown(button) => {
-                match button {
-                    MouseButton::Left => self.0.mouse.left.state = MouseButtonState::Pressed,
-                    MouseButton::Right => self.0.mouse.right.state = MouseButtonState::Pressed,
-                    MouseButton::Middle => self.0.mouse.middle.state = MouseButtonState::Pressed,
-                    _ => {}
-                }
-
-                let new_click_time = Instant::now();
-                let click_duration = new_click_time - self.0.click_time;
-                let new_click_pos = (self.0.mouse.cursorx, self.0.mouse.cursory);
-
-                match button {
-                    MouseButton::Left => {
-                        self.0.mouse.left.pos_down = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.left.pressed = self.0.hovered;
-                        self.0.triggered = self.0.hovered;
-                        let focusable = self
-                            .0
-                            .style
-                            .abilities
-                            .get(self.0.hovered)
-                            .filter(|abilities| abilities.contains(Abilities::FOCUSABLE))
-                            .is_some();
-
-                        self.with_current(
-                            if focusable { self.0.hovered } else { self.0.focused },
-                            |cx| cx.focus_with_visibility(false),
-                        );
-
-                        self.dispatch_direct_or_up(
-                            WindowEvent::TriggerDown { mouse: true },
-                            self.0.captured,
-                            self.0.triggered,
-                            true,
-                        );
-                    }
-                    MouseButton::Right => {
-                        self.0.mouse.right.pos_down = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.right.pressed = self.0.hovered;
-                    }
-                    MouseButton::Middle => {
-                        self.0.mouse.middle.pos_down = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.middle.pressed = self.0.hovered;
-                    }
-                    _ => {}
-                }
-
-                self.dispatch_direct_or_up(event, self.0.captured, self.0.hovered, true);
-
-                if click_duration <= DOUBLE_CLICK_INTERVAL && new_click_pos == self.0.click_pos {
-                    if self.0.clicks <= 2 {
-                        self.0.clicks += 1;
-                        let event = if self.0.clicks == 3 {
-                            WindowEvent::MouseTripleClick(button)
-                        } else {
-                            WindowEvent::MouseDoubleClick(button)
-                        };
-                        self.dispatch_direct_or_up(event, self.0.captured, self.0.hovered, true);
-                    }
-                } else {
-                    self.0.clicks = 1;
-                }
-
-                self.0.click_time = new_click_time;
-                self.0.click_pos = new_click_pos;
-            }
-            WindowEvent::MouseUp(button) => {
-                match button {
-                    MouseButton::Left => {
-                        self.0.mouse.left.pos_up = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.left.released = self.0.hovered;
-                        self.0.mouse.left.state = MouseButtonState::Released;
-                        self.dispatch_direct_or_up(
-                            WindowEvent::TriggerUp { mouse: true },
-                            self.0.captured,
-                            self.0.triggered,
-                            true,
-                        );
-                    }
-                    MouseButton::Right => {
-                        self.0.mouse.right.pos_up = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.right.released = self.0.hovered;
-                        self.0.mouse.right.state = MouseButtonState::Released;
-                    }
-                    MouseButton::Middle => {
-                        self.0.mouse.middle.pos_up = (self.0.mouse.cursorx, self.0.mouse.cursory);
-                        self.0.mouse.middle.released = self.0.hovered;
-                        self.0.mouse.middle.state = MouseButtonState::Released;
-                    }
-                    _ => {}
-                }
-                self.dispatch_direct_or_up(event, self.0.captured, self.0.hovered, true);
-            }
-            WindowEvent::MouseScroll(_, _) => {
-                self.0.event_queue.push_back(Event::new(event).target(self.0.hovered));
-            }
-            WindowEvent::KeyDown(code, _) => {
-                #[cfg(debug_assertions)]
-                if *code == Code::KeyH {
-                    for entity in self.0.tree.into_iter() {
-                        println!("Entity: {} Parent: {:?} View: {} posx: {} posy: {} width: {} height: {}", entity, entity.parent(&self.0.tree), self.0.views.get(&entity).map_or("<None>", |view| view.element().unwrap_or("<Unnamed>")), self.0.cache.get_posx(entity), self.0.cache.get_posy(entity), self.0.cache.get_width(entity), self.0.cache.get_height(entity));
-                    }
-                }
-
-                #[cfg(debug_assertions)]
-                if *code == Code::KeyI && self.0.modifiers.contains(Modifiers::CTRL) {
-                    println!("Entity tree");
-                    let (tree, views, cache) = (&self.0.tree, &self.0.views, &self.0.cache);
-                    let has_next_sibling = |entity| tree.get_next_sibling(entity).is_some();
-                    let root_indents = |entity: Entity| {
-                        entity
-                            .parent_iter(tree)
-                            .skip(1)
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .rev()
-                            .skip(1)
-                            .map(|entity| if has_next_sibling(entity) { "│   " } else { "    " })
-                            .collect::<String>()
-                    };
-                    let local_idents =
-                        |entity| if has_next_sibling(entity) { "├── " } else { "└── " };
-                    let indents = |entity| root_indents(entity) + local_idents(entity);
-
-                    for entity in TreeIterator::full(tree).skip(1) {
-                        if let Some(element_name) =
-                            views.get(&entity).and_then(|view| view.element())
-                        {
-                            println!(
-                                "{}{} {} {:?} display={:?} bounds={} clip={}",
-                                indents(entity),
-                                entity,
-                                element_name,
-                                cache.get_visibility(entity),
-                                cache.get_display(entity),
-                                cache.get_bounds(entity),
-                                cache.get_clip_region(entity),
-                            );
-                        } else if let Some(binding_name) =
-                            self.0.bindings.get(&entity).and_then(|binding| binding.name())
-                        {
-                            println!(
-                                "{}{} binding observing {}",
-                                indents(entity),
-                                entity,
-                                binding_name
-                            );
-                        } else {
-                            println!(
-                                "{}{} {}",
-                                indents(entity),
-                                entity,
-                                if views.get(&entity).is_some() {
-                                    "unnamed view"
-                                } else {
-                                    "no binding or view"
-                                }
-                            );
-                        }
-                    }
-                }
-
-                if *code == Code::F5 {
-                    self.0.reload_styles().unwrap();
-                }
-
-                if *code == Code::Tab {
-                    self.0.set_focus_pseudo_classes(self.0.focused, false, true);
-
-                    let lock_focus_to = self.0.tree.lock_focus_within(self.0.focused);
-                    if self.0.modifiers.contains(Modifiers::SHIFT) {
-                        let prev_focused = if let Some(prev_focused) =
-                            focus_backward(&self.0, self.0.focused, lock_focus_to)
-                        {
-                            prev_focused
-                        } else {
-                            TreeIterator::full(&self.0.tree)
-                                .filter(|node| is_navigatable(&self.0, *node, lock_focus_to))
-                                .next_back()
-                                .unwrap_or(Entity::root())
-                        };
-
-                        if prev_focused != self.0.focused {
-                            self.0.event_queue.push_back(
-                                Event::new(WindowEvent::FocusOut).target(self.0.focused),
-                            );
-                            self.0
-                                .event_queue
-                                .push_back(Event::new(WindowEvent::FocusIn).target(prev_focused));
-                            self.0.focused = prev_focused;
-                        }
-                    } else {
-                        let next_focused = if let Some(next_focused) =
-                            focus_forward(&self.0, self.0.focused, lock_focus_to)
-                        {
-                            next_focused
-                        } else {
-                            TreeIterator::full(&self.0.tree)
-                                .filter(|node| is_navigatable(&self.0, *node, lock_focus_to))
-                                .next()
-                                .unwrap_or(Entity::root())
-                        };
-
-                        if next_focused != self.0.focused {
-                            self.0.event_queue.push_back(
-                                Event::new(WindowEvent::FocusOut).target(self.0.focused),
-                            );
-                            self.0
-                                .event_queue
-                                .push_back(Event::new(WindowEvent::FocusIn).target(next_focused));
-                            self.0.focused = next_focused;
-                        }
-                    }
-
-                    self.0.set_focus_pseudo_classes(self.0.focused, true, true);
-
-                    self.style().needs_relayout = true;
-                    self.style().needs_redraw = true;
-                    self.style().needs_restyle = true;
-                }
-
-                if matches!(*code, Code::Enter | Code::NumpadEnter | Code::Space) {
-                    self.0.triggered = self.0.focused;
-                    self.0.with_current(self.0.focused, |cx| {
-                        cx.emit(WindowEvent::TriggerDown { mouse: false })
-                    });
-                }
-
-                self.0.event_queue.push_back(Event::new(event).target(self.0.focused));
-            }
-            WindowEvent::KeyUp(_, _) | WindowEvent::CharInput(_) => {
-                if matches!(
-                    event,
-                    WindowEvent::KeyUp(Code::Enter | Code::NumpadEnter | Code::Space, _)
-                ) {
-                    self.0.with_current(self.0.triggered, |cx| {
-                        cx.emit(WindowEvent::TriggerUp { mouse: false })
-                    });
-                }
-                self.0.event_queue.push_back(Event::new(event).target(self.0.focused));
-            }
-            _ => {}
-        }
-    }
-
-    pub fn dispatch_direct_or_up(
-        &mut self,
-        event: WindowEvent,
-        direct: Entity,
-        up: Entity,
-        root: bool,
-    ) {
-        if direct != Entity::null() {
-            self.0
-                .event_queue
-                .push_back(Event::new(event).target(direct).propagate(Propagation::Direct));
-        } else if up != Entity::root() || root {
-            self.0.event_queue.push_back(Event::new(event).target(up).propagate(Propagation::Up));
-        }
+    pub fn emit_origin<M: Send + Any>(&mut self, message: M) {
+        self.0.event_queue.push_back(
+            Event::new(message)
+                .target(self.0.current)
+                .origin(Entity::root())
+                .propagate(Propagation::Up),
+        );
     }
 }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -184,7 +184,12 @@ impl Context {
     }
 
     /// Enables or disables pseudoclasses for the focus of an entity
-    fn set_focus_pseudo_classes(&mut self, focused: Entity, enabled: bool, focus_visible: bool) {
+    pub(crate) fn set_focus_pseudo_classes(
+        &mut self,
+        focused: Entity,
+        enabled: bool,
+        focus_visible: bool,
+    ) {
         #[cfg(debug_assertions)]
         if enabled {
             println!(

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -26,7 +26,7 @@ pub struct Event {
     /// The meta data of the event
     pub meta: EventMeta,
     /// The message of the event
-    message: Option<Box<dyn Any + Send>>,
+    pub(crate) message: Option<Box<dyn Any + Send>>,
 }
 
 impl Debug for Event {

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -1,7 +1,7 @@
 use crate::context::InternalEvent;
 use crate::events::EventMeta;
 use crate::prelude::*;
-use crate::systems::hover_system;
+use crate::systems::{compute_matched_rules, hover_system};
 use crate::tree::{focus_backward, focus_forward, is_navigatable};
 use instant::{Duration, Instant};
 use std::any::Any;
@@ -364,6 +364,31 @@ fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, met
                             }
                         );
                     }
+                }
+            }
+
+            #[cfg(debug_assertions)]
+            if *code == Code::KeyS
+                && context.modifiers == Modifiers::CTRL | Modifiers::SHIFT | Modifiers::ALT
+            {
+                let mut result = vec![];
+                compute_matched_rules(context, &context.tree, context.hovered, &mut result);
+
+                let entity = context.hovered;
+                println!("/* Matched rules for Entity: {} Parent: {:?} View: {} posx: {} posy: {} width: {} height: {}",
+                    entity,
+                    entity.parent(&context.tree),
+                    context
+                        .views
+                        .get(&entity)
+                        .map_or("<None>", |view| view.element().unwrap_or("<Unnamed>")),
+                    context.cache.get_posx(entity),
+                    context.cache.get_posy(entity),
+                    context.cache.get_width(entity),
+                    context.cache.get_height(entity)
+                );
+                for rule in result.into_iter() {
+                    println!("{}", rule);
                 }
             }
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -1,7 +1,15 @@
 use crate::context::InternalEvent;
+use crate::events::EventMeta;
 use crate::prelude::*;
+use crate::systems::hover_system;
+use crate::tree::{focus_backward, focus_forward, is_navigatable};
+use instant::{Duration, Instant};
+use std::any::Any;
 use vizia_id::GenerationalId;
 use vizia_storage::TreeExt;
+use vizia_storage::TreeIterator;
+
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Dispatches events to views and models.
 ///
@@ -27,8 +35,6 @@ impl EventManager {
         // Clear the event queue in the event manager
         self.event_queue.clear();
 
-        //state.removed_entities.clear();
-
         // Move events from state to event manager
         self.event_queue.extend(context.event_queue.drain(0..));
 
@@ -47,10 +53,12 @@ impl EventManager {
                     }
                 }
             });
-
-            // if event.trace {
-            //     println!("Event: {:?}", event);
-            // }
+            // handle state updates for window events
+            event.map(|window_event, meta| {
+                if meta.origin == Entity::root() {
+                    internal_state_updates(context, &window_event, meta);
+                }
+            });
 
             // Send events to any global listeners
             let mut global_listeners = vec![];
@@ -95,10 +103,6 @@ impl EventManager {
             if event.meta.consumed {
                 continue 'events;
             }
-
-            // if event.trace {
-            //     println!("Target: {} Parents: {:?} Tree: {:?}", target, target.parent_iter(&self.tree).collect::<Vec<_>>(), self.tree.parent);
-            // }
 
             // Propagate up from target to root (not including target)
             if event.meta.propagation == Propagation::Up {
@@ -170,4 +174,310 @@ fn visit_entity(cx: &mut Context, entity: Entity, event: &mut Event) {
             }
         }
     }
+}
+
+fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, meta: &mut EventMeta) {
+    match window_event {
+        WindowEvent::MouseMove(x, y) => {
+            context.mouse.previous_cursorx = context.mouse.cursorx;
+            context.mouse.previous_cursory = context.mouse.cursory;
+            context.mouse.cursorx = *x;
+            context.mouse.cursory = *y;
+
+            hover_system(context);
+            mutate_direct_or_up(meta, context.captured, context.hovered, false);
+        }
+        WindowEvent::MouseDown(button) => {
+            // do direct state-updates
+            match button {
+                MouseButton::Left => {
+                    context.mouse.left.state = MouseButtonState::Pressed;
+
+                    context.mouse.left.pos_down = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.left.pressed = context.hovered;
+                    context.triggered = context.hovered;
+                    let focusable = context
+                        .style
+                        .abilities
+                        .get(context.hovered)
+                        .filter(|abilities| abilities.contains(Abilities::FOCUSABLE))
+                        .is_some();
+
+                    context.with_current(
+                        if focusable { context.hovered } else { context.focused },
+                        |cx| cx.focus_with_visibility(false),
+                    );
+                }
+                MouseButton::Right => {
+                    context.mouse.right.state = MouseButtonState::Pressed;
+                    context.mouse.right.pos_down = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.right.pressed = context.hovered;
+                }
+                MouseButton::Middle => {
+                    context.mouse.middle.state = MouseButtonState::Pressed;
+                    context.mouse.middle.pos_down = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.middle.pressed = context.hovered;
+                }
+                _ => {}
+            }
+
+            // emit trigger events
+            if matches!(button, MouseButton::Left) {
+                emit_direct_or_up(
+                    context,
+                    WindowEvent::TriggerDown { mouse: true },
+                    context.captured,
+                    context.triggered,
+                    true,
+                );
+            }
+
+            // track double-click
+            let new_click_time = Instant::now();
+            let click_duration = new_click_time - context.click_time;
+            let new_click_pos = (context.mouse.cursorx, context.mouse.cursory);
+            if click_duration <= DOUBLE_CLICK_INTERVAL && new_click_pos == context.click_pos {
+                if context.clicks <= 2 {
+                    context.clicks += 1;
+                    let event = if context.clicks == 3 {
+                        WindowEvent::MouseTripleClick(*button)
+                    } else {
+                        WindowEvent::MouseDoubleClick(*button)
+                    };
+                    emit_direct_or_up(context, event, context.captured, context.hovered, true);
+                }
+            } else {
+                context.clicks = 1;
+            }
+            context.click_time = new_click_time;
+            context.click_pos = new_click_pos;
+
+            mutate_direct_or_up(meta, context.captured, context.hovered, true);
+        }
+        WindowEvent::MouseUp(button) => {
+            match button {
+                MouseButton::Left => {
+                    context.mouse.left.pos_up = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.left.released = context.hovered;
+                    context.mouse.left.state = MouseButtonState::Released;
+                }
+                MouseButton::Right => {
+                    context.mouse.right.pos_up = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.right.released = context.hovered;
+                    context.mouse.right.state = MouseButtonState::Released;
+                }
+                MouseButton::Middle => {
+                    context.mouse.middle.pos_up = (context.mouse.cursorx, context.mouse.cursory);
+                    context.mouse.middle.released = context.hovered;
+                    context.mouse.middle.state = MouseButtonState::Released;
+                }
+                _ => {}
+            }
+
+            if matches!(button, MouseButton::Left) {
+                emit_direct_or_up(
+                    context,
+                    WindowEvent::TriggerUp { mouse: true },
+                    context.captured,
+                    context.triggered,
+                    true,
+                );
+            }
+
+            mutate_direct_or_up(meta, context.captured, context.hovered, true);
+        }
+        WindowEvent::MouseScroll(_, _) => {
+            meta.target = context.hovered;
+        }
+        WindowEvent::KeyDown(code, _) => {
+            meta.target = context.focused;
+
+            #[cfg(debug_assertions)]
+            if *code == Code::KeyH {
+                for entity in context.tree.into_iter() {
+                    println!(
+                        "Entity: {} Parent: {:?} View: {} posx: {} posy: {} width: {} height: {}",
+                        entity,
+                        entity.parent(&context.tree),
+                        context
+                            .views
+                            .get(&entity)
+                            .map_or("<None>", |view| view.element().unwrap_or("<Unnamed>")),
+                        context.cache.get_posx(entity),
+                        context.cache.get_posy(entity),
+                        context.cache.get_width(entity),
+                        context.cache.get_height(entity)
+                    );
+                }
+            }
+
+            #[cfg(debug_assertions)]
+            if *code == Code::KeyI && context.modifiers.contains(Modifiers::CTRL) {
+                println!("Entity tree");
+                let (tree, views, cache) = (&context.tree, &context.views, &context.cache);
+                let has_next_sibling = |entity| tree.get_next_sibling(entity).is_some();
+                let root_indents = |entity: Entity| {
+                    entity
+                        .parent_iter(tree)
+                        .skip(1)
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .rev()
+                        .skip(1)
+                        .map(|entity| if has_next_sibling(entity) { "│   " } else { "    " })
+                        .collect::<String>()
+                };
+                let local_idents =
+                    |entity| if has_next_sibling(entity) { "├── " } else { "└── " };
+                let indents = |entity| root_indents(entity) + local_idents(entity);
+
+                for entity in TreeIterator::full(tree).skip(1) {
+                    if let Some(element_name) = views.get(&entity).and_then(|view| view.element()) {
+                        println!(
+                            "{}{} {} {:?} display={:?} bounds={} clip={}",
+                            indents(entity),
+                            entity,
+                            element_name,
+                            cache.get_visibility(entity),
+                            cache.get_display(entity),
+                            cache.get_bounds(entity),
+                            cache.get_clip_region(entity),
+                        );
+                    } else if let Some(binding_name) =
+                        context.bindings.get(&entity).and_then(|binding| binding.name())
+                    {
+                        println!(
+                            "{}{} binding observing {}",
+                            indents(entity),
+                            entity,
+                            binding_name
+                        );
+                    } else {
+                        println!(
+                            "{}{} {}",
+                            indents(entity),
+                            entity,
+                            if views.get(&entity).is_some() {
+                                "unnamed view"
+                            } else {
+                                "no binding or view"
+                            }
+                        );
+                    }
+                }
+            }
+
+            if *code == Code::F5 {
+                context.reload_styles().unwrap();
+            }
+
+            if *code == Code::Tab {
+                let lock_focus_to = context.tree.lock_focus_within(context.focused);
+                if context.modifiers.contains(Modifiers::SHIFT) {
+                    let prev_focused = if let Some(prev_focused) =
+                        focus_backward(&context, context.focused, lock_focus_to)
+                    {
+                        prev_focused
+                    } else {
+                        TreeIterator::full(&context.tree)
+                            .filter(|node| is_navigatable(&context, *node, lock_focus_to))
+                            .next_back()
+                            .unwrap_or(Entity::root())
+                    };
+
+                    if prev_focused != context.focused {
+                        context.event_queue.push_back(
+                            Event::new(WindowEvent::FocusOut)
+                                .target(context.focused)
+                                .origin(Entity::root()),
+                        );
+                        context.event_queue.push_back(
+                            Event::new(WindowEvent::FocusIn)
+                                .target(prev_focused)
+                                .origin(Entity::root()),
+                        );
+                    }
+                } else {
+                    let next_focused = if let Some(next_focused) =
+                        focus_forward(&context, context.focused, lock_focus_to)
+                    {
+                        next_focused
+                    } else {
+                        TreeIterator::full(&context.tree)
+                            .filter(|node| is_navigatable(&context, *node, lock_focus_to))
+                            .next()
+                            .unwrap_or(Entity::root())
+                    };
+
+                    if next_focused != context.focused {
+                        context.event_queue.push_back(
+                            Event::new(WindowEvent::FocusOut)
+                                .target(context.focused)
+                                .origin(Entity::root()),
+                        );
+                        context.event_queue.push_back(
+                            Event::new(WindowEvent::FocusIn)
+                                .target(next_focused)
+                                .origin(Entity::root()),
+                        );
+                    }
+                }
+
+                context.style.needs_relayout = true;
+                context.style.needs_redraw = true;
+                context.style.needs_restyle = true;
+            }
+
+            if matches!(*code, Code::Enter | Code::NumpadEnter | Code::Space) {
+                context.triggered = context.focused;
+                context.with_current(context.focused, |cx| {
+                    cx.emit(WindowEvent::TriggerDown { mouse: false })
+                });
+            }
+        }
+        WindowEvent::KeyUp(code, _) => {
+            meta.target = context.focused;
+            if matches!(code, Code::Enter | Code::NumpadEnter | Code::Space) {
+                context.with_current(context.triggered, |cx| {
+                    cx.emit(WindowEvent::TriggerUp { mouse: false })
+                });
+            }
+        }
+        WindowEvent::CharInput(_) => {
+            meta.target = context.focused;
+        }
+        WindowEvent::FocusOut => {
+            context.set_focus_pseudo_classes(context.focused, false, true);
+            context.focused = Entity::null();
+        }
+        WindowEvent::FocusIn => {
+            context.focused = meta.target;
+            context.set_focus_pseudo_classes(context.focused, true, true);
+        }
+        _ => {}
+    }
+}
+
+pub fn mutate_direct_or_up(meta: &mut EventMeta, direct: Entity, up: Entity, root: bool) {
+    if direct != Entity::null() {
+        meta.target = direct;
+        meta.propagation = Propagation::Direct;
+    } else if up != Entity::root() || root {
+        meta.target = up;
+        meta.propagation = Propagation::Up;
+    } else {
+        meta.consume();
+    }
+}
+
+pub fn emit_direct_or_up<M: Any + Send>(
+    context: &mut Context,
+    message: M,
+    direct: Entity,
+    up: Entity,
+    root: bool,
+) {
+    let mut event = Event::new(message);
+    mutate_direct_or_up(&mut event.meta, direct, up, root);
+    context.emit_custom(event);
 }

--- a/crates/vizia_core/src/style/color.rs
+++ b/crates/vizia_core/src/style/color.rs
@@ -1,5 +1,6 @@
 use crate::animation::Interpolator;
 use std::fmt;
+use std::fmt::Formatter;
 
 /// Describes a color.
 ///
@@ -8,6 +9,18 @@ use std::fmt;
 #[derive(Copy, Clone)]
 pub struct Color {
     pub data: u32,
+}
+
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.a() == 0 {
+            write!(f, "transparent")
+        } else if self.a() == 255 {
+            write!(f, "#{:02x}{:02x}{:02x}", self.r(), self.g(), self.b())
+        } else {
+            write!(f, "#{:02x}{:02x}{:02x}{:02x}", self.r(), self.g(), self.b(), self.a())
+        }
+    }
 }
 
 impl Color {
@@ -81,18 +94,6 @@ impl Color {
 
     fn interp(start_color: u8, end_color: u8, scale: f64) -> u8 {
         (end_color as f64 - start_color as f64).mul_add(scale, start_color as f64) as u8
-    }
-}
-
-impl ToString for Color {
-    fn to_string(&self) -> String {
-        if self.a() == 0 {
-            return String::from("transparent");
-        }
-
-        let data = self.data;
-
-        format!("#{:x}", data)
     }
 }
 

--- a/crates/vizia_core/src/style/display.rs
+++ b/crates/vizia_core/src/style/display.rs
@@ -1,5 +1,6 @@
 use crate::animation::Interpolator;
 use crate::entity::Entity;
+use std::fmt::Formatter;
 use vizia_id::GenerationalId;
 
 /// Display determines whether an entity will be rendered and acted on by the layout system.
@@ -10,6 +11,19 @@ use vizia_id::GenerationalId;
 pub enum Display {
     None,
     Flex,
+}
+
+impl std::fmt::Display for Display {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Display::None => "none",
+                Display::Flex => "flex",
+            }
+        )
+    }
 }
 
 impl Default for Display {
@@ -45,6 +59,19 @@ pub enum Visibility {
     Invisible,
 }
 
+impl std::fmt::Display for Visibility {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Visibility::Visible => "visible",
+                Visibility::Invisible => "invisible",
+            }
+        )
+    }
+}
+
 impl From<bool> for Visibility {
     fn from(val: bool) -> Self {
         if val {
@@ -73,6 +100,12 @@ impl Interpolator for Visibility {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Opacity(pub f32);
 
+impl std::fmt::Display for Opacity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl Default for Opacity {
     fn default() -> Self {
         Opacity(1.0)
@@ -92,6 +125,19 @@ impl Interpolator for Opacity {
 pub enum Overflow {
     Visible,
     Hidden,
+}
+
+impl std::fmt::Display for Overflow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Overflow::Visible => "visible",
+                Overflow::Hidden => "hidden",
+            }
+        )
+    }
 }
 
 impl Default for Overflow {
@@ -121,6 +167,19 @@ impl Default for FocusOrder {
 pub enum BorderCornerShape {
     Round,
     Bevel,
+}
+
+impl std::fmt::Display for BorderCornerShape {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BorderCornerShape::Round => "round",
+                BorderCornerShape::Bevel => "bevel",
+            }
+        )
+    }
 }
 
 impl Default for BorderCornerShape {

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -25,7 +25,7 @@ mod parser;
 pub use parser::*;
 
 mod style_rule;
-use style_rule::StyleRule;
+pub(crate) use style_rule::StyleRule;
 
 mod selector;
 pub use selector::*;

--- a/crates/vizia_core/src/style/property.rs
+++ b/crates/vizia_core/src/style/property.rs
@@ -120,113 +120,158 @@ pub(crate) enum Property {
     Cursor(CursorIcon),
 }
 
-/*
+pub(crate) fn fmt_units(val: &Units) -> String {
+    match val {
+        Units::Pixels(px) => format!("{}px", px),
+        Units::Percentage(p) => format!("{}%", p),
+        Units::Stretch(s) => format!("{}s", s),
+        Units::Auto => format!("auto"),
+    }
+}
+
+fn fmt_layout_type(val: &LayoutType) -> String {
+    match val {
+        LayoutType::Row => "row",
+        LayoutType::Column => "column",
+        LayoutType::Grid => "grid",
+    }
+    .to_owned()
+}
+
+fn fmt_position_type(val: &PositionType) -> String {
+    match val {
+        PositionType::SelfDirected => "self-directed",
+        PositionType::ParentDirected => "parent-directed",
+    }
+    .to_owned()
+}
+
 impl std::fmt::Display for Property {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-
-            Property::None => write!(f, ""),
-
             Property::Unknown(ident, prop) => {
-                write!(f, "display: {};", match prop {
-                    PropType::Units(val) => {
-                        match val {
-                            Units::Pixels(px) => {
-                                format!("{}px", px)
-                            }
+                write!(
+                    f,
+                    "/* unknown: {}: {}; /*",
+                    ident,
+                    match prop {
+                        PropType::Units(val) => fmt_units(val),
 
-                            Units::Percentage(p) => {
-                                format!("{}%", p)
-                            }
-
-                            Units::Stretch(s) => {
-                                format!("{}s", s)
-                            }
-
-                            Units::Auto => {
-                                format!("auto")
-                            }
-
+                        PropType::String(string) => {
+                            string.clone()
                         }
                     }
-
-                    PropType::String(string) => {
-                        string.clone()
-                    }
-                })
+                )
             }
             // General
-            Property::Display(val) => write!(f, "display: {};", 1),
-            Property::Visibility(val) => write!(f, "visibility: {};", 2),
-            Property::Overflow(val) => write!(f, "overflow: {};", 3),
+            Property::Display(val) => write!(f, "display: {};", val),
+            Property::Visibility(val) => write!(f, "visibility: {};", val),
+            Property::Overflow(val) => write!(f, "overflow: {};", val),
             Property::Opacity(val) => write!(f, "opacity: {};", val),
 
             // Positioning
-            Property::LayoutType(val) => write!(f, "layout-type: {};", val),
-            Property::PositionType(val) => write!(f, "position-type: {};", val),
+            Property::LayoutType(val) => write!(f, "layout-type: {};", fmt_layout_type(val)),
+            Property::PositionType(val) => write!(f, "position-type: {};", fmt_position_type(val)),
 
             // Position and Size
-            Property::Space(val) => write!(f, "space: {};", val),
-            Property::Left(val) => write!(f, "left: {};", val),
-            Property::Width(val) => write!(f, "width: {};", val),
-            Property::Right(val) => write!(f, "right: {};", val),
-            Property::Top(val) => write!(f, "top: {};", val),
-            Property::Height(val) => write!(f, "height: {};", val),
-            Property::Bottom(val) => write!(f, "bottom: {};", val),
+            Property::Space(val) => write!(f, "space: {};", fmt_units(val)),
+            Property::Left(val) => write!(f, "left: {};", fmt_units(val)),
+            Property::Width(val) => write!(f, "width: {};", fmt_units(val)),
+            Property::Right(val) => write!(f, "right: {};", fmt_units(val)),
+            Property::Top(val) => write!(f, "top: {};", fmt_units(val)),
+            Property::Height(val) => write!(f, "height: {};", fmt_units(val)),
+            Property::Bottom(val) => write!(f, "bottom: {};", fmt_units(val)),
 
             // Constraints
-            Property::MinLeft(val) => write!(f, "min-left: {};", val),
-            Property::MaxLeft(val) => write!(f, "max-left: {};", val),
-            Property::MinWidth(val) => write!(f, "min-width: {};", val),
-            Property::MaxWidth(val) => write!(f, "max-width: {};", val),
-            Property::MinRight(val) => write!(f, "min-right: {};", val),
-            Property::MaxRight(val) => write!(f, "max-right: {};", val),
+            Property::MinLeft(val) => write!(f, "min-left: {};", fmt_units(val)),
+            Property::MaxLeft(val) => write!(f, "max-left: {};", fmt_units(val)),
+            Property::MinWidth(val) => write!(f, "min-width: {};", fmt_units(val)),
+            Property::MaxWidth(val) => write!(f, "max-width: {};", fmt_units(val)),
+            Property::MinRight(val) => write!(f, "min-right: {};", fmt_units(val)),
+            Property::MaxRight(val) => write!(f, "max-right: {};", fmt_units(val)),
 
-            Property::MinTop(val) => write!(f, "min-top: {};", val),
-            Property::MaxTop(val) => write!(f, "max-top: {};", val),
-            Property::MinHeight(val) => write!(f, "min-height: {};", val),
-            Property::MaxHeight(val) => write!(f, "max-height: {};", val),
-            Property::MinBottom(val) => write!(f, "min-bottom: {};", val),
-            Property::MaxBottom(val) => write!(f, "max-bottom: {};", val),
+            Property::MinTop(val) => write!(f, "min-top: {};", fmt_units(val)),
+            Property::MaxTop(val) => write!(f, "max-top: {};", fmt_units(val)),
+            Property::MinHeight(val) => write!(f, "min-height: {};", fmt_units(val)),
+            Property::MaxHeight(val) => write!(f, "max-height: {};", fmt_units(val)),
+            Property::MinBottom(val) => write!(f, "min-bottom: {};", fmt_units(val)),
+            Property::MaxBottom(val) => write!(f, "max-bottom: {};", fmt_units(val)),
 
             // Child Spacing
-            Property::ChildSpace(val) => write!(f, "child-space: {};", val),
-            Property::ChildLeft(val) => write!(f, "child-left: {};", val),
-            Property::ChildRight(val) => write!(f, "child-right: {};", val),
-            Property::ChildTop(val) => write!(f, "child-top: {};", val),
-            Property::ChildBottom(val) => write!(f, "child-bottom: {};", val),
-            Property::ChildBetween(val) => write!(f, "child-between: {};", val),
+            Property::ChildSpace(val) => write!(f, "child-space: {};", fmt_units(val)),
+            Property::ChildLeft(val) => write!(f, "child-left: {};", fmt_units(val)),
+            Property::ChildRight(val) => write!(f, "child-right: {};", fmt_units(val)),
+            Property::ChildTop(val) => write!(f, "child-top: {};", fmt_units(val)),
+            Property::ChildBottom(val) => write!(f, "child-bottom: {};", fmt_units(val)),
+            Property::RowBetween(val) => write!(f, "row-between: {};", fmt_units(val)),
+            Property::ColBetween(val) => write!(f, "col-between: {};", fmt_units(val)),
 
             // Border
-            Property::BorderRadius(val) => write!(f, "border-radius: {};", val),
-            Property::BorderTopLeftRadius(val) => write!(f, "border-top-left-radius: {};", val),
-            Property::BorderTopRightRadius(val) => write!(f, "border-top-right-radius: {};", val),
+            Property::BorderRadius(val) => write!(f, "border-radius: {};", fmt_units(val)),
+            Property::BorderTopLeftRadius(val) => {
+                write!(f, "border-top-left-radius: {};", fmt_units(val))
+            }
+            Property::BorderTopRightRadius(val) => {
+                write!(f, "border-top-right-radius: {};", fmt_units(val))
+            }
             Property::BorderBottomLeftRadius(val) => {
-                write!(f, "border-bottom-left-radius: {};", val)
+                write!(f, "border-bottom-left-radius: {};", fmt_units(val))
             }
             Property::BorderBottomRightRadius(val) => {
-                write!(f, "border-bottom-right-radius: {};", val)
+                write!(f, "border-bottom-right-radius: {};", fmt_units(val))
             }
-            Property::BorderWidth(val) => write!(f, "border-width: {};", val),
-            Property::BorderColor(val) => write!(f, "border-color: {:?};", val),
+            Property::BorderWidth(val) => write!(f, "border-width: {};", fmt_units(val)),
+            Property::BorderColor(val) => write!(f, "border-color: {};", val),
+            Property::BorderCornerShape(val) => write!(f, "border-corner-shape: {};", val),
+            Property::BorderTopLeftShape(val) => write!(f, "border-top-left-shape: {};", val),
+            Property::BorderTopRightShape(val) => write!(f, "border-top-right-shape: {};", val),
+            Property::BorderBottomLeftShape(val) => write!(f, "border-bottom-left-shape: {};", val),
+            Property::BorderBottomRightShape(val) => {
+                write!(f, "border-bottom-right-shape: {};", val)
+            }
 
             // Background
-            Property::BackgroundColor(val) => write!(f, "background-color: {:?};", val),
+            Property::BackgroundColor(val) => write!(f, "background-color: {};", val),
             Property::BackgroundImage(val) => write!(f, "background-image: {};", val),
-            Property::BackgroundGradient(val) => write!(f, "background-gradient: {};", 4),
 
+            // Outline
+            Property::OutlineWidth(val) => write!(f, "outline-width: {}", fmt_units(val)),
+            Property::OutlineColor(val) => write!(f, "outline-color: {}", val),
+            Property::OutlineOffset(val) => write!(f, "outline-offset: {}", fmt_units(val)),
+
+            // Text
             Property::FontSize(val) => write!(f, "font-size: {};", val),
-            Property::FontColor(val) => write!(f, "color: {:?};", val),
+            Property::FontColor(val) => write!(f, "color: {};", val),
+            Property::Font(val) => write!(f, "font: {}", val),
+            Property::SelectionColor(val) => write!(f, "selection-color: {}", val),
+            Property::CaretColor(val) => write!(f, "caret-color: {}", val),
+            Property::TextWrap(val) => write!(f, "text-wrap: {}", val),
 
-            Property::OuterShadow(val) => write!(f, "outer-shadow: {};", 5),
-            Property::InnerShadow(val) => write!(f, "inner-shadow: {};", 6),
+            // Shadow
+            Property::OuterShadow(val) => write!(f, "outer-shadow: {};", val),
+            Property::InnerShadow(val) => write!(f, "inner-shadow: {};", val),
+            Property::OuterShadowHOffset(val) => {
+                write!(f, "outer-shadow-h-offset: {}", fmt_units(val))
+            }
+            Property::OuterShadowVOffset(val) => {
+                write!(f, "outer-shadow-v-offset: {}", fmt_units(val))
+            }
+            Property::OuterShadowBlur(val) => write!(f, "inner-shadow-blur: {}", fmt_units(val)),
+            Property::OuterShadowColor(val) => write!(f, "inner-shadow-color: {}", val),
+            Property::InnerShadowHOffset(val) => {
+                write!(f, "inner-shadow-h-offset: {}", fmt_units(val))
+            }
+            Property::InnerShadowVOffset(val) => {
+                write!(f, "inner-shadow-v-offset: {}", fmt_units(val))
+            }
+            Property::InnerShadowBlur(val) => write!(f, "inner-shadow-blur: {}", fmt_units(val)),
+            Property::InnerShadowColor(val) => write!(f, "inner-shadow-color: {}", val),
 
             Property::Transition(val) => write!(f, "transition: {:?};", val),
 
             Property::ZIndex(val) => write!(f, "z-index: {};", val),
 
-            _=> write!(f, ""),
+            Property::Cursor(val) => write!(f, "cursor: {};", val),
         }
     }
 }
-*/

--- a/crates/vizia_core/src/style/shadow.rs
+++ b/crates/vizia_core/src/style/shadow.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use crate::style::fmt_units;
+use std::fmt::Formatter;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) struct BoxShadow {
@@ -16,5 +18,18 @@ impl Default for BoxShadow {
             blur_radius: Units::Auto,
             color: Color::rgba(0, 0, 0, 128),
         }
+    }
+}
+
+impl std::fmt::Display for BoxShadow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} {} {}",
+            fmt_units(&self.horizontal_offset),
+            fmt_units(&self.vertical_offset),
+            fmt_units(&self.blur_radius),
+            &self.color
+        )
     }
 }

--- a/crates/vizia_core/src/style/style_rule.rs
+++ b/crates/vizia_core/src/style/style_rule.rs
@@ -9,23 +9,23 @@ pub(crate) struct StyleRule {
     pub(crate) properties: Vec<Property>,
 }
 
-// impl std::fmt::Display for StyleRule {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         for selector in self.selectors.iter() {
-//             write!(f, "{}", selector)?;
-//         }
+impl std::fmt::Display for StyleRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for selector in self.selectors.iter() {
+            write!(f, "{}", selector)?;
+        }
 
-//         write!(f, " {{\n")?;
+        write!(f, " {{\n")?;
 
-//         for property in self.properties.iter() {
-//             write!(f, "    {}\n", property)?;
-//         }
+        for property in self.properties.iter() {
+            write!(f, "    {}\n", property)?;
+        }
 
-//         write!(f, "}}\n\n")?;
+        write!(f, "}}\n")?;
 
-//         Ok(())
-//     }
-// }
+        Ok(())
+    }
+}
 
 impl StyleRule {
     pub(crate) fn specificity(&self) -> Specificity {

--- a/crates/vizia_core/src/views/menu.rs
+++ b/crates/vizia_core/src/views/menu.rs
@@ -147,7 +147,7 @@ impl View for MenuController {
                             Event::new(window_event.clone())
                                 .propagate(Propagation::Up)
                                 .target(cx.hovered())
-                                .origin(meta.origin.clone()),
+                                .origin(cx.current()),
                         );
                     }
                     // if we click outside the menu, close everything

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -78,6 +78,8 @@ impl TextboxData {
 
         // do the computation
         let (mut tx, mut ty) = self.transform;
+        tx *= scale;
+        ty *= scale;
         let text_box = BoundingBox { x: bounds.x + tx, y: bounds.y + ty, w: bounds.w, h: bounds.h };
         if text_box.x < parent_bounds.x
             && text_box.x + text_box.w < parent_bounds.x + parent_bounds.w
@@ -387,8 +389,8 @@ impl Model for TextboxData {
             }
 
             TextEvent::Hit(posx, posy) => {
-                let posx = *posx - self.transform.0;
-                let posy = *posy - self.transform.1;
+                let posx = *posx - self.transform.0 * cx.style.dpi_factor as f32;
+                let posy = *posy - self.transform.1 * cx.style.dpi_factor as f32;
                 let idx = pos_to_idx(
                     posx,
                     posy,
@@ -401,8 +403,8 @@ impl Model for TextboxData {
             }
 
             TextEvent::Drag(posx, posy) => {
-                let posx = *posx - self.transform.0;
-                let posy = *posy - self.transform.1;
+                let posx = *posx - self.transform.0 * cx.style.dpi_factor as f32;
+                let posy = *posy - self.transform.1 * cx.style.dpi_factor as f32;
                 let idx = pos_to_idx(
                     posx,
                     posy,

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -797,12 +797,9 @@ where
                 Code::PageDown => {}
 
                 Code::KeyA => {
-                    //if self.edit {
                     if cx.modifiers.contains(Modifiers::CTRL) {
-                        // self.select_all(cx);
                         cx.emit(TextEvent::SelectAll);
                     }
-                    //}
                 }
 
                 Code::KeyC => {

--- a/crates/vizia_core/src/window/mod.rs
+++ b/crates/vizia_core/src/window/mod.rs
@@ -1,2 +1,4 @@
 mod window_modifiers;
 pub use window_modifiers::*;
+
+pub use vizia_window;

--- a/crates/vizia_window/src/cursor.rs
+++ b/crates/vizia_window/src/cursor.rs
@@ -1,3 +1,5 @@
+use std::fmt::Formatter;
+
 /// Describes the icon the mouse cursor should use.
 ///
 /// See the cursor_icon example for a gallery of icons and sample usage.
@@ -46,5 +48,52 @@ pub enum CursorIcon {
 impl Default for CursorIcon {
     fn default() -> Self {
         CursorIcon::Default
+    }
+}
+
+impl std::fmt::Display for CursorIcon {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                CursorIcon::Default => "default",
+                CursorIcon::Crosshair => "crosshair",
+                CursorIcon::Hand => "hand",
+                CursorIcon::Arrow => "arrow",
+                CursorIcon::Move => "move",
+                CursorIcon::Text => "text",
+                CursorIcon::Wait => "wait",
+                CursorIcon::Help => "help",
+                CursorIcon::Progress => "progress",
+                CursorIcon::NotAllowed => "not-allowed",
+                CursorIcon::ContextMenu => "context-menu",
+                CursorIcon::Cell => "cell",
+                CursorIcon::VerticalText => "vertical-text",
+                CursorIcon::Alias => "alias",
+                CursorIcon::Copy => "copy",
+                CursorIcon::NoDrop => "no-drop",
+                CursorIcon::Grab => "grab",
+                CursorIcon::Grabbing => "grabbing",
+                CursorIcon::AllScroll => "all-scroll",
+                CursorIcon::ZoomIn => "zoom-in",
+                CursorIcon::ZoomOut => "zoom-out",
+                CursorIcon::EResize => "e-resize",
+                CursorIcon::NResize => "n-resize",
+                CursorIcon::NeResize => "ne-resize",
+                CursorIcon::NwResize => "nw-resize",
+                CursorIcon::SResize => "s-resize",
+                CursorIcon::SeResize => "se-resize",
+                CursorIcon::SwResize => "sw-resize",
+                CursorIcon::WResize => "w-resize",
+                CursorIcon::EwResize => "ew-resize",
+                CursorIcon::NsResize => "ns-resize",
+                CursorIcon::NeswResize => "nesw-resize",
+                CursorIcon::NwseResize => "nwse-resize",
+                CursorIcon::ColResize => "col-resize",
+                CursorIcon::RowResize => "row-resize",
+                CursorIcon::None => "none",
+            }
+        )
     }
 }

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -213,7 +213,6 @@ impl Application {
                     if has_animations(&cx.0) {
                         *stored_control_flow.borrow_mut() = ControlFlow::Poll;
 
-                        //context.insert_event(Event::new(WindowEvent::Relayout).target(Entity::root()));
                         event_loop_proxy.send_event(Event::new(WindowEvent::Redraw)).unwrap();
                         //window.handle.window().request_redraw();
                         if let Some(window_event_handler) = cx.views().remove(&Entity::root()) {
@@ -286,7 +285,7 @@ impl Application {
                             position,
                             modifiers: _,
                         } => {
-                            cx.dispatch_system_event(WindowEvent::MouseMove(
+                            cx.emit_origin(WindowEvent::MouseMove(
                                 position.x as f32,
                                 position.y as f32,
                             ));
@@ -315,7 +314,7 @@ impl Application {
                                 }
                             };
 
-                            cx.dispatch_system_event(event);
+                            cx.emit_origin(event);
                         }
 
                         winit::event::WindowEvent::MouseWheel { delta, phase: _, .. } => {
@@ -331,7 +330,7 @@ impl Application {
                                 }
                             };
 
-                            cx.dispatch_system_event(out_event);
+                            cx.emit_origin(out_event);
                         }
 
                         winit::event::WindowEvent::KeyboardInput {
@@ -358,11 +357,11 @@ impl Application {
                                 }
                             };
 
-                            cx.dispatch_system_event(event);
+                            cx.emit_origin(event);
                         }
 
                         winit::event::WindowEvent::ReceivedCharacter(character) => {
-                            cx.dispatch_system_event(WindowEvent::CharInput(character));
+                            cx.emit_origin(WindowEvent::CharInput(character));
                         }
 
                         winit::event::WindowEvent::Resized(physical_size) => {


### PR DESCRIPTION
As discussed on discord. This has the weird side effect that WindowEvents get emitted without _any_ targeting information, and then the event manager targets them as it processes them, but I think this is desired behavior.