### PR TITLE
Set modifiers on baseview mouse events

### DIFF
--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -12,7 +12,7 @@ vizia_core = { path = "../vizia_core" }
 vizia_input = { path = "../vizia_input" }
 vizia_id = { path = "../vizia_id" }
 
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "b3712638bacb3fdf2883cb5aa3f6caed0e91ac8c", features = ["opengl"] }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "eae4033e7d2cc9c31ccaa2794d5d08eedf2f510c", features = ["opengl"] }
 raw-window-handle = "0.4.2"
 femtovg = { git = "https://github.com/femtovg/femtovg", rev = "8df076f1dd610b5e0a584f0d7fd7f210988b3684", default-features = false }
 lazy_static = "1.4.0"

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -233,25 +233,44 @@ impl ApplicationRunner {
             *should_quit = true;
         }
 
+        let mut update_modifiers = |modifiers: vizia_input::KeyboardModifiers| {
+            cx.modifiers()
+                .set(Modifiers::SHIFT, modifiers.contains(vizia_input::KeyboardModifiers::SHIFT));
+            cx.modifiers()
+                .set(Modifiers::CTRL, modifiers.contains(vizia_input::KeyboardModifiers::CONTROL));
+            cx.modifiers()
+                .set(Modifiers::LOGO, modifiers.contains(vizia_input::KeyboardModifiers::META));
+            cx.modifiers()
+                .set(Modifiers::ALT, modifiers.contains(vizia_input::KeyboardModifiers::ALT));
+        };
+
         match event {
             baseview::Event::Mouse(event) => match event {
-                baseview::MouseEvent::CursorMoved { position } => {
+                baseview::MouseEvent::CursorMoved { position, modifiers } => {
+                    update_modifiers(modifiers);
+
                     let physical_posx = position.x * cx.style().dpi_factor;
                     let physical_posy = position.y * cx.style().dpi_factor;
                     let cursorx = (physical_posx) as f32;
                     let cursory = (physical_posy) as f32;
                     cx.emit_origin(WindowEvent::MouseMove(cursorx, cursory));
                 }
-                baseview::MouseEvent::ButtonPressed(button) => {
+                baseview::MouseEvent::ButtonPressed { button, modifiers } => {
+                    update_modifiers(modifiers);
+
                     let b = translate_mouse_button(button);
                     cx.emit_origin(WindowEvent::MouseDown(b));
                 }
-                baseview::MouseEvent::ButtonReleased(button) => {
+                baseview::MouseEvent::ButtonReleased { button, modifiers } => {
+                    update_modifiers(modifiers);
+
                     let b = translate_mouse_button(button);
                     cx.emit_origin(WindowEvent::MouseUp(b));
                 }
-                baseview::MouseEvent::WheelScrolled(scroll_delta) => {
-                    let (lines_x, lines_y) = match scroll_delta {
+                baseview::MouseEvent::WheelScrolled { delta, modifiers } => {
+                    update_modifiers(modifiers);
+
+                    let (lines_x, lines_y) = match delta {
                         baseview::ScrollDelta::Lines { x, y } => (x, y),
                         baseview::ScrollDelta::Pixels { x, y } => (
                             if x < 0.0 {


### PR DESCRIPTION
Using the changes from https://github.com/RustAudio/baseview/pull/117.

Until baseview implements proper keyboard focus handling this helps when dragging a knob or slider outside of the window. Otherwise the modifier state may get stuck on an incorrect value.