### PR TITLE
Require Eq instead of PartialEq for bindings

### DIFF
--- a/crates/vizia_core/src/handle.rs
+++ b/crates/vizia_core/src/handle.rs
@@ -69,7 +69,7 @@ impl<'a, V> Handle<'a, V> {
     pub fn bind<L, F>(self, lens: L, closure: F) -> Self
     where
         L: Lens,
-        <L as Lens>::Target: Clone + PartialEq,
+        <L as Lens>::Target: Clone + Eq,
         F: 'static + Fn(Handle<'_, V>, L),
     {
         let entity = self.entity();

--- a/crates/vizia_core/src/localization/mod.rs
+++ b/crates/vizia_core/src/localization/mod.rs
@@ -22,7 +22,7 @@ pub struct ValState<T> {
 impl<L> FluentStore for LensState<L>
 where
     L: Lens,
-    <L as Lens>::Target: Into<FluentValue<'static>> + Clone + PartialEq,
+    <L as Lens>::Target: Into<FluentValue<'static>> + Clone + Eq,
 {
     fn get_val(&self, cx: &Context) -> FluentValue<'static> {
         self.lens.view(
@@ -98,7 +98,7 @@ impl Localized {
     pub fn arg<L>(mut self, key: &str, lens: L) -> Self
     where
         L: Lens,
-        <L as Lens>::Target: Into<FluentValue<'static>> + Clone + PartialEq,
+        <L as Lens>::Target: Into<FluentValue<'static>> + Clone + Eq,
     {
         self.args.insert(key.to_owned(), Box::new(LensState { lens }));
         self

--- a/crates/vizia_core/src/state/binding.rs
+++ b/crates/vizia_core/src/state/binding.rs
@@ -20,7 +20,7 @@ impl<L> Binding<L>
 where
     L: 'static + Lens,
     <L as Lens>::Source: 'static,
-    <L as Lens>::Target: PartialEq,
+    <L as Lens>::Target: Eq,
 {
     /// Creates a new binding view.
     ///
@@ -57,7 +57,7 @@ where
             lens: L,
             id: Entity,
         ) where
-            L::Target: Clone + PartialEq,
+            L::Target: Clone + Eq,
         {
             let key = lens.cache_key();
 

--- a/crates/vizia_core/src/state/data.rs
+++ b/crates/vizia_core/src/state/data.rs
@@ -1,3 +1,3 @@
-pub trait Data: 'static + Clone + PartialEq {}
+pub trait Data: 'static + Clone + Eq {}
 
-impl<D: 'static + Clone + PartialEq> Data for D {}
+impl<D: 'static + Clone + Eq> Data for D {}

--- a/crates/vizia_core/src/state/lens.rs
+++ b/crates/vizia_core/src/state/lens.rs
@@ -114,6 +114,20 @@ pub trait LensExt: Lens {
     {
         self.then(IntoLens::new())
     }
+
+    fn to_bits32(self) -> Then<Self, F32ToBitsLens>
+    where
+        Self: Lens<Target = f32>,
+    {
+        self.then(F32ToBitsLens())
+    }
+
+    fn to_f32(self) -> Then<Self, F32FromBitsLens>
+    where
+        Self: Lens<Target = u32>,
+    {
+        self.then(F32FromBitsLens())
+    }
 }
 
 // Implement LensExt for all types which implement Lens
@@ -363,5 +377,29 @@ where
         } else {
             map(None)
         }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct F32FromBitsLens();
+
+impl Lens for F32FromBitsLens {
+    type Source = u32;
+    type Target = f32;
+
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        map(Some(&f32::from_bits(*source)))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct F32ToBitsLens();
+
+impl Lens for F32ToBitsLens {
+    type Source = f32;
+    type Target = u32;
+
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        map(Some(&f32::to_bits(*source)))
     }
 }

--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -53,7 +53,7 @@ impl_res_simple!(Overflow);
 impl<T, L> Res<T> for L
 where
     L: Lens<Target = T> + LensExt,
-    T: Clone + PartialEq,
+    T: Clone + Eq,
 {
     fn get_val(&self, cx: &Context) -> T {
         self.get(cx)

--- a/crates/vizia_core/src/state/store.rs
+++ b/crates/vizia_core/src/state/store.rs
@@ -38,7 +38,7 @@ pub(crate) struct BasicStore<L: Lens, T> {
 impl<L: Lens, T> Store for BasicStore<L, T>
 where
     L: Lens<Target = T>,
-    <L as Lens>::Target: Clone + PartialEq,
+    <L as Lens>::Target: Clone + Eq,
 {
     fn entity(&self) -> Entity {
         self.entity

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -440,8 +440,8 @@ impl View for TickKnob {
 impl Handle<'_, TickKnob> {
     pub fn value<L: Lens<Target = f32>>(self, lens: L) -> Self {
         let entity = self.entity;
-        Binding::new(self.cx, lens, move |cx, value| {
-            let value = value.get(cx);
+        Binding::new(self.cx, lens.map(|f| f.to_bits()), move |cx, value| {
+            let value = f32::from_bits(value.get(cx));
             if let Some(view) = cx.views.get_mut(&entity) {
                 if let Some(knob) = view.downcast_mut::<TickKnob>() {
                     knob.normalized_value = value;
@@ -573,8 +573,8 @@ impl View for ArcTrack {
 impl Handle<'_, ArcTrack> {
     pub fn value<L: Lens<Target = f32>>(self, lens: L) -> Self {
         let entity = self.entity;
-        Binding::new(self.cx, lens, move |cx, value| {
-            let value = value.get(cx);
+        Binding::new(self.cx, lens.map(|f| f.to_bits()), move |cx, value| {
+            let value = f32::from_bits(value.get(cx));
             if let Some(view) = cx.views.get_mut(&entity) {
                 if let Some(knob) = view.downcast_mut::<ArcTrack>() {
                     knob.normalized_value = value;

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -440,8 +440,8 @@ impl View for TickKnob {
 impl Handle<'_, TickKnob> {
     pub fn value<L: Lens<Target = f32>>(self, lens: L) -> Self {
         let entity = self.entity;
-        Binding::new(self.cx, lens.map(|f| f.to_bits()), move |cx, value| {
-            let value = f32::from_bits(value.get(cx));
+        Binding::new(self.cx, lens.to_bits32(), move |cx, value| {
+            let value = value.to_f32().get(cx);
             if let Some(view) = cx.views.get_mut(&entity) {
                 if let Some(knob) = view.downcast_mut::<TickKnob>() {
                     knob.normalized_value = value;
@@ -573,8 +573,8 @@ impl View for ArcTrack {
 impl Handle<'_, ArcTrack> {
     pub fn value<L: Lens<Target = f32>>(self, lens: L) -> Self {
         let entity = self.entity;
-        Binding::new(self.cx, lens.map(|f| f.to_bits()), move |cx, value| {
-            let value = f32::from_bits(value.get(cx));
+        Binding::new(self.cx, lens.to_bits32(), move |cx, value| {
+            let value = value.to_f32().get(cx);
             if let Some(view) = cx.views.get_mut(&entity) {
                 if let Some(knob) = view.downcast_mut::<ArcTrack>() {
                     knob.normalized_value = value;

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -30,8 +30,8 @@ impl<L1: Lens<Target = f32>> Scrollbar<L1> {
         .build(cx, move |cx| {
             Element::new(cx)
                 .class("thumb")
-                .bind(value, move |handle, value| {
-                    let value = value.get(handle.cx);
+                .bind(value.map(|f| f.to_bits()), move |handle, value| {
+                    let value = f32::from_bits(value.get(handle.cx));
                     match orientation {
                         Orientation::Horizontal => {
                             handle.left(Units::Stretch(value)).right(Units::Stretch(1.0 - value))
@@ -41,8 +41,8 @@ impl<L1: Lens<Target = f32>> Scrollbar<L1> {
                         }
                     };
                 })
-                .bind(ratio, move |handle, ratio| {
-                    let ratio = ratio.get(handle.cx);
+                .bind(ratio.map(|f| f.to_bits()), move |handle, ratio| {
+                    let ratio = f32::from_bits(ratio.get(handle.cx));
                     match orientation {
                         Orientation::Horizontal => handle.width(Units::Percentage(ratio * 100.0)),
                         Orientation::Vertical => handle.height(Units::Percentage(ratio * 100.0)),

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -30,22 +30,22 @@ impl<L1: Lens<Target = f32>> Scrollbar<L1> {
         .build(cx, move |cx| {
             Element::new(cx)
                 .class("thumb")
-                .bind(value.map(|f| f.to_bits()), move |handle, value| {
-                    let value = f32::from_bits(value.get(handle.cx));
+                .bind(value.to_bits32(), move |handle, value| {
+                    let value = value.to_f32().get(handle.cx);
                     match orientation {
                         Orientation::Horizontal => {
-                            handle.left(Units::Stretch(value)).right(Units::Stretch(1.0 - value))
+                            handle.left(Stretch(value)).right(Stretch(1.0 - value))
                         }
                         Orientation::Vertical => {
-                            handle.top(Units::Stretch(value)).bottom(Units::Stretch(1.0 - value))
+                            handle.top(Stretch(value)).bottom(Stretch(1.0 - value))
                         }
                     };
                 })
-                .bind(ratio.map(|f| f.to_bits()), move |handle, ratio| {
-                    let ratio = f32::from_bits(ratio.get(handle.cx));
+                .bind(ratio.to_bits32(), move |handle, ratio| {
+                    let ratio = ratio.to_f32().get(handle.cx);
                     match orientation {
-                        Orientation::Horizontal => handle.width(Units::Percentage(ratio * 100.0)),
-                        Orientation::Vertical => handle.height(Units::Percentage(ratio * 100.0)),
+                        Orientation::Horizontal => handle.width(Percentage(ratio * 100.0)),
+                        Orientation::Vertical => handle.height(Percentage(ratio * 100.0)),
                     };
                 });
         });

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -3,17 +3,18 @@ use morphorm::{GeometryChanged, PositionType};
 use crate::prelude::*;
 use crate::state::RatioLens;
 use crate::views::Orientation;
+use crate::views::scrollview::scroll_data_derived_lenses::scroll_y_bits;
 
 pub(crate) const SCROLL_SENSITIVITY: f32 = 35.0;
 
 #[derive(Lens, Clone, Debug, PartialEq)]
 pub struct ScrollData {
-    pub scroll_x: f32,
-    pub scroll_y: f32,
-    pub child_x: f32,
-    pub child_y: f32,
-    pub parent_x: f32,
-    pub parent_y: f32,
+    scroll_x_bits: u32,
+    scroll_y_bits: u32,
+    child_x_bits: u32,
+    child_y_bits: u32,
+    parent_x_bits: u32,
+    parent_y_bits: u32,
 }
 
 pub enum ScrollEvent {
@@ -26,6 +27,41 @@ pub enum ScrollEvent {
 }
 
 impl ScrollData {
+    pub fn new(scroll_x: f32, scroll_y: f32, child_x: f32, child_y: f32, parent_x: f32, parent_y: f32) -> Self {
+        Self {
+            scroll_x_bits: scroll_x.to_bits(),
+            scroll_y_bits: scroll_y.to_bits(),
+            child_x_bits: child_x.to_bits(),
+            child_y_bits: child_y.to_bits(),
+            parent_x_bits: parent_x.to_bits(),
+            parent_y_bits: parent_y.to_bits(),
+        }
+    }
+
+    pub fn scroll_x(&self) -> f32 {
+        f32::from_bits(self.scroll_x_bits)
+    }
+
+    pub fn scroll_y(&self) -> f32 {
+        f32::from_bits(self.scroll_y_bits)
+    }
+
+    pub fn parent_x(&self) -> f32 {
+        f32::from_bits(self.parent_x_bits)
+    }
+
+    pub fn parent_y(&self) -> f32 {
+        f32::from_bits(self.parent_y_bits)
+    }
+
+    pub fn child_x(&self) -> f32 {
+        f32::from_bits(self.child_x_bits)
+    }
+
+    pub fn child_y(&self) -> f32 {
+        f32::from_bits(self.child_y_bits)
+    }
+
     fn reset(&mut self) {
         if self.child_x == self.parent_x {
             self.scroll_x = 0.0;
@@ -79,15 +115,7 @@ impl ScrollView<scroll_data_derived_lenses::root> {
         F: 'static + FnOnce(&mut Context),
     {
         Self { data: ScrollData::root }.build(cx, move |cx| {
-            ScrollData {
-                scroll_x: initial_x,
-                scroll_y: initial_y,
-                child_x: 0.0,
-                child_y: 0.0,
-                parent_x: 0.0,
-                parent_y: 0.0,
-            }
-            .build(cx);
+            ScrollData::new(initial_x, initial_y, 0.0, 0.0, 0.0, 0.0).build(cx);
 
             Self::common_builder(cx, ScrollData::root, content, scroll_x, scroll_y);
         })

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -10,13 +10,43 @@ enum SliderEventInternal {
     SetKeyboardFraction(f32),
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SliderDataInternal {
     pub orientation: Orientation,
-    pub size: f32,
-    pub thumb_size: f32,
-    pub range: Range<f32>,
-    pub keyboard_fraction: f32,
+    size_bits: u32,
+    thumb_size_bits: u32,
+    range_start_bits: u32,
+    range_end_bits: u32,
+    keyboard_fraction_bits: u32,
+}
+
+impl SliderDataInternal {
+    pub fn new(orientation: Orientation, size: f32, thumb_size: f32, range: Range<f32>, keyboard_fraction: f32) -> Self {
+        Self {
+            orientation,
+            size_bits: size.to_bits(),
+            thumb_size_bits: thumb_size.to_bits(),
+            range_start_bits: range.start.to_bits(),
+            range_end_bits: range.end.to_bits(),
+            keyboard_fraction_bits: keyboard_fraction.to_bits(),
+        }
+    }
+
+    pub fn size(&self) -> f32 {
+        f32::from_bits(self.size_bits)
+    }
+
+    pub fn thumb_size(&self) -> f32 {
+        f32::from_bits(self.size_bits)
+    }
+
+    pub fn range(&self) -> Range<f32> {
+        f32::from_bits(self.range_start_bits)..f32::from_bits(self.range_end_bits)
+    }
+
+    pub fn fraction_keyboard(&self) -> f32 {
+        f32::from_bits(self.keyboard_fraction_bits)
+    }
 }
 
 /// The slider control can be used to select from a continuous set of values.
@@ -102,13 +132,13 @@ where
             lens: lens.clone(),
             is_dragging: false,
 
-            internal: SliderDataInternal {
-                orientation: Orientation::Horizontal,
-                thumb_size: 0.0,
-                size: 0.0,
-                range: 0.0..1.0,
-                keyboard_fraction: 0.1,
-            },
+            internal: SliderDataInternal::new(
+                Orientation::Horizontal,
+                0.0,
+                0.0,
+                0.0..1.0,
+                0.1,
+            ),
 
             on_changing: None,
         }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -562,7 +562,13 @@ where
                         .class("textbox_content")
                         .text(TextboxData::text)
                         .text_selection(TextboxData::selection)
-                        .translate(TextboxData::transform)
+                        .bind(
+                            TextboxData::transform.map(|(f1, f2)| (f1.to_bits(), f2.to_bits())),
+                            |handle, lens| {
+                                let (f1, f2) = lens.get(handle.cx);
+                                handle.translate((f32::from_bits(f1), f32::from_bits(f2)));
+                            },
+                        )
                         .on_geo_changed(|cx, _| cx.emit(TextEvent::GeometryChanged))
                         .entity;
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -506,7 +506,7 @@ pub enum TextboxKind {
 
 impl<L: Lens> Textbox<L>
 where
-    <L as Lens>::Target: PartialEq + Clone + ToString,
+    <L as Lens>::Target: Eq + Clone + ToString,
 {
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
         Self::new_core(cx, lens, TextboxKind::SingleLine)


### PR DESCRIPTION
This fixes a bug following https://github.com/vizia/vizia/pull/269 where vizia applications could take 100% cpu when any value in any model was NaN. To put it lightly, this sucks. Requiring Eq is a pain when anything is a floating point type, but this is mitigated partially by two new lenses which can be invoked to translate a float type to and from its underlying bit representation. Things get messier when you are binding to structs which contain floats - my only suggestions are to either impl PartialEq explicitly such that you can safely implement Eq, or to replace all your f32 types with a wrapper type that implements Eq, for example the eq-float crate.

If people think this is gross we can just revert #269.