### PR TITLE
Rich text support

### DIFF
--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -40,8 +40,8 @@ instant = "0.1.12"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 ouroboros = "^0.15"
 #cosmic-text = "^0.6"
-cosmic-text = { git = "https://github.com/pop-os/cosmic-text", rev = "e00109d77f06d5a2e3057865eda3f530bc40a046" }
-# cosmic-text = { git = "https://github.com/rhelmot/cosmic-text", rev = "45fbf25958437706e4f5c07b5169eee8079d774d" }
+#cosmic-text = { git = "https://github.com/pop-os/cosmic-text", rev = "e00109d77f06d5a2e3057865eda3f530bc40a046" }
+cosmic-text = { git = "https://github.com/rhelmot/cosmic-text", rev = "c1a7654873137326bf320a07d534a8a2650d86cb" }
 #cosmic-text = { path = "../../../cosmic-text" }
 swash = "^0.1"
 replace_with = "0.1.7"

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -3,7 +3,8 @@
 use crate::context::Context;
 use crate::entity::Entity;
 use crate::view::Canvas;
-use fluent_bundle::{FluentBundle, FluentResource};
+use fluent_bundle::resolver::Scope;
+use fluent_bundle::{FluentBundle, FluentResource, FluentValue};
 use image::GenericImageView;
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet};
@@ -113,6 +114,79 @@ impl ResourceManager {
             .expect("Failed to parse translation as FTL");
         let bundle =
             self.translations.entry(lang.clone()).or_insert_with(|| FluentBundle::new(vec![lang]));
+        bundle
+            .add_function("CLASS", |args, _| {
+                FluentValue::String(
+                    format!(
+                        "\0.{}\0",
+                        args[0].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        ))
+                    )
+                    .into(),
+                )
+            })
+            .expect("Failed to add function to bundle");
+        bundle
+            .add_function("ID", |args, _| {
+                FluentValue::String(
+                    format!(
+                        "\0#{}\0",
+                        args[0].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        ))
+                    )
+                    .into(),
+                )
+            })
+            .expect("Failed to add function to bundle");
+        bundle
+            .add_function("END", |_, _| FluentValue::String(format!("\0-\0").into()))
+            .expect("Failed to add function to bundle");
+        bundle
+            .add_function("WITH_CLASS", |args, _| {
+                FluentValue::String(
+                    format!(
+                        "\0.{}\0{}\0-\0",
+                        args[1].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        )),
+                        args[0].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        ))
+                    )
+                    .into(),
+                )
+            })
+            .expect("Failed to add function to bundle");
+        bundle
+            .add_function("WITH_ID", |args, _| {
+                FluentValue::String(
+                    format!(
+                        "\0#{}\0{}\0-\0",
+                        args[1].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        )),
+                        args[0].as_string(&Scope::<FluentResource, _>::new(
+                            &FluentBundle::new(vec![]),
+                            None,
+                            None
+                        ))
+                    )
+                    .into(),
+                )
+            })
+            .expect("Failed to add function to bundle");
         bundle.add_resource(res).expect("Failed to add resource to bundle");
         self.renegotiate_language();
     }

--- a/crates/vizia_core/src/systems/text_constraints.rs
+++ b/crates/vizia_core/src/systems/text_constraints.rs
@@ -69,7 +69,7 @@ pub fn text_constraints_system(cx: &mut Context, tree: &Tree<Entity>) {
             let mut content_height = 0.0;
 
             if cx.text_context.has_buffer(entity) {
-                cx.text_context.sync_styles(entity, &cx.style);
+                cx.text_context.sync_styles(entity, &cx.style, &cx.tree, &cx.views);
                 let (text_width, text_height) = cx.text_context.with_buffer(entity, |buf| {
                     buf.set_size(999999, i32::MAX);
                     let w = buf

--- a/crates/vizia_core/src/text/cosmic.rs
+++ b/crates/vizia_core/src/text/cosmic.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use swash::scale::image::Content;
 use swash::scale::{Render, ScaleContext, Source, StrikeWith};
 use swash::zeno::{Format, Vector};
-use vizia_storage::{Tree, TreeExt, TreeIterator};
+use vizia_storage::{Tree, TreeIterator};
 
 const GLYPH_PADDING: u32 = 1;
 const GLYPH_MARGIN: u32 = 1;

--- a/crates/vizia_core/src/text/mod.rs
+++ b/crates/vizia_core/src/text/mod.rs
@@ -12,3 +12,6 @@ pub use scrolling::*;
 
 pub(crate) mod cosmic;
 pub(crate) use cosmic::*;
+
+pub(crate) mod span;
+pub use span::*;

--- a/crates/vizia_core/src/text/span.rs
+++ b/crates/vizia_core/src/text/span.rs
@@ -1,0 +1,16 @@
+use crate::prelude::{Context, Handle, View};
+use cosmic_text::Cursor;
+
+#[derive(Copy, Clone)]
+pub struct TextSpan {
+    pub cursor_start: Cursor,
+    pub cursor_end: Cursor,
+}
+
+impl TextSpan {
+    pub fn new(cx: &mut Context, cursor_start: Cursor, cursor_end: Cursor) -> Handle<Self> {
+        Self { cursor_end, cursor_start }.build(cx, |_| {})
+    }
+}
+
+impl View for TextSpan {}

--- a/crates/vizia_core/src/view.rs
+++ b/crates/vizia_core/src/view.rs
@@ -573,7 +573,7 @@ fn draw_view(cx: &mut DrawContext, canvas: &mut Canvas) {
             let origin_x = box_x + box_w * justify_x;
             let origin_y = box_y + (box_h * justify_y).ceil();
 
-            cx.text_context.sync_styles(cx.current, &cx.style);
+            cx.text_context.sync_styles(cx.current, &cx.style, &cx.tree, &cx.views);
 
             cx.draw_highlights(canvas, (origin_x, origin_y), (justify_x, justify_y));
             cx.draw_caret(canvas, (origin_x, origin_y), (justify_x, justify_y), 1.0);

--- a/crates/vizia_core/src/views/label.rs
+++ b/crates/vizia_core/src/views/label.rs
@@ -1,4 +1,7 @@
 use crate::prelude::*;
+use crate::text::TextSpan;
+use cosmic_text::Cursor;
+use std::marker::PhantomData;
 
 /// A label used to display text to the screen.
 ///
@@ -103,7 +106,128 @@ impl Label {
     where
         T: ToString,
     {
-        Self { describing: None }.build(cx, |_| {}).text(text)
+        Self::new_with_spans(cx, text, |_| {})
+    }
+
+    pub fn new_with_spans<'a, T, F>(
+        cx: &'a mut Context,
+        text: impl Res<T>,
+        builder: F,
+    ) -> Handle<'a, Self>
+    where
+        T: ToString,
+        F: FnOnce(&mut Context),
+    {
+        Self { describing: None }.build(cx, builder).text(text)
+    }
+
+    pub fn new_rich_formatted<T>(cx: &mut Context, text: impl Res<T>) -> Handle<Self>
+    where
+        T: AsRef<str> + Data,
+    {
+        Self { describing: None }.build(cx, move |cx| {
+            #[derive(Clone, Debug)]
+            enum FmtCmd {
+                Class(String),
+                Id(String),
+            }
+            #[derive(Debug)]
+            struct FmtSpan {
+                cmds: Vec<FmtCmd>,
+                begin: Cursor,
+                end: Cursor,
+            }
+            text.set_or_bind(cx, cx.current, move |cx, entity, text_etc| {
+                let mut text = String::new();
+                let mut spans = Vec::new();
+                let mut literal = true;
+                let mut cmd_buf = String::new();
+                let mut line = 0;
+                let mut line_start = 0;
+                let mut last_cursor = Cursor::new(0, 0);
+                let mut stack = Vec::new();
+
+                for ch in text_etc.as_ref().chars() {
+                    if literal {
+                        match ch {
+                            '\0' => {
+                                literal = false;
+                            }
+                            '\n' => {
+                                text.push('\n');
+                                line += 1;
+                                line_start = text.len();
+                            }
+                            '\r' => {}
+                            _ => {
+                                text.push(ch);
+                            }
+                        }
+                    } else {
+                        match ch {
+                            '\0' => {
+                                literal = true;
+                                if cmd_buf.is_empty() {
+                                    text.push('\0');
+                                } else {
+                                    let new_cursor = Cursor::new(line, text.len() - line_start);
+                                    if new_cursor != last_cursor && !stack.is_empty() {
+                                        spans.push(FmtSpan {
+                                            cmds: stack.clone(),
+                                            begin: last_cursor,
+                                            end: new_cursor,
+                                        });
+                                    }
+                                    last_cursor = new_cursor;
+                                    let (cmd, rest) = cmd_buf.as_str().split_at(1);
+                                    match cmd {
+                                        "." => stack.push(FmtCmd::Class(rest.to_owned())),
+                                        "#" => stack.push(FmtCmd::Id(rest.to_owned())),
+                                        "-" => {
+                                            stack.pop().expect("Bad pop command - empty stack");
+                                        }
+                                        _ => panic!("Bad formatting command"),
+                                    }
+                                    cmd_buf.clear();
+                                }
+                            }
+                            _ => {
+                                cmd_buf.push(ch);
+                            }
+                        }
+                    }
+                }
+                if !literal {
+                    panic!("Bad formatting command - unclosed directive");
+                }
+                if !stack.is_empty() {
+                    panic!("Bad formatting commands - stack not empty");
+                }
+                let new_cursor = Cursor::new(line, text.len() - line_start);
+                if new_cursor != last_cursor && !stack.is_empty() {
+                    spans.push(FmtSpan {
+                        cmds: stack.clone(),
+                        begin: last_cursor,
+                        end: new_cursor,
+                    });
+                }
+                Handle { entity, p: PhantomData::<Self>::default(), cx }.text(&text);
+                println!("SO true bestie {:?}", entity);
+                for FmtSpan { begin, end, cmds } in spans.into_iter() {
+                    let mut handle = TextSpan::new(cx, begin, end);
+                    for cmd in cmds {
+                        match cmd {
+                            FmtCmd::Class(name) => {
+                                handle = handle.class(&name);
+                            }
+                            FmtCmd::Id(name) => {
+                                handle = handle.id(&name);
+                            }
+                        }
+                    }
+                }
+            });
+        })
     }
 }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -45,7 +45,7 @@ impl TextboxData {
         let bounds = cx.cache.bounds.get(entity).unwrap().clone();
         let mut parent_bounds = cx.cache.bounds.get(parent).unwrap().clone();
 
-        cx.text_context.sync_styles(entity, &cx.style);
+        cx.text_context.sync_styles(entity, &cx.style, &cx.tree, &cx.views);
 
         // do the computation
         let (mut tx, mut ty) = self.transform;

--- a/examples/localization/l10n.rs
+++ b/examples/localization/l10n.rs
@@ -30,6 +30,7 @@ impl Model for AppData {
 
 fn main() {
     Application::new(|cx| {
+        cx.add_theme(".bold { font-style: italic; }");
         cx.add_translation(
             "en-US".parse().unwrap(),
             include_str!("../resources/en-US/hello.ftl").to_owned(),
@@ -64,7 +65,10 @@ fn main() {
             .height(Auto)
             .col_between(Pixels(5.0));
             Label::new(cx, Localized::new("intro").arg("name", AppData::name));
-            Label::new(cx, Localized::new("emails").arg("unread_emails", AppData::emails));
+            Label::new_rich_formatted(
+                cx,
+                Localized::new("emails").arg("unread_emails", AppData::emails),
+            );
             Button::new(
                 cx,
                 |cx| cx.emit(AppEvent::ReceiveEmail),

--- a/examples/resources/en-US/hello.ftl
+++ b/examples/resources/en-US/hello.ftl
@@ -3,7 +3,7 @@ enter-name = Please enter your name:
 intro = Welcome, { $name }.
 emails =
     { $unread_emails ->
-        [one] You have one unread email.
-       *[other] You have { $unread_emails } unread emails.
+        [one] You have { WITH_CLASS("one", "bold") } unread email.
+       *[other] You have { WITH_CLASS($unread_emails, "bold") } unread emails.
     }
 refresh = Refresh

--- a/examples/resources/fr/hello.ftl
+++ b/examples/resources/fr/hello.ftl
@@ -3,7 +3,7 @@ intro = Bienvenue, { $name }.
 enter-name = Veuillez saisir votre nom:
 emails =
     { $unread_emails ->
-        [one] Vous avez un e-mail non lu.
-       *[other] Vous avez { $unread_emails } e-mails non lus.
+        [one] Vous avez { WITH_CLASS("un", "bold") } e-mail non lu.
+       *[other] Vous avez { WITH_CLASS($unread_emails, "bold") } e-mails non lus.
     }
 refresh = Actualiser la page


### PR DESCRIPTION
Adds rich text to labels, and any custom view that wants to make its text rich by figuring out what indices should be what styles.

Essentially, by constructing child TextSpan views as children of an entity with text set, the spans described in the TextSpan view will be styled according to the child element's style. Supported properties right now are color, font-family, font-style, and font-weight.

High level support for labels is supported at two levels. At the ftl level, there are functions you can call to insert markup into text, and a function Label::new_rich_formatted to parse this markup. The ftl functions are fairly self-explanatory based on the example, and the markup is pretty simple so could write it by hand in a pinch.