### PR TITLE
Split modifiers into separate traits

### DIFF
--- a/crates/vizia_core/src/handle.rs
+++ b/crates/vizia_core/src/handle.rs
@@ -382,55 +382,55 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
-    pub fn grid_rows(self, rows: Vec<Units>) -> Self {
-        self.cx.style.grid_rows.insert(self.entity, rows);
+    // pub fn grid_rows(self, rows: Vec<Units>) -> Self {
+    //     self.cx.style.grid_rows.insert(self.entity, rows);
 
-        self
-    }
+    //     self
+    // }
 
-    pub fn grid_cols(self, cols: Vec<Units>) -> Self {
-        self.cx.style.grid_cols.insert(self.entity, cols);
+    // pub fn grid_cols(self, cols: Vec<Units>) -> Self {
+    //     self.cx.style.grid_cols.insert(self.entity, cols);
 
-        self
-    }
+    //     self
+    // }
 
     set_style!(background_color, Color);
     set_style!(background_image, String);
 
-    set_style!(layout_type, LayoutType);
-    set_style!(position_type, PositionType);
+    // set_style!(layout_type, LayoutType);
+    // set_style!(position_type, PositionType);
 
-    set_style!(left, Units);
-    set_style!(right, Units);
-    set_style!(top, Units);
-    set_style!(bottom, Units);
-    set_style!(width, Units);
-    set_style!(height, Units);
+    // set_style!(left, Units);
+    // set_style!(right, Units);
+    // set_style!(top, Units);
+    // set_style!(bottom, Units);
+    // set_style!(width, Units);
+    // set_style!(height, Units);
 
-    set_style!(min_width, Units);
-    set_style!(max_width, Units);
-    set_style!(min_height, Units);
-    set_style!(max_height, Units);
+    // set_style!(min_width, Units);
+    // set_style!(max_width, Units);
+    // set_style!(min_height, Units);
+    // set_style!(max_height, Units);
 
-    set_style!(min_left, Units);
-    set_style!(max_left, Units);
-    set_style!(min_right, Units);
-    set_style!(max_right, Units);
-    set_style!(min_top, Units);
-    set_style!(max_top, Units);
-    set_style!(min_bottom, Units);
-    set_style!(max_bottom, Units);
+    // set_style!(min_left, Units);
+    // set_style!(max_left, Units);
+    // set_style!(min_right, Units);
+    // set_style!(max_right, Units);
+    // set_style!(min_top, Units);
+    // set_style!(max_top, Units);
+    // set_style!(min_bottom, Units);
+    // set_style!(max_bottom, Units);
 
-    set_style!(child_left, Units);
-    set_style!(child_right, Units);
-    set_style!(child_top, Units);
-    set_style!(child_bottom, Units);
-    set_style!(row_between, Units);
-    set_style!(col_between, Units);
-    set_style!(row_index, usize);
-    set_style!(row_span, usize);
-    set_style!(col_index, usize);
-    set_style!(col_span, usize);
+    // set_style!(child_left, Units);
+    // set_style!(child_right, Units);
+    // set_style!(child_top, Units);
+    // set_style!(child_bottom, Units);
+    // set_style!(row_between, Units);
+    // set_style!(col_between, Units);
+    // set_style!(row_index, usize);
+    // set_style!(row_span, usize);
+    // set_style!(col_index, usize);
+    // set_style!(col_span, usize);
 
     set_style!(border_width, Units);
     set_style!(border_color, Color);

--- a/crates/vizia_core/src/handle.rs
+++ b/crates/vizia_core/src/handle.rs
@@ -1,44 +1,19 @@
 use std::marker::PhantomData;
 
-use morphorm::{LayoutType, PositionType, Units};
-
 use vizia_id::GenerationalId;
 
 use crate::prelude::*;
-use crate::text::Selection;
-
-macro_rules! set_style {
-    ($name:ident, $t:ty) => {
-        pub fn $name(self, value: impl Res<$t>) -> Self {
-            value.set_or_bind(self.cx, self.entity, |cx, entity, v| {
-                cx.style.$name.insert(entity, v.into());
-
-                // TODO - Split this out
-                cx.need_relayout();
-                cx.need_redraw();
-            });
-
-            // self.cx.style().$name.insert(self.entity, value.get_val(self.cx).into());
-
-            // // TODO - Split this out
-            // self.cx.need_relayout();
-            // self.cx.need_redraw();
-
-            self
-        }
-    };
-}
 
 /// A handle to a view which has been already built into the tree.
 ///
 /// This type is part of the prelude.
-pub struct Handle<'a, T> {
+pub struct Handle<'a, V> {
     pub entity: Entity,
-    pub p: PhantomData<T>,
+    pub p: PhantomData<V>,
     pub cx: &'a mut Context,
 }
 
-impl<'a, T> Handle<'a, T> {
+impl<'a, V> Handle<'a, V> {
     pub fn entity(&self) -> Entity {
         self.entity
     }
@@ -64,14 +39,14 @@ impl<'a, T> Handle<'a, T> {
 
     pub fn modify<F>(self, f: F) -> Self
     where
-        F: FnOnce(&mut T),
-        T: 'static,
+        F: FnOnce(&mut V),
+        V: 'static,
     {
         if let Some(view) = self
             .cx
             .views
             .get_mut(&self.entity)
-            .and_then(|view_handler| view_handler.downcast_mut::<T>())
+            .and_then(|view_handler| view_handler.downcast_mut::<V>())
         {
             (f)(view);
         }
@@ -79,7 +54,7 @@ impl<'a, T> Handle<'a, T> {
         self
     }
 
-    /// Callback which is run when the view is built/rebuilt
+    /// Callback which is run when the view is built/rebuilt.
     pub fn on_build<F>(self, callback: F) -> Self
     where
         F: Fn(&mut EventContext),
@@ -95,7 +70,7 @@ impl<'a, T> Handle<'a, T> {
     where
         L: Lens,
         <L as Lens>::Target: Data,
-        F: 'static + Fn(Handle<'_, T>, L),
+        F: 'static + Fn(Handle<'_, V>, L),
     {
         let entity = self.entity();
         Binding::new(self.cx, lens, move |cx, data| {
@@ -106,359 +81,4 @@ impl<'a, T> Handle<'a, T> {
         });
         self
     }
-
-    pub fn id(self, id: impl Into<String>) -> Self {
-        let id = id.into();
-        self.cx.style.ids.insert(self.entity, id.clone()).expect("Could not insert id");
-        self.cx.need_restyle();
-
-        self.cx.entity_identifiers.insert(id, self.entity);
-
-        self
-    }
-
-    pub fn cursor(self, cursor_icon: CursorIcon) -> Self {
-        self.cx.style.cursor.insert(self.entity, cursor_icon);
-
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn class(self, name: &str) -> Self {
-        if let Some(class_list) = self.cx.style.classes.get_mut(self.entity) {
-            class_list.insert(name.to_string());
-        }
-
-        self.cx.need_restyle();
-
-        self
-    }
-
-    pub fn toggle_class(self, name: &str, applied: impl Res<bool>) -> Self {
-        let name = name.to_owned();
-        applied.set_or_bind(self.cx, self.entity, move |cx, entity, applied| {
-            if let Some(class_list) = cx.style.classes.get_mut(entity) {
-                if applied {
-                    class_list.insert(name.clone());
-                } else {
-                    class_list.remove(&name);
-                }
-            }
-
-            cx.need_restyle();
-        });
-
-        self
-    }
-
-    pub fn font(self, font_name: &str) -> Self {
-        self.cx.style.font.insert(self.entity, font_name.to_owned());
-
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn checked(self, state: impl Res<bool>) -> Self {
-        state.set_or_bind(self.cx, self.entity, |cx, entity, val| {
-            if let Some(pseudo_classes) = cx.style.pseudo_classes.get_mut(entity) {
-                pseudo_classes.set(PseudoClass::CHECKED, val);
-            } else {
-                let mut pseudoclass = PseudoClass::empty();
-                pseudoclass.set(PseudoClass::CHECKED, val);
-                cx.style.pseudo_classes.insert(entity, pseudoclass).unwrap();
-            }
-
-            cx.need_restyle();
-        });
-
-        // let state = state.get_val(self.cx);
-        // if let Some(pseudo_classes) = self.cx.style().pseudo_classes.get_mut(self.entity) {
-        //     pseudo_classes.set(PseudoClass::CHECKED, state);
-        // } else {
-        //     let mut pseudoclass = PseudoClass::empty();
-        //     pseudoclass.set(PseudoClass::CHECKED, state);
-        //     self.cx.style().pseudo_classes.insert(self.entity, pseudoclass).unwrap();
-        // }
-
-        // self.cx.need_restyle();
-
-        self
-    }
-
-    pub fn disabled(self, state: impl Res<bool>) -> Self {
-        state.set_or_bind(self.cx, self.entity, |cx, entity, val| {
-            cx.style.disabled.insert(entity, val);
-            cx.need_restyle();
-        });
-
-        self
-    }
-
-    pub fn text<U: ToString>(self, value: impl Res<U>) -> Self {
-        value.set_or_bind(self.cx, self.entity, |cx, entity, val| {
-            if let Some(prev_data) = cx.style.text.get(entity) {
-                if prev_data != &val.to_string() {
-                    cx.style.text.insert(entity, val.to_string());
-
-                    cx.need_relayout();
-                    cx.need_redraw();
-                }
-            } else {
-                cx.style.text.insert(entity, val.to_string());
-
-                cx.need_relayout();
-                cx.need_redraw();
-            }
-        });
-
-        self
-    }
-
-    pub fn image<U: ToString>(self, value: impl Res<U>) -> Self {
-        value.set_or_bind(self.cx, self.entity, |cx, entity, val| {
-            let val = val.to_string();
-            if let Some(prev_data) = cx.style.image.get(entity) {
-                if prev_data != &val {
-                    cx.style.image.insert(entity, val);
-
-                    cx.need_redraw();
-                }
-            } else {
-                cx.style.image.insert(entity, val);
-
-                cx.need_redraw();
-            }
-        });
-
-        self
-    }
-
-    pub fn z_order(self, value: i32) -> Self {
-        self.cx.style.z_order.insert(self.entity, value);
-
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn overflow(self, value: Overflow) -> Self {
-        self.cx.style.overflow.insert(self.entity, value);
-
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn display<U: Clone + Into<Display>>(self, value: impl Res<U>) -> Self {
-        value.set_or_bind(self.cx, self.entity, |cx, entity, val| {
-            cx.style.display.insert(entity, val.into());
-
-            cx.need_relayout();
-            cx.need_redraw();
-        });
-
-        self
-    }
-
-    pub fn visibility<U: Clone + Into<Visibility>>(self, value: impl Res<U>) -> Self {
-        value.set_or_bind(self.cx, self.entity, move |cx, entity, v| {
-            cx.style.visibility.insert(entity, v.into());
-
-            cx.need_redraw();
-        });
-
-        self
-    }
-
-    // Abilities
-    pub fn hoverable(self, state: bool) -> Self {
-        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
-            abilities.set(Abilities::HOVERABLE, state);
-        }
-
-        self.cx.need_restyle();
-
-        self
-    }
-
-    pub fn focusable(self, state: bool) -> Self {
-        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
-            abilities.set(Abilities::FOCUSABLE, state);
-            // If an element is not focusable then it can't be keyboard navigatable
-            if !state {
-                abilities.set(Abilities::KEYBOARD_NAVIGATABLE, false);
-            }
-        }
-
-        self.cx.need_restyle();
-
-        self
-    }
-
-    pub fn keyboard_navigatable(self, state: bool) -> Self {
-        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
-            abilities.set(Abilities::KEYBOARD_NAVIGATABLE, state);
-            if state {
-                // If an element is keyboard navigatable then it must be focusable
-                abilities.set(Abilities::FOCUSABLE, state);
-            }
-        }
-
-        self.cx.need_restyle();
-
-        self
-    }
-
-    pub fn child_space(self, value: Units) -> Self {
-        self.cx.style.child_left.insert(self.entity, value);
-        self.cx.style.child_right.insert(self.entity, value);
-        self.cx.style.child_top.insert(self.entity, value);
-        self.cx.style.child_bottom.insert(self.entity, value);
-
-        self.cx.need_relayout();
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn border_radius(self, value: Units) -> Self {
-        self.cx.style.border_radius_top_left.insert(self.entity, value);
-        self.cx.style.border_radius_top_right.insert(self.entity, value);
-        self.cx.style.border_radius_bottom_left.insert(self.entity, value);
-        self.cx.style.border_radius_bottom_right.insert(self.entity, value);
-
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn space(self, value: Units) -> Self {
-        self.cx.style.left.insert(self.entity, value);
-        self.cx.style.right.insert(self.entity, value);
-        self.cx.style.top.insert(self.entity, value);
-        self.cx.style.bottom.insert(self.entity, value);
-
-        self.cx.need_relayout();
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn size(self, value: Units) -> Self {
-        self.cx.style.width.insert(self.entity, value);
-        self.cx.style.height.insert(self.entity, value);
-
-        self.cx.need_relayout();
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn min_size(self, value: Units) -> Self {
-        self.cx.style.min_width.insert(self.entity, value);
-        self.cx.style.min_height.insert(self.entity, value);
-
-        self.cx.need_relayout();
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn max_size(self, value: Units) -> Self {
-        self.cx.style.max_width.insert(self.entity, value);
-        self.cx.style.max_height.insert(self.entity, value);
-
-        self.cx.need_relayout();
-        self.cx.need_redraw();
-
-        self
-    }
-
-    pub fn color(self, color: Color) -> Self {
-        self.cx.style.font_color.insert(self.entity, color);
-
-        self
-    }
-
-    // pub fn grid_rows(self, rows: Vec<Units>) -> Self {
-    //     self.cx.style.grid_rows.insert(self.entity, rows);
-
-    //     self
-    // }
-
-    // pub fn grid_cols(self, cols: Vec<Units>) -> Self {
-    //     self.cx.style.grid_cols.insert(self.entity, cols);
-
-    //     self
-    // }
-
-    set_style!(background_color, Color);
-    set_style!(background_image, String);
-
-    // set_style!(layout_type, LayoutType);
-    // set_style!(position_type, PositionType);
-
-    // set_style!(left, Units);
-    // set_style!(right, Units);
-    // set_style!(top, Units);
-    // set_style!(bottom, Units);
-    // set_style!(width, Units);
-    // set_style!(height, Units);
-
-    // set_style!(min_width, Units);
-    // set_style!(max_width, Units);
-    // set_style!(min_height, Units);
-    // set_style!(max_height, Units);
-
-    // set_style!(min_left, Units);
-    // set_style!(max_left, Units);
-    // set_style!(min_right, Units);
-    // set_style!(max_right, Units);
-    // set_style!(min_top, Units);
-    // set_style!(max_top, Units);
-    // set_style!(min_bottom, Units);
-    // set_style!(max_bottom, Units);
-
-    // set_style!(child_left, Units);
-    // set_style!(child_right, Units);
-    // set_style!(child_top, Units);
-    // set_style!(child_bottom, Units);
-    // set_style!(row_between, Units);
-    // set_style!(col_between, Units);
-    // set_style!(row_index, usize);
-    // set_style!(row_span, usize);
-    // set_style!(col_index, usize);
-    // set_style!(col_span, usize);
-
-    set_style!(border_width, Units);
-    set_style!(border_color, Color);
-
-    set_style!(font_size, f32);
-    set_style!(text_selection, Selection);
-    set_style!(caret_color, Color);
-    set_style!(selection_color, Color);
-    set_style!(text_wrap, bool);
-
-    //set_style!(display, Display);
-    //set_style!(visibility, Visibility);
-
-    set_style!(rotate, f32);
-    set_style!(translate, (f32, f32));
-    set_style!(scale, (f32, f32));
-
-    set_style!(border_shape_top_left, BorderCornerShape);
-    set_style!(border_shape_top_right, BorderCornerShape);
-    set_style!(border_shape_bottom_left, BorderCornerShape);
-    set_style!(border_shape_bottom_right, BorderCornerShape);
-
-    set_style!(border_radius_top_left, Units);
-    set_style!(border_radius_top_right, Units);
-    set_style!(border_radius_bottom_left, Units);
-    set_style!(border_radius_bottom_right, Units);
-
-    set_style!(outline_width, Units);
-    set_style!(outline_color, Color);
-    set_style!(outline_offset, Units);
 }

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -48,7 +48,7 @@ pub mod prelude {
     pub use super::handle::Handle;
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;
-    pub use super::modifiers::ActionModifiers;
+    pub use super::modifiers::{ActionModifiers, LayoutModifiers};
     pub use super::state::{Binding, Data, Lens, LensExt, Model, Res, Setter};
     pub use super::view::{Canvas, View};
     pub use super::views::*;

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -48,7 +48,9 @@ pub mod prelude {
     pub use super::handle::Handle;
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::localization::Localized;
-    pub use super::modifiers::{ActionModifiers, LayoutModifiers};
+    pub use super::modifiers::{
+        AbilityModifiers, ActionModifiers, LayoutModifiers, StyleModifiers, TextModifiers,
+    };
     pub use super::state::{Binding, Data, Lens, LensExt, Model, Res, Setter};
     pub use super::view::{Canvas, View};
     pub use super::views::*;

--- a/crates/vizia_core/src/modifiers/abilities.rs
+++ b/crates/vizia_core/src/modifiers/abilities.rs
@@ -1,0 +1,58 @@
+use super::internal;
+use crate::prelude::*;
+
+/// Modifiers for changing the abilities of a view.
+pub trait AbilityModifiers: internal::Modifiable {
+    /// Sets whether the view can be hovered by the mouse.
+    ///
+    /// Views which cannot be hovered will not receive mouse input events unless
+    /// the view has captured the mouse input, see [`cx.capture()`](crate::prelude::EventContext::capture).
+    fn hoverable<U: Into<bool>>(mut self, state: impl Res<U>) -> Self {
+        let entity = self.entity();
+        state.set_or_bind(self.context(), entity, |cx, entity, v| {
+            if let Some(abilities) = cx.style.abilities.get_mut(entity) {
+                abilities.set(Abilities::HOVERABLE, v.into());
+                cx.need_restyle();
+            }
+        });
+
+        self
+    }
+
+    /// Sets whether the view can be focused to receive keyboard input events.
+    fn focusable<U: Into<bool>>(mut self, state: impl Res<U>) -> Self {
+        let entity = self.entity();
+        state.set_or_bind(self.context(), entity, |cx, entity, v| {
+            if let Some(abilities) = cx.style.abilities.get_mut(entity) {
+                let state = v.into();
+                abilities.set(Abilities::FOCUSABLE, state);
+
+                // If an element is not focusable then it can't be keyboard navigable.
+                if !state {
+                    abilities.set(Abilities::NAVIGABLE, false);
+                }
+
+                cx.need_restyle();
+            }
+        });
+
+        self
+    }
+
+    /// Sets whether the view can be navigated to, i.e. focused, by the keyboard.
+    ///
+    /// Navigating to a view with the keyboard gives the view keyboard focus and is typically done with `tab` and `shift + tab` key combinations.
+    fn navigable<U: Into<bool>>(mut self, state: impl Res<U>) -> Self {
+        let entity = self.entity();
+        state.set_or_bind(self.context(), entity, |cx, entity, v| {
+            if let Some(abilities) = cx.style.abilities.get_mut(entity) {
+                abilities.set(Abilities::NAVIGABLE, v.into());
+                cx.need_restyle();
+            }
+        });
+
+        self
+    }
+}
+
+impl<'a, V> AbilityModifiers for Handle<'a, V> {}

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -1,6 +1,5 @@
-use crate::prelude::*;
-
 use super::internal;
+use crate::prelude::*;
 
 /// Modifiers for changing the layout properties of a view.
 pub trait LayoutModifiers: internal::Modifiable {
@@ -99,9 +98,39 @@ pub trait LayoutModifiers: internal::Modifiable {
 
     modifier!(bottom, Units);
 
+    fn space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.left.insert(entity, value);
+            cx.style.right.insert(entity, value);
+            cx.style.top.insert(entity, value);
+            cx.style.bottom.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
+
     modifier!(width, Units);
 
     modifier!(height, Units);
+
+    fn size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.width.insert(entity, value);
+            cx.style.height.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
 
     modifier!(child_left, Units);
 
@@ -111,33 +140,109 @@ pub trait LayoutModifiers: internal::Modifiable {
 
     modifier!(child_bottom, Units);
 
+    fn child_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.child_left.insert(entity, value);
+            cx.style.child_right.insert(entity, value);
+            cx.style.child_top.insert(entity, value);
+            cx.style.child_bottom.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
+
     modifier!(row_between, Units);
 
     modifier!(col_between, Units);
 
     modifier!(min_width, Units);
 
-    modifier!(max_width, Units);
-
     modifier!(min_height, Units);
+
+    fn min_size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.min_width.insert(entity, value);
+            cx.style.min_height.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
+
+    modifier!(max_width, Units);
 
     modifier!(max_height, Units);
 
-    modifier!(min_left, Units);
+    fn max_size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.max_width.insert(entity, value);
+            cx.style.max_height.insert(entity, value);
 
-    modifier!(max_left, Units);
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
+
+    modifier!(min_left, Units);
 
     modifier!(min_right, Units);
 
-    modifier!(max_right, Units);
-
     modifier!(min_top, Units);
-
-    modifier!(max_top, Units);
 
     modifier!(min_bottom, Units);
 
+    fn min_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.min_left.insert(entity, value);
+            cx.style.min_right.insert(entity, value);
+            cx.style.min_top.insert(entity, value);
+            cx.style.min_bottom.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
+
+    modifier!(max_left, Units);
+
+    modifier!(max_right, Units);
+
+    modifier!(max_top, Units);
+
     modifier!(max_bottom, Units);
+
+    fn max_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.max_left.insert(entity, value);
+            cx.style.max_right.insert(entity, value);
+            cx.style.max_top.insert(entity, value);
+            cx.style.max_bottom.insert(entity, value);
+
+            cx.need_relayout();
+            cx.need_redraw();
+        });
+
+        self
+    }
 
     fn grid_rows(mut self, rows: Vec<Units>) -> Self {
         let entity = self.entity();

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -94,10 +94,47 @@ pub trait LayoutModifiers: internal::Modifiable {
         Units
     );
 
-    modifier!(top, Units);
+    modifier!(
+        /// Sets the space on the top side of the view.
+        ///
+        /// The top space, along with the bottom space, determines the vertical position of a view.
+        ///
+        /// - `Units::Pixels(...)` - The top space will be a fixed number of points. This will scale with the DPI of the target display.
+        /// - `Units::Percentage(...)` - The top space will be a proportion of the parent width.
+        /// - `Units::Stretch(...)` - The top space will be a ratio of the remaining free space, see [`Units`](crate::prelude::Units).
+        /// - `Units::Auto` - The top space will be determined by the parent `child-left`, see [`child_left`](crate::prelude::LayoutModifiers::left).
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// Element::new(cx).top(Units::Pixels(100.0));
+        /// ```
+        top,
+        Units
+    );
 
-    modifier!(bottom, Units);
+    modifier!(
+        /// Sets the space on the bottom side of the view.
+        ///
+        /// The bottom space, along with the top space, determines the vertical position of a view.
+        ///
+        /// - `Units::Pixels(...)` - The bottom space will be a fixed number of points. This will scale with the DPI of the target display.
+        /// - `Units::Percentage(...)` - The bottom space will be a proportion of the parent width.
+        /// - `Units::Stretch(...)` - The bottom space will be a ratio of the remaining free space, see [`Units`](crate::prelude::Units).
+        /// - `Units::Auto` - The bottom space will be determined by the parent `child-left`, see [`child_left`](crate::prelude::LayoutModifiers::left).
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// Element::new(cx).bottom(Units::Pixels(100.0));
+        /// ```
+        bottom,
+        Units
+    );
 
+    /// Sets the space for all sides of the view.
     fn space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -114,10 +151,19 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(width, Units);
+    modifier!(
+        /// Sets the width of the view.
+        width,
+        Units
+    );
 
-    modifier!(height, Units);
+    modifier!(
+        /// Sets the height of the view.
+        height,
+        Units
+    );
 
+    /// Sets the width and height of the view.
     fn size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -132,14 +178,41 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(child_left, Units);
+    modifier!(
+        /// Sets the space between the left side of the view and the left side of its children.
+        ///
+        /// Applies only to child views which have a `left` property set to `Auto`.
+        child_left,
+        Units
+    );
 
-    modifier!(child_right, Units);
+    modifier!(
+        /// Sets the space between the right side of the view and the right side of its children.
+        ///
+        /// Applies only to child views which have a `right` property set to `Auto`.
+        child_right,
+        Units
+    );
 
-    modifier!(child_top, Units);
+    modifier!(
+        /// Sets the space between the top side of the view and the top side of its children.
+        ///
+        /// Applies only to child views which have a `top` property set to `Auto`.
+        child_top,
+        Units
+    );
 
-    modifier!(child_bottom, Units);
+    modifier!(
+        /// Sets the space between the bottom side of the view and the bottom side of its children.
+        ///
+        /// Applies only to child views which have a `bottom` property set to `Auto`.
+        child_bottom,
+        Units
+    );
 
+    /// Sets the space between the vew and its children.
+    ///
+    /// The child_space works by overriding the `Auto` space properties of its children.
     fn child_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -156,14 +229,31 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(row_between, Units);
+    modifier!(
+        /// Sets the space between the views children in a vertical stack.
+        row_between,
+        Units
+    );
 
-    modifier!(col_between, Units);
+    modifier!(
+        /// Sets the space between the views children in a horizontal stack.
+        col_between,
+        Units
+    );
 
-    modifier!(min_width, Units);
+    modifier!(
+        /// Sets the minimum width of the view.
+        min_width,
+        Units
+    );
 
-    modifier!(min_height, Units);
+    modifier!(
+        /// Sets the minimum height of the view.
+        min_height,
+        Units
+    );
 
+    /// Sets the minimum width and minimum height of the view.
     fn min_size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -178,10 +268,19 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(max_width, Units);
+    modifier!(
+        /// Sets the maximum width of the view.
+        max_width,
+        Units
+    );
 
-    modifier!(max_height, Units);
+    modifier!(
+        /// Sets the maximum height of the view.
+        max_height,
+        Units
+    );
 
+    /// Sets the maximum width and maximum height of the view.
     fn max_size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -196,14 +295,31 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(min_left, Units);
+    modifier!(
+        /// Sets the minimum left space of the view.
+        min_left,
+        Units
+    );
 
-    modifier!(min_right, Units);
+    modifier!(
+        /// Sets the minimum right space of the view.
+        min_right,
+        Units
+    );
 
-    modifier!(min_top, Units);
+    modifier!(
+        /// Sets the minimum top space of the view.
+        min_top,
+        Units
+    );
 
-    modifier!(min_bottom, Units);
+    modifier!(
+        /// Sets the minimum bottom space of the view.
+        min_bottom,
+        Units
+    );
 
+    /// Sets the minimum space for all sides of the view.
     fn min_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -220,14 +336,31 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(max_left, Units);
+    modifier!(
+        /// Sets the maximum left space of the view.
+        max_left,
+        Units
+    );
 
-    modifier!(max_right, Units);
+    modifier!(
+        /// Sets the maximum right space of the view.
+        max_right,
+        Units
+    );
 
-    modifier!(max_top, Units);
+    modifier!(
+        /// Sets the maximum top space of the view.
+        max_top,
+        Units
+    );
 
-    modifier!(max_bottom, Units);
+    modifier!(
+        /// Sets the maximum bottom space of the view.
+        max_bottom,
+        Units
+    );
 
+    /// Sets the maximum space for all sides of the view.
     fn max_space<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, v| {
@@ -244,6 +377,7 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
+    /// Sets the grid rows of the view.
     fn grid_rows(mut self, rows: Vec<Units>) -> Self {
         let entity = self.entity();
         self.context().style.grid_rows.insert(entity, rows);
@@ -251,6 +385,7 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
+    /// Sets the grid columns of the view.
     fn grid_cols(mut self, cols: Vec<Units>) -> Self {
         let entity = self.entity();
         self.context().style.grid_cols.insert(entity, cols);
@@ -258,10 +393,34 @@ pub trait LayoutModifiers: internal::Modifiable {
         self
     }
 
-    modifier!(row_index, usize);
-    modifier!(row_span, usize);
-    modifier!(col_index, usize);
-    modifier!(col_span, usize);
+    modifier!(
+        /// Sets the grid row index of the view.
+        ///
+        /// This index relates to the grid rows of the parent view when the parent layout type is set to `Grid`.
+        row_index,
+        usize
+    );
+    modifier!(
+        /// Sets the grid row span of the view.
+        ///
+        /// This relates to the range of occupied grid rows of the parent view when the parent layout type is set to `Grid`.
+        row_span,
+        usize
+    );
+    modifier!(
+        /// Sets the grid column index of the view.
+        ///
+        /// This index relates to the grid columns of the parent view when the parent layout type is set to `Grid`.
+        col_index,
+        usize
+    );
+    modifier!(
+        /// Sets the grid column span of the view.
+        ///
+        /// This relates to the range of occupied grid columns of the parent view when the parent layout type is set to `Grid`.
+        col_span,
+        usize
+    );
 }
 
 impl<'a, V: View> LayoutModifiers for Handle<'a, V> {}

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -1,0 +1,162 @@
+use crate::prelude::*;
+
+use super::internal;
+
+/// Modifiers for changing the layout properties of a view.
+pub trait LayoutModifiers: internal::Modifiable {
+    modifier!(
+        /// Sets the layout type of the view.
+        ///
+        /// The layout type controls how a parent will position any children which have `PositionType::ParentDirected`.
+        /// Accepts any value, or lens to a target, with a type which can be converted into `LayoutType`.
+        ///
+        /// There are three variants:
+        /// - `LayoutType::Row` - Parent will stack its children horizontally.
+        /// - `LayoutType::Column` - (default) Parent will stack its children vertically.
+        /// - `LayoutType::Grid` - The position of children is determine by the grid properties.
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// #[derive(Lens, Model, Setter)]
+        /// pub struct AppData {
+        ///     layout_type: LayoutType,
+        /// }
+        ///
+        /// # AppData {
+        /// #   layout_type: LayoutType::Row,
+        /// # }.build(cx);
+        ///
+        /// Element::new(cx).layout_type(LayoutType::Row);  // Value of type `LayoutType`.
+        /// Element::new(cx).layout_type(AppData::layout_type); // Lens to target of type `LayoutType`.
+        /// ```
+        layout_type,
+        LayoutType
+    );
+
+    modifier!(
+        /// Sets the position type of the view.
+        ///
+        /// The position type determines how a child will be positioned within a parent.
+        ///
+        /// - `PositionType::ParentDirected` - The child will be positioned relative to its siblings in a stack
+        /// (if parent layout type is `Row` or `Column`), or relative to its grid position (if parent layout type is `Grid`).
+        /// - `PositionType::SelfDirected` - The child will be positioned relative to the top-left corner of its parents bounding box
+        /// and will ignore its siblings or grid position. This is approximately equivalent to absolute positioning.
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// Element::new(cx).position_type(PositionType::SelfDirected);
+        /// ```
+        position_type,
+        PositionType
+    );
+
+    modifier!(
+        /// Sets the space on the left side of the view.
+        ///
+        /// The left space, along with the right space, determines the horizontal position of a view.
+        ///
+        /// - `Units::Pixels(...)` - The left space will be a fixed number of points. This will scale with the DPI of the target display.
+        /// - `Units::Percentage(...)` - The left space will be a proportion of the parent width.
+        /// - `Units::Stretch(...)` - The left space will be a ratio of the remaining free space, see [`Units`](crate::prelude::Units).
+        /// - `Units::Auto` - The left space will be determined by the parent `child-left`, see [`child_left`](crate::prelude::LayoutModifiers::left).
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// Element::new(cx).left(Units::Pixels(100.0));
+        /// ```
+        left,
+        Units
+    );
+
+    modifier!(
+        /// Sets the space on the right side of the view.
+        ///
+        /// The right space, along with the left space, determines the horizontal position of a view.
+        ///
+        /// - `Units::Pixels(...)` - The right space will be a fixed number of points. This will scale with the DPI of the target display.
+        /// - `Units::Percentage(...)` - The right space will be a proportion of the parent width.
+        /// - `Units::Stretch(...)` - The right space will be a ratio of the remaining free space, see [`Units`](crate::prelude::Units).
+        /// - `Units::Auto` - The right space will be determined by the parent `child-left`, see [`child_left`](crate::prelude::LayoutModifiers::left).
+        ///
+        /// # Example
+        /// ```
+        /// # use vizia_core::prelude::*;
+        /// # let cx = &mut Context::new();
+        /// Element::new(cx).right(Units::Pixels(100.0));
+        /// ```
+        right,
+        Units
+    );
+
+    modifier!(top, Units);
+
+    modifier!(bottom, Units);
+
+    modifier!(width, Units);
+
+    modifier!(height, Units);
+
+    modifier!(child_left, Units);
+
+    modifier!(child_right, Units);
+
+    modifier!(child_top, Units);
+
+    modifier!(child_bottom, Units);
+
+    modifier!(row_between, Units);
+
+    modifier!(col_between, Units);
+
+    modifier!(min_width, Units);
+
+    modifier!(max_width, Units);
+
+    modifier!(min_height, Units);
+
+    modifier!(max_height, Units);
+
+    modifier!(min_left, Units);
+
+    modifier!(max_left, Units);
+
+    modifier!(min_right, Units);
+
+    modifier!(max_right, Units);
+
+    modifier!(min_top, Units);
+
+    modifier!(max_top, Units);
+
+    modifier!(min_bottom, Units);
+
+    modifier!(max_bottom, Units);
+
+    fn grid_rows(mut self, rows: Vec<Units>) -> Self {
+        let entity = self.entity();
+        self.context().style.grid_rows.insert(entity, rows);
+        self.context().need_relayout();
+        self
+    }
+
+    fn grid_cols(mut self, cols: Vec<Units>) -> Self {
+        let entity = self.entity();
+        self.context().style.grid_cols.insert(entity, cols);
+        self.context().need_relayout();
+        self
+    }
+
+    modifier!(row_index, usize);
+    modifier!(row_span, usize);
+    modifier!(col_index, usize);
+    modifier!(col_span, usize);
+}
+
+impl<'a, V: View> LayoutModifiers for Handle<'a, V> {}

--- a/crates/vizia_core/src/modifiers/mod.rs
+++ b/crates/vizia_core/src/modifiers/mod.rs
@@ -1,4 +1,53 @@
-// Need better name for this module
+//! Methods on views for changing their style properties or for adding actions.
+
+// Macro used within modifier traits to set style properties.
+macro_rules! modifier {
+    (
+        $(#[$meta:meta])*
+        $name:ident, $t:ty
+    ) => {
+        $(#[$meta])*
+        #[allow(unused_variables)]
+        fn $name<U: Into<$t>>(mut self, value: impl Res<U>) -> Self {
+            let entity = self.entity();
+            value.set_or_bind(self.context(), entity, |cx, entity, v| {
+                cx.style.$name.insert(entity, v.into());
+
+                cx.need_relayout();
+                cx.need_redraw();
+            });
+
+            self
+        }
+    };
+}
+
+// Inside private module to hide implementation details.
+mod internal {
+    use crate::prelude::{Context, Entity, Handle, View};
+
+    // Allows a modifier trait to access to context and entity from `self`.
+    pub trait Modifiable: Sized {
+        fn context(&mut self) -> &mut Context;
+        fn entity(&self) -> Entity;
+    }
+
+    impl<'a, V: View> Modifiable for Handle<'a, V> {
+        fn context(&mut self) -> &mut Context {
+            self.cx
+        }
+
+        fn entity(&self) -> Entity {
+            self.entity
+        }
+    }
+}
 
 mod actions;
 pub use actions::*;
+
+mod layout;
+pub use layout::*;
+
+mod style;
+pub use style::*;

--- a/crates/vizia_core/src/modifiers/mod.rs
+++ b/crates/vizia_core/src/modifiers/mod.rs
@@ -24,7 +24,7 @@ macro_rules! modifier {
 
 // Inside private module to hide implementation details.
 mod internal {
-    use crate::prelude::{Context, Entity, Handle, View};
+    use crate::prelude::{Context, Entity, Handle};
 
     // Allows a modifier trait to access to context and entity from `self`.
     pub trait Modifiable: Sized {
@@ -32,7 +32,7 @@ mod internal {
         fn entity(&self) -> Entity;
     }
 
-    impl<'a, V: View> Modifiable for Handle<'a, V> {
+    impl<'a, V> Modifiable for Handle<'a, V> {
         fn context(&mut self) -> &mut Context {
             self.cx
         }
@@ -51,3 +51,9 @@ pub use layout::*;
 
 mod style;
 pub use style::*;
+
+mod text;
+pub use text::*;
+
+mod abilities;
+pub use abilities::*;

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -1,0 +1,17 @@
+use super::internal;
+use crate::prelude::*;
+
+pub trait StyleModifiers: internal::Modifiable {
+    // Background Properties
+
+    modifier!(background_color, Color);
+
+    // Border Properties
+    modifier!(border_width, Units);
+    modifier!(border_color, Color);
+
+    modifier!(border_radius_bottom_left, Units);
+    modifier!(border_radius_bottom_right, Units);
+    modifier!(border_radius_bottom_top, Units);
+    modifier!(border_radius_bottom_bottom, Units);
+}

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -1,17 +1,296 @@
 use super::internal;
 use crate::prelude::*;
 
+/// Modifiers for changing the style properties of a view.
 pub trait StyleModifiers: internal::Modifiable {
-    // Background Properties
+    // Selectors
 
-    modifier!(background_color, Color);
+    /// Sets the ID name of the view.
+    ///
+    /// The ID name can be references by a CSS selector.
+    /// # Example
+    /// ```
+    /// # use vizia_core::prelude::*;
+    /// # let cx = &mut Context::new();
+    /// Element::new(cx).id("foo");
+    /// ```
+    /// css
+    /// ```css
+    /// #foo {
+    ///     background-color: red;
+    /// }
+    ///```
+    fn id(mut self, id: impl Into<String>) -> Self {
+        let id = id.into();
+        let entity = self.entity();
+        self.context().style.ids.insert(entity, id.clone()).expect("Could not insert id");
+        self.context().need_restyle();
+
+        self.context().entity_identifiers.insert(id, entity);
+
+        self
+    }
+
+    /// Adds a class name to the view.
+    fn class(mut self, name: &str) -> Self {
+        let entity = self.entity();
+        if let Some(class_list) = self.context().style.classes.get_mut(entity) {
+            class_list.insert(name.to_string());
+        }
+
+        self.context().need_restyle();
+
+        self
+    }
+
+    /// Sets whether a view should have the given class name.
+    fn toggle_class(mut self, name: &str, applied: impl Res<bool>) -> Self {
+        let name = name.to_owned();
+        let entity = self.entity();
+        applied.set_or_bind(self.context(), entity, move |cx, entity, applied| {
+            if let Some(class_list) = cx.style.classes.get_mut(entity) {
+                if applied {
+                    class_list.insert(name.clone());
+                } else {
+                    class_list.remove(&name);
+                }
+            }
+
+            cx.need_restyle();
+        });
+
+        self
+    }
+
+    // Pseudoclass
+    // TODO: Should these have their own modifiers trait?
+
+    /// Sets the state of the view to checked.
+    fn checked<U: Into<bool>>(mut self, state: impl Res<U>) -> Self {
+        let entity = self.entity();
+        state.set_or_bind(self.context(), entity, |cx, entity, val| {
+            if let Some(pseudo_classes) = cx.style.pseudo_classes.get_mut(entity) {
+                pseudo_classes.set(PseudoClass::CHECKED, val.into());
+            } else {
+                let mut pseudoclass = PseudoClass::empty();
+                pseudoclass.set(PseudoClass::CHECKED, val.into());
+                cx.style.pseudo_classes.insert(entity, pseudoclass).unwrap();
+            }
+
+            cx.need_restyle();
+        });
+
+        self
+    }
+
+    modifier!(
+        /// Sets the view to be disabled.
+        ///
+        /// This property is inherited by the descendants of the view.
+        disabled,
+        bool
+    );
+
+    modifier!(
+        /// Sets whether the view should be positioned and rendered.
+        ///
+        /// A display value of `Display::None` causes the view to be ignored by both layout and rendering.
+        display,
+        Display
+    );
+
+    modifier!(
+        /// Sets whether the view should be rendered.
+        ///
+        /// The layout system will still compute the size and position of an invisible view.
+        visibility,
+        Visibility
+    );
+
+    modifier!(
+        /// Sets the z-order index of the view.
+        ///
+        /// Views with a higher z-order will be rendered on top of those with a lower z-order.
+        /// Views with the same z-order are rendered in tree order.
+        z_order,
+        i32
+    );
+
+    modifier!(
+        /// Sets the overflow behavior of the view.
+        ///
+        /// The overflow behavior determines whether child views can render outside the bounds of their parent.
+        overflow,
+        Overflow
+    );
+
+    // Background Properties
+    modifier!(
+        /// Sets the background color of the view.
+        background_color,
+        Color
+    );
+    modifier!(
+        /// Sets the background image of the view.
+        ///
+        /// Background image will override any background gradient or color.
+        background_image,
+        String
+    );
+
+    fn image<U: ToString>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, val| {
+            let val = val.to_string();
+            if let Some(prev_data) = cx.style.image.get(entity) {
+                if prev_data != &val {
+                    cx.style.image.insert(entity, val);
+
+                    cx.need_redraw();
+                }
+            } else {
+                cx.style.image.insert(entity, val);
+
+                cx.need_redraw();
+            }
+        });
+
+        self
+    }
 
     // Border Properties
-    modifier!(border_width, Units);
-    modifier!(border_color, Color);
+    modifier!(
+        /// Sets the border width of the view.
+        border_width,
+        Units
+    );
 
-    modifier!(border_radius_bottom_left, Units);
-    modifier!(border_radius_bottom_right, Units);
-    modifier!(border_radius_bottom_top, Units);
-    modifier!(border_radius_bottom_bottom, Units);
+    modifier!(
+        /// Sets the border color of the view.
+        border_color,
+        Color
+    );
+
+    modifier!(
+        /// Sets the border radius for the top-left corner of the view.
+        border_radius_top_left,
+        Units
+    );
+    modifier!(
+        /// Sets the border radius for the top-right corner of the view.
+        border_radius_top_right,
+        Units
+    );
+    modifier!(
+        /// Sets the border radius for the bottom-left corner of the view.
+        border_radius_bottom_left,
+        Units
+    );
+    modifier!(
+        /// Sets the border radius for the bottom-right corner of the view.
+        border_radius_bottom_right,
+        Units
+    );
+
+    /// Sets the border radius for all four corners of the view.
+    fn border_radius<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.border_radius_top_left.insert(entity, value);
+            cx.style.border_radius_top_right.insert(entity, value);
+            cx.style.border_radius_bottom_left.insert(entity, value);
+            cx.style.border_radius_bottom_right.insert(entity, value);
+
+            cx.need_redraw();
+        });
+
+        self
+    }
+
+    modifier!(
+        /// Sets the border corner shape for the top-left corner of the view.
+        border_shape_top_left,
+        BorderCornerShape
+    );
+    modifier!(
+        /// Sets the border corner shape for the top-right corner of the view.
+        border_shape_top_right,
+        BorderCornerShape
+    );
+    modifier!(
+        /// Sets the border corner shape for the bottom-left corner of the view.
+        border_shape_bottom_left,
+        BorderCornerShape
+    );
+    modifier!(
+        /// Sets the border corner shape for the bottom-right corner of the view.
+        border_shape_bottom_right,
+        BorderCornerShape
+    );
+
+    /// Sets the border corner shape for all four corners of the view.
+    fn border_corner_shape<U: Into<BorderCornerShape>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            let value = v.into();
+            cx.style.border_shape_top_left.insert(entity, value);
+            cx.style.border_shape_top_right.insert(entity, value);
+            cx.style.border_shape_bottom_left.insert(entity, value);
+            cx.style.border_shape_bottom_right.insert(entity, value);
+
+            cx.need_redraw();
+        });
+
+        self
+    }
+
+    // Outine Properties
+    modifier!(
+        /// Sets the outline width of the view.
+        outline_width,
+        Units
+    );
+
+    modifier!(
+        /// Sets the outline color of the view.
+        outline_color,
+        Color
+    );
+    modifier!(
+        /// Sets the outline offset of the view.
+        outline_offset,
+        Units
+    );
+
+    modifier!(
+        /// Sets the mouse cursor used when the view is hovered.
+        cursor,
+        CursorIcon
+    );
+
+    // Transform Properties
+    modifier!(
+        /// Sets the angle of rotation for the view.
+        ///
+        /// Rotation applies to the rendered view and does not affect layout.
+        rotate,
+        f32
+    );
+    modifier!(
+        /// Sets the translation offset of the view.
+        ///
+        /// Translation applies to the rendered view and does not affect layout.
+        translate,
+        (f32, f32)
+    );
+    modifier!(
+        /// Sets the scale of the view.
+        ///
+        /// Scale applies to the rendered view and does not affect layout.
+        scale,
+        (f32, f32)
+    );
 }
+
+impl<'a, V: View> StyleModifiers for Handle<'a, V> {}

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -138,6 +138,7 @@ pub trait StyleModifiers: internal::Modifiable {
         String
     );
 
+    // TODO: Docs for this.
     fn image<U: ToString>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, val| {

--- a/crates/vizia_core/src/modifiers/text.rs
+++ b/crates/vizia_core/src/modifiers/text.rs
@@ -1,0 +1,79 @@
+use super::internal;
+use crate::{prelude::*, text::Selection};
+
+/// Modifiers for changing the text properties of a view.
+pub trait TextModifiers: internal::Modifiable {
+    /// Sets the text content of the view.
+    fn text<U: ToString>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, val| {
+            if let Some(prev_data) = cx.style.text.get(entity) {
+                if prev_data != &val.to_string() {
+                    cx.style.text.insert(entity, val.to_string());
+
+                    cx.need_relayout();
+                    cx.need_redraw();
+                }
+            } else {
+                cx.style.text.insert(entity, val.to_string());
+
+                cx.need_relayout();
+                cx.need_redraw();
+            }
+        });
+
+        self
+    }
+
+    modifier!(
+        /// Sets the font that should be used by the view.
+        ///
+        /// The font name refers to the name assigned when the font is added to context.
+        font,
+        String
+    );
+
+    /// Sets the text color of the view.
+    fn color<U: Into<Color>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            cx.style.font_color.insert(entity, v.into());
+        });
+        self
+    }
+
+    /// Sets the font size of the view.
+    fn font_size(mut self, value: impl Res<f32>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), entity, |cx, entity, v| {
+            cx.style.font_size.insert(entity, v.into());
+        });
+        self
+    }
+
+    modifier!(
+        /// Sets the text selection of the view.
+        text_selection,
+        Selection
+    );
+
+    modifier!(
+        /// Sets the ext caret color of the view.
+        caret_color,
+        Color
+    );
+
+    modifier!(
+        /// Sets the color used to highlight selected text within the view.
+        selection_color,
+        Color
+    );
+
+    modifier!(
+        /// Sets whether the text of the view should be allowed to wrap.
+        text_wrap,
+        bool
+    );
+}
+
+impl<'a, V> TextModifiers for Handle<'a, V> {}

--- a/crates/vizia_core/src/state/data.rs
+++ b/crates/vizia_core/src/state/data.rs
@@ -279,6 +279,18 @@ impl Data for morphorm::Units {
     }
 }
 
+impl Data for morphorm::LayoutType {
+    fn same(&self, other: &Self) -> bool {
+        *self == *other
+    }
+}
+
+impl Data for morphorm::PositionType {
+    fn same(&self, other: &Self) -> bool {
+        *self == *other
+    }
+}
+
 impl Data for Color {
     fn same(&self, other: &Self) -> bool {
         *self == *other

--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -47,6 +47,7 @@ impl_res_simple!(char);
 impl_res_simple!(bool);
 impl_res_simple!(f32);
 impl_res_simple!(f64);
+impl_res_simple!(CursorIcon);
 
 impl<T, L> Res<T> for L
 where

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -64,7 +64,7 @@ bitflags! {
         const SELECTABLE = 1 << 3;
         /// The element should be focusable in sequential keyboard navigation -
         /// allowing the equivilant of a negative tabindex in html.
-        const KEYBOARD_NAVIGATABLE = 1 << 4;
+        const NAVIGABLE = 1 << 4;
     }
 }
 

--- a/crates/vizia_core/src/tree/focus_iter.rs
+++ b/crates/vizia_core/src/tree/focus_iter.rs
@@ -26,7 +26,7 @@ pub fn is_navigatable(cx: &Context, node: Entity, lock_focus_to: Entity) -> bool
         return false;
     }
 
-    has_ability(cx, node, Abilities::KEYBOARD_NAVIGATABLE)
+    has_ability(cx, node, Abilities::NAVIGABLE)
 }
 
 /// Is the entity focusable - some focusable entities are not in the tab order.

--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -83,7 +83,7 @@ impl Button {
                 (content)(cx).hoverable(false);
             })
             .cursor(CursorIcon::Hand)
-            .keyboard_navigatable(true)
+            .navigable(true)
     }
 }
 

--- a/crates/vizia_core/src/views/checkbox.rs
+++ b/crates/vizia_core/src/views/checkbox.rs
@@ -143,7 +143,7 @@ impl Checkbox {
                 }
             })
             .cursor(CursorIcon::Hand)
-            .keyboard_navigatable(true)
+            .navigable(true)
     }
 }
 

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -74,7 +74,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
                 //     .rotate(30.0);
             });
         })
-        .keyboard_navigatable(true)
+        .navigable(true)
     }
 
     pub fn custom<F, V: View>(

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -77,14 +77,14 @@ impl<L: Lens<Target = f32>> Knob<L> {
         .keyboard_navigatable(true)
     }
 
-    pub fn custom<F, T>(
+    pub fn custom<F, V: View>(
         cx: &mut Context,
         default_normal: f32,
         lens: L,
         content: F,
     ) -> Handle<'_, Self>
     where
-        F: 'static + Fn(&mut Context, L) -> Handle<T>,
+        F: 'static + Fn(&mut Context, L) -> Handle<V>,
     {
         Self {
             lens: lens.clone(),

--- a/crates/vizia_core/src/views/menu.rs
+++ b/crates/vizia_core/src/views/menu.rs
@@ -23,7 +23,7 @@ where
         let i = *data.counter.borrow();
         *data.counter.borrow_mut() += 1;
         handle
-            .keyboard_navigatable(true)
+            .navigable(true)
             .bind(MenuData::selected, move |handle, selected| {
                 let selected = selected.get(handle.cx) == Some(i);
                 handle.cx.set_selected(selected);
@@ -267,7 +267,7 @@ impl MenuButton {
                 .build(cx, move |cx| {
                     contents(cx);
                 })
-                .keyboard_navigatable(true),
+                .navigable(true),
             |_| {},
             |_| {},
         )

--- a/crates/vizia_core/src/views/radio_buttons.rs
+++ b/crates/vizia_core/src/views/radio_buttons.rs
@@ -94,7 +94,7 @@ impl RadioButton {
             })
             .checked(checked)
             .cursor(CursorIcon::Hand)
-            .keyboard_navigatable(true)
+            .navigable(true)
     }
 }
 

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -177,7 +177,7 @@ where
                 });
             });
         })
-        .keyboard_navigatable(true)
+        .navigable(true)
     }
 }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -549,7 +549,7 @@ where
                 TextboxKind::MultiLineWrapped => "multi_line_wrapped",
             })
             .cursor(CursorIcon::Text)
-            .keyboard_navigatable(true)
+            .navigable(true)
     }
 }
 


### PR DESCRIPTION
This is part of an ongoing effort to improve the documentation of the vizia crate. The modifiers which apply to `Handle` have now been split up accross multiple traits to improve organisation and the generated docs.

This PR also renames the ability `KEYBOARD_NAVIGATABLE` to `NAVIGABLE`.