### PR TITLE
Fix clipping problems

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -339,11 +339,14 @@ impl ApplicationRunner {
                     cx.cache().set_width(Entity::root(), physical_size.0 as f32);
                     cx.cache().set_height(Entity::root(), physical_size.1 as f32);
 
-                    let mut bounding_box = BoundingBox::default();
-                    bounding_box.w = physical_size.0 as f32;
-                    bounding_box.h = physical_size.1 as f32;
+                    let clip_region = BoundingBox {
+                        x: -std::f32::MAX / 2.0,
+                        y: -std::f32::MAX / 2.0,
+                        w: std::f32::MAX,
+                        h: std::f32::MAX,
+                    };
 
-                    cx.cache().set_clip_region(Entity::root(), bounding_box);
+                    cx.cache().set_clip_region(Entity::root(), clip_region);
 
                     cx.0.need_restyle();
                     cx.0.need_relayout();

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -100,10 +100,14 @@ impl<'a> BackendContext<'a> {
         self.0.style.pseudo_classes.insert(Entity::root(), PseudoClass::default()).unwrap();
         self.0.style.disabled.insert(Entity::root(), false);
 
-        let bounding_box =
-            BoundingBox { w: physical_width, h: physical_height, ..Default::default() };
+        let clip_region = BoundingBox {
+            x: -std::f32::MAX / 2.0,
+            y: -std::f32::MAX / 2.0,
+            w: std::f32::MAX,
+            h: std::f32::MAX,
+        };
 
-        self.0.cache.set_clip_region(Entity::root(), bounding_box);
+        self.0.cache.set_clip_region(Entity::root(), clip_region);
 
         self.0.canvases.insert(Entity::root(), canvas);
     }

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -25,10 +25,13 @@ pub fn draw_system(cx: &mut Context) {
                 && cx.cache.get_opacity(entity) > 0.0
                 && {
                     let bounds = cx.cache.get_bounds(entity);
-                    !(bounds.x > window_width
-                        || bounds.y > window_height
-                        || bounds.x + bounds.w <= 0.0
-                        || bounds.y + bounds.h <= 0.0)
+                    let transform = cx.cache.get_transform(entity);
+                    let (x, y) = transform.transform_point(bounds.x, bounds.y);
+                    let (w, h) = transform.transform_point(bounds.w, bounds.h);
+                    !(x > window_width
+                        || y > window_height
+                        || w + bounds.w <= 0.0
+                        || h + bounds.h <= 0.0)
                 }
         })
         .collect();

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -390,11 +390,14 @@ impl Application {
                             cx.cache().set_width(Entity::root(), physical_size.width as f32);
                             cx.cache().set_height(Entity::root(), physical_size.height as f32);
 
-                            let mut bounding_box = BoundingBox::default();
-                            bounding_box.w = physical_size.width as f32;
-                            bounding_box.h = physical_size.height as f32;
+                            let clip_region = BoundingBox {
+                                x: -std::f32::MAX / 2.0,
+                                y: -std::f32::MAX / 2.0,
+                                w: std::f32::MAX,
+                                h: std::f32::MAX,
+                            };
 
-                            cx.cache().set_clip_region(Entity::root(), bounding_box);
+                            cx.cache().set_clip_region(Entity::root(), clip_region);
 
                             cx.0.need_restyle();
                             cx.0.need_relayout();


### PR DESCRIPTION
I noticed that views couldn't be hovered and wouldn't be drawn outside the bounds of a transformed parent even if the overflow was set to visible. This is because overflow: visible would cause the view to clip to the root clip region (window bounds). This was actually 2 separate problems:

1. The hover system correctly transforms the view but if the view is moved outside of the bounds of the window then it can't be hovered, even though it may be visible thanks to the transform. To fix this I changed the root clip_region.
2. The draw system was ulling views outside of the window but not taking into account any transforms. To fix this the bounds are now transformed before culling.

