### PR TITLE
Textbox: Do not select all on start, do not scroll on end

### DIFF
--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -27,7 +27,6 @@ pub struct TextboxData {
 
 impl TextboxData {
     pub fn new(text: String) -> Self {
-        let text_length = text.as_str().len();
         Self {
             text: text.clone(),
             selection: Selection::new(0, 0),

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -1,4 +1,5 @@
 use vizia::prelude::*;
+use vizia_core::state::StaticLens;
 
 #[derive(Lens, Setter, Model)]
 pub struct AppData {
@@ -9,12 +10,21 @@ fn main() {
     Application::new(|cx| {
         AppData { text: "This text is editable!".to_string() }.build(cx);
 
-        Textbox::new(cx, AppData::text)
+        Textbox::new_multiline(cx, AppData::text, true)
             .on_edit(|cx, text| cx.emit(AppDataSetter::Text(text)))
             .width(Pixels(200.0))
             .on_build(|cx| {
                 cx.emit(TextEvent::StartEdit);
             });
+
+        Textbox::new_multiline(
+            cx,
+            StaticLens::new(
+                &"This text is editable, but will reset on blur. Good luck editing it, haha!",
+            ),
+            true,
+        )
+        .width(Pixels(200.0));
     })
     .title("Textbox")
     .run();


### PR DESCRIPTION
Closes #92, kind of, it doesn't actually implement the parameter described in that issue but I'm not convinced such a parameter needs to exist. I am pretty sure we have selection behavior parity with most other gui toolkits.