### PR TITLE
Propagate hoverability state

### DIFF
--- a/crates/vizia_core/src/cache.rs
+++ b/crates/vizia_core/src/cache.rs
@@ -742,12 +742,26 @@ impl CachedData {
     //     }
     // }
 
+    pub fn get_hoverability(&self, entity: Entity) -> bool {
+        if let Some(abilities) = self.abilities.get(entity) {
+            abilities.contains(Abilities::HOVERABLE)
+        } else {
+            false
+        }
+    }
+
     pub fn get_visibility(&self, entity: Entity) -> Visibility {
         self.visibility.get(entity).cloned().unwrap()
     }
 
     pub fn get_display(&self, entity: Entity) -> Display {
         self.display.get(entity).cloned().unwrap()
+    }
+
+    pub(crate) fn set_hoverability(&mut self, entity: Entity, val: bool) {
+        if let Some(abilities) = self.abilities.get_mut(entity) {
+            abilities.set(Abilities::HOVERABLE, val);
+        }
     }
 
     pub(crate) fn set_visibility(&mut self, entity: Entity, val: Visibility) {

--- a/crates/vizia_core/src/systems/hover.rs
+++ b/crates/vizia_core/src/systems/hover.rs
@@ -32,14 +32,8 @@ pub fn hover_system(cx: &mut Context) {
         }
 
         // Skip non-hoverable widgets
-        // if cx.cache.get_hoverable(entity) != true {
-        //     continue;
-        // }
-
-        if let Some(abilities) = cx.style.abilities.get(entity).cloned() {
-            if !abilities.contains(Abilities::HOVERABLE) {
-                continue;
-            }
+        if !cx.cache.get_hoverability(entity) {
+            continue;
         }
 
         let mut transform = cx.cache.get_transform(entity);

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -29,37 +29,32 @@ pub fn shared_inheritance_system(cx: &mut Context, tree: &Tree<Entity>) {
     }
 }
 
-// pub fn apply_abilities(cx: &mut Context, tree: &Tree) {
-//     let mut draw_tree: Vec<Entity> = tree.into_iter().collect();
-//     draw_tree.sort_by_cached_key(|entity| cx.cache().get_z_index(*entity));
+pub fn hoverability_system(cx: &mut Context, tree: &Tree<Entity>) {
+    let mut draw_tree: Vec<Entity> = tree.into_iter().collect();
+    draw_tree.sort_by_cached_key(|entity| cx.cache.get_z_index(*entity));
 
-//     for entity in draw_tree.into_iter() {
+    for entity in draw_tree.into_iter() {
+        if entity == Entity::root() {
+            continue;
+        }
 
-//         if entity == Entity::root() {
-//             continue;
-//         }
+        if tree.is_ignored(entity) {
+            continue;
+        }
 
-//         let parent= entity.parent(tree).unwrap();
+        let parent = tree.get_layout_parent(entity).unwrap();
 
-//         let parent_abilities = cx.cache().abilities.get(parent).cloned().unwrap_or_default();
-
-//         if !cx.style().abilities.get(parent).contains(Abilities::HOVERABLE) {
-//             if let Some(abilities) = cx.style().abilities.get_mut(entity) {
-//                 abilities.set(Abilities::HOVERABLE, false);
-//             }
-//         }
-
-//         if cx.cache().get_visibility(parent) == Visibility::Invisible {
-//             cx.cache().set_visibility(entity, Visibility::Invisible);
-//         } else {
-//             if let Some(visibility) = cx.style().visibility.get(entity) {
-//                 cx.cache().set_visibility(entity, *visibility);
-//             } else {
-//                 cx.cache().set_visibility(entity, Visibility::Visible);
-//             }
-//         }
-//     }
-// }
+        if !cx.cache.get_hoverability(parent) {
+            cx.cache.set_hoverability(entity, false);
+        } else {
+            if let Some(abilities) = cx.style.abilities.get(entity) {
+                cx.cache.set_hoverability(entity, abilities.contains(Abilities::HOVERABLE));
+            } else {
+                cx.cache.set_hoverability(entity, false);
+            }
+        }
+    }
+}
 
 // Returns the selector of an entity
 fn entity_selector(cx: &Context, entity: Entity) -> Selector {
@@ -506,6 +501,8 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 // Iterate tree and determine the matched style rules for each entity. Link the entity to the style data.
 pub fn style_system(cx: &mut Context, tree: &Tree<Entity>) {
     if cx.style.needs_restyle {
+        hoverability_system(cx, tree);
+
         let mut prev_entity = None;
 
         let mut matched_rule_ids = Vec::with_capacity(100);

--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -82,6 +82,7 @@ impl Button {
             .build(cx, move |cx| {
                 (content)(cx).hoverable(false);
             })
+            .cursor(CursorIcon::Hand)
             .keyboard_navigatable(true)
     }
 }


### PR DESCRIPTION
This means that children of a container which is marked non-hoverable will also be non-hoverable. Allows for the cursor icon to be set for a button, even when it contains multiple descendent views, such as a label + icon.