### PR TITLE
fix on_release never happening

### DIFF
--- a/crates/vizia_core/src/modifiers/actions.rs
+++ b/crates/vizia_core/src/modifiers/actions.rs
@@ -102,7 +102,7 @@ impl<V: View> View for Release<V> {
         self.view.event(cx, event);
 
         event.map(|window_event, meta| match window_event {
-            WindowEvent::TriggerDown { .. } => {
+            WindowEvent::TriggerUp { .. } => {
                 if meta.target == cx.current() {
                     if let Some(action) = &self.action {
                         (action)(cx);


### PR DESCRIPTION
Changing `MouseEnter` [here](https://github.com/vizia/vizia/blob/main/crates/vizia_core/src/modifiers/actions.rs#L163) to `MouseOver` seems to fix `on_hover` too, but from reading what it should do, I'd think something's wrong in [hover.rs](https://github.com/vizia/vizia/blob/main/crates/vizia_core/src/systems/hover.rs).