### PR TITLE
Use `WindowClose` event to close the window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,10 @@ path = "examples/ignore_default_theme.rs"
 name = "outline"
 path = "examples/style/outline.rs"
 
+[[example]]
+name = "save_dialog"
+path = "examples/save_dialog.rs"
+
 [features]
 default = ["winit", "clipboard", "x11", "wayland"]
 clipboard = ["vizia_core/clipboard", "vizia_winit/clipboard"]

--- a/crates/vizia_window/src/window_event.rs
+++ b/crates/vizia_window/src/window_event.rs
@@ -8,7 +8,7 @@ use vizia_input::{Code, Key, MouseButton};
 /// This type is part of the prelude.
 #[derive(Debug, Clone)]
 pub enum WindowEvent {
-    /// Emitted when a window is closed.
+    /// Emitted when a window is closed. Can also be emitted by a view or model to close the window.
     WindowClose,
     /// Emitted when a window changes size.
     WindowResize(f32, f32),

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -249,6 +249,16 @@ impl Application {
                         *stored_control_flow.borrow_mut() = ControlFlow::Poll;
                         event_loop_proxy.send_event(Event::new(())).expect("Failed to send event");
                     }
+
+                    if let Some(window_event_handler) = cx.views().remove(&Entity::root()) {
+                        if let Some(window) = window_event_handler.downcast_ref::<Window>() {
+                            if window.should_close {
+                                *stored_control_flow.borrow_mut() = ControlFlow::Exit;
+                            }
+                        }
+
+                        cx.views().insert(Entity::root(), window_event_handler);
+                    }
                 }
 
                 winit::event::Event::RedrawRequested(_) => {
@@ -259,7 +269,7 @@ impl Application {
                 winit::event::Event::WindowEvent { window_id: _, event } => {
                     match event {
                         winit::event::WindowEvent::CloseRequested => {
-                            *stored_control_flow.borrow_mut() = ControlFlow::Exit;
+                            cx.0.emit(WindowEvent::WindowClose);
                         }
 
                         winit::event::WindowEvent::ScaleFactorChanged {

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -60,6 +60,7 @@ impl Window {
         let window = Window {
             id: handle.id(),
             handle,
+            should_close: false,
             //canvas: Canvas::new(renderer).expect("Cannot create canvas"),
         };
 

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -13,6 +13,7 @@ pub struct Window {
     handle: glutin::WindowedContext<glutin::PossiblyCurrent>,
     #[cfg(target_arch = "wasm32")]
     handle: winit::window::Window,
+    pub should_close: bool,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -125,7 +126,7 @@ impl Window {
         //cx.canvases.insert(Entity::root(), canvas);
 
         // Build our window
-        let window = Window { id: handle.window().id(), handle };
+        let window = Window { id: handle.window().id(), handle, should_close: false };
 
         (window, canvas)
     }
@@ -216,6 +217,10 @@ impl View for Window {
 
             WindowEvent::ReloadStyles => {
                 cx.reload_styles().unwrap();
+            }
+
+            WindowEvent::WindowClose => {
+                self.should_close = true;
             }
 
             _ => {}

--- a/examples/save_dialog.rs
+++ b/examples/save_dialog.rs
@@ -1,0 +1,123 @@
+use vizia::prelude::*;
+
+const STYLE: &str = r#"
+
+    .modal {
+        space: 1s;
+        background-color: white;
+        border-radius: 3px;
+        border-width: 1px;
+        border-color: #999999;
+        outer-shadow: 0 3 10 #00000055;
+        overflow: visible;
+        child-space: 10px;
+    }
+
+    .modal>vstack>label {
+        width: auto;
+        height: auto;
+        space: 5px;
+        child-space: 1s;
+    }
+
+    .modal button {
+        border-radius: 3px;
+        child-space: 1s;
+    }
+
+    .modal hstack {
+        child-space: 1s;
+        col-between: 20px;
+    }
+"#;
+
+#[derive(Lens)]
+pub struct AppData {
+    is_saved: bool,
+    show_dialog: bool,
+}
+
+impl Model for AppData {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.map(|window_event, meta| match window_event {
+            // Intercept WindowClose event to show a dialog if not 'saved'.
+            WindowEvent::WindowClose => {
+                if !self.is_saved {
+                    self.show_dialog = true;
+                    meta.consume();
+                }
+            }
+            _ => {}
+        });
+
+        event.map(|app_event, _| match app_event {
+            AppEvent::HideModal => {
+                self.show_dialog = false;
+            }
+
+            AppEvent::Save => {
+                self.is_saved = true;
+            }
+
+            AppEvent::SaveAndClose => {
+                self.is_saved = true;
+                cx.emit(WindowEvent::WindowClose);
+            }
+
+            AppEvent::Cancel => {
+                self.is_saved = false;
+            }
+        });
+    }
+}
+
+pub enum AppEvent {
+    HideModal,
+    Save,
+    SaveAndClose,
+    Cancel,
+}
+
+fn main() {
+    Application::new(|cx| {
+        cx.add_theme(STYLE);
+        AppData { is_saved: false, show_dialog: false }.build(cx);
+
+        HStack::new(cx, |cx| {
+            Button::new(cx, |cx| cx.emit(WindowEvent::WindowClose), |cx| Label::new(cx, "Close"));
+            Button::new(cx, |cx| cx.emit(AppEvent::Save), |cx| Label::new(cx, "Save"));
+        })
+        .col_between(Pixels(10.0))
+        .space(Pixels(20.0));
+
+        Popup::new(cx, AppData::show_dialog, true, |cx| {
+            VStack::new(cx, |cx| {
+                Label::new(cx, "Save before close?").width(Stretch(1.0)).child_space(Stretch(1.0));
+                HStack::new(cx, |cx| {
+                    Button::new(
+                        cx,
+                        |cx| cx.emit(AppEvent::SaveAndClose),
+                        |cx| Label::new(cx, "Save & Close"),
+                    )
+                    .width(Pixels(120.0))
+                    .class("accent");
+
+                    Button::new(
+                        cx,
+                        |cx| cx.emit(AppEvent::HideModal),
+                        |cx| Label::new(cx, "Cancel"),
+                    )
+                    .width(Pixels(120.0));
+                });
+            })
+            .row_between(Pixels(20.0))
+            .height(Auto);
+        })
+        .on_blur(|cx| cx.emit(AppEvent::HideModal))
+        .width(Pixels(300.0))
+        .height(Auto)
+        .row_between(Pixels(20.0))
+        .class("modal");
+    })
+    .run();
+}


### PR DESCRIPTION
Fixes #207.

Also added example for a save dialog which uses a model to intercept the `WidowClose` event and conditionally consume it before it can be handled by the window.

As a result of this, event handling has been changed so that for a particular entity events are handled by attached models first and then by the associated view. Events consumed by models will not propagate to the view. Hopefully this doesn't have any unforeseen consequences.