### PR TITLE
Some small performance improvements

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -251,6 +251,8 @@ impl ApplicationRunner {
         cx.process_data_updates();
         cx.process_style_updates();
 
+        cx.process_animations();
+
         cx.process_visual_updates();
 
         if cx.style().needs_redraw {

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -17,8 +17,6 @@ use crate::{
 };
 use vizia_id::GenerationalId;
 
-pub use crate::systems::animation::has_animations;
-
 #[cfg(feature = "clipboard")]
 use copypasta::ClipboardProvider;
 
@@ -241,13 +239,15 @@ impl<'a> BackendContext<'a> {
         image_system(self.0);
     }
 
+    // Returns true if animations are playing
+    pub fn process_animations(&mut self) -> bool {
+        animation_system(self.0)
+    }
+
     /// Massages the style system until everything is coherent
     pub fn process_visual_updates(&mut self) {
         // Not ideal
         let tree = self.0.tree.clone();
-
-        // Compute any animations for this frame.
-        animation_system(self.0);
 
         // Apply z-order inheritance.
         z_ordering_system(self.0, &tree);

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -114,8 +114,6 @@ impl<'a> EventContext<'a> {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     /// Capture mouse input for the current entity.
@@ -175,9 +173,7 @@ impl<'a> EventContext<'a> {
         }
         self.set_focus_pseudo_classes(new_focus, true, focus_visible);
 
-        // self.style.needs_relayout = true;
-        // self.style.needs_redraw = true;
-        // self.style.needs_restyle = true;
+        self.style.needs_restyle = true;
     }
 
     /// Sets application focus to the current entity using the previous focus visibility.
@@ -242,8 +238,6 @@ impl<'a> EventContext<'a> {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     /// Sets the checked flag of the current entity.
@@ -254,8 +248,6 @@ impl<'a> EventContext<'a> {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     /// Sets the checked flag of the current entity.
@@ -266,8 +258,6 @@ impl<'a> EventContext<'a> {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     /// Get the contents of the system clipboard. This may fail for a variety of backend-specific
@@ -302,8 +292,6 @@ impl<'a> EventContext<'a> {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     pub fn play_animation(&mut self, animation: Animation) {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -175,9 +175,9 @@ impl<'a> EventContext<'a> {
         }
         self.set_focus_pseudo_classes(new_focus, true, focus_visible);
 
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
-        self.style.needs_restyle = true;
+        // self.style.needs_relayout = true;
+        // self.style.needs_redraw = true;
+        // self.style.needs_restyle = true;
     }
 
     /// Sets application focus to the current entity using the previous focus visibility.

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -175,6 +175,10 @@ impl Context {
             ignore_default_theme: false,
         };
 
+        result.style.needs_restyle = true;
+        result.style.needs_relayout = true;
+        result.style.needs_redraw = true;
+
         Environment::new().build(&mut result);
 
         result.entity_manager.create();
@@ -290,9 +294,9 @@ impl Context {
         }
         self.set_focus_pseudo_classes(new_focus, true, focus_visible);
 
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
-        self.style.needs_restyle = true;
+        // self.style.needs_relayout = true;
+        // self.style.needs_redraw = true;
+        // self.style.needs_restyle = true;
     }
 
     /// Sets application focus to the current entity using the previous focus visibility

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -513,8 +513,8 @@ impl Context {
                 });
             }
         }
+        self.need_relayout();
         self.style.needs_redraw = true;
-        self.style.needs_relayout = true;
     }
 
     pub fn add_translation(&mut self, lang: LanguageIdentifier, ftl: String) {

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -294,9 +294,7 @@ impl Context {
         }
         self.set_focus_pseudo_classes(new_focus, true, focus_visible);
 
-        // self.style.needs_relayout = true;
-        // self.style.needs_redraw = true;
-        // self.style.needs_restyle = true;
+        self.style.needs_restyle = true;
     }
 
     /// Sets application focus to the current entity using the previous focus visibility
@@ -319,8 +317,6 @@ impl Context {
         }
 
         self.style.needs_restyle = true;
-        self.style.needs_relayout = true;
-        self.style.needs_redraw = true;
     }
 
     pub(crate) fn remove_children(&mut self, entity: Entity) {

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -513,9 +513,9 @@ fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, met
                     }
                 }
 
-                context.style.needs_relayout = true;
-                context.style.needs_redraw = true;
-                context.style.needs_restyle = true;
+                // context.style.needs_relayout = true;
+                // context.style.needs_redraw = true;
+                // context.style.needs_restyle = true;
             }
 
             if matches!(*code, Code::Enter | Code::NumpadEnter | Code::Space) {

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -146,12 +146,12 @@ pub trait StyleModifiers: internal::Modifiable {
             if let Some(prev_data) = cx.style.image.get(entity) {
                 if prev_data != &val {
                     cx.style.image.insert(entity, val);
-
+                    cx.style.needs_text_layout.insert(entity, true).unwrap();
                     cx.need_redraw();
                 }
             } else {
                 cx.style.image.insert(entity, val);
-
+                cx.style.needs_text_layout.insert(entity, true).unwrap();
                 cx.need_redraw();
             }
         });

--- a/crates/vizia_core/src/modifiers/text.rs
+++ b/crates/vizia_core/src/modifiers/text.rs
@@ -11,7 +11,7 @@ pub trait TextModifiers: internal::Modifiable {
             let text_data = val.to_string();
             cx.text_context.set_text(entity, &text_data);
 
-            cx.need_relayout();
+            cx.style.needs_text_layout.insert(entity, true).unwrap();
             cx.need_redraw();
         });
 

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -234,6 +234,9 @@ pub struct Style {
     pub needs_restyle: bool,
     pub needs_relayout: bool,
     pub needs_redraw: bool,
+    // TODO: When we can do incremental updates on a per entity basis, change this to a bitflag
+    // for layout, text layout, rendering, etc. to replace the above `needs_` members.
+    pub needs_text_layout: SparseSet<bool>,
 
     /// This includes both the system's HiDPI scaling factor as well as `cx.user_scale_factor`.
     pub dpi_factor: f64,
@@ -1083,6 +1086,8 @@ impl Style {
         self.name.remove(entity);
 
         self.image.remove(entity);
+
+        self.needs_text_layout.remove(entity);
     }
 
     pub fn clear_style_rules(&mut self) {

--- a/crates/vizia_core/src/systems/animation.rs
+++ b/crates/vizia_core/src/systems/animation.rs
@@ -1,97 +1,57 @@
 use crate::prelude::*;
 
-pub fn has_animations(cx: &Context) -> bool {
-    cx.style.display.has_animations()
-        | cx.style.visibility.has_animations()
-        | cx.style.opacity.has_animations()
-        | cx.style.rotate.has_animations()
-        | cx.style.translate.has_animations()
-        | cx.style.scale.has_animations()
-        | cx.style.border_width.has_animations()
-        | cx.style.border_color.has_animations()
-        | cx.style.border_radius_top_left.has_animations()
-        | cx.style.border_radius_top_right.has_animations()
-        | cx.style.border_radius_bottom_left.has_animations()
-        | cx.style.border_radius_bottom_right.has_animations()
-        | cx.style.background_color.has_animations()
-        | cx.style.outer_shadow_h_offset.has_animations()
-        | cx.style.outer_shadow_v_offset.has_animations()
-        | cx.style.outer_shadow_blur.has_animations()
-        | cx.style.outer_shadow_color.has_animations()
-        | cx.style.font_color.has_animations()
-        | cx.style.font_size.has_animations()
-        | cx.style.left.has_animations()
-        | cx.style.right.has_animations()
-        | cx.style.top.has_animations()
-        | cx.style.bottom.has_animations()
-        | cx.style.width.has_animations()
-        | cx.style.height.has_animations()
-        | cx.style.max_width.has_animations()
-        | cx.style.max_height.has_animations()
-        | cx.style.min_width.has_animations()
-        | cx.style.min_height.has_animations()
-        | cx.style.min_left.has_animations()
-        | cx.style.max_left.has_animations()
-        | cx.style.min_right.has_animations()
-        | cx.style.max_right.has_animations()
-        | cx.style.min_top.has_animations()
-        | cx.style.max_top.has_animations()
-        | cx.style.min_bottom.has_animations()
-        | cx.style.max_bottom.has_animations()
-        | cx.style.row_between.has_animations()
-        | cx.style.col_between.has_animations()
-        | cx.style.child_left.has_animations()
-        | cx.style.child_right.has_animations()
-        | cx.style.child_top.has_animations()
-        | cx.style.child_bottom.has_animations()
-}
-
-pub fn animation_system(cx: &mut Context) {
+pub fn animation_system(cx: &mut Context) -> bool {
     let time = instant::Instant::now();
 
-    cx.style.display.tick(time);
-    cx.style.visibility.tick(time);
-    cx.style.opacity.tick(time);
-    cx.style.rotate.tick(time);
-    cx.style.translate.tick(time);
-    cx.style.scale.tick(time);
-    cx.style.border_width.tick(time);
-    cx.style.border_color.tick(time);
-    cx.style.border_radius_top_left.tick(time);
-    cx.style.border_radius_top_right.tick(time);
-    cx.style.border_radius_bottom_left.tick(time);
-    cx.style.border_radius_bottom_right.tick(time);
-    cx.style.background_color.tick(time);
-    cx.style.outer_shadow_h_offset.tick(time);
-    cx.style.outer_shadow_v_offset.tick(time);
-    cx.style.outer_shadow_blur.tick(time);
-    cx.style.outer_shadow_color.tick(time);
-    cx.style.font_color.tick(time);
-    cx.style.font_size.tick(time);
-    cx.style.left.tick(time);
-    cx.style.right.tick(time);
-    cx.style.top.tick(time);
-    cx.style.bottom.tick(time);
-    cx.style.width.tick(time);
-    cx.style.height.tick(time);
-    cx.style.max_width.tick(time);
-    cx.style.max_height.tick(time);
-    cx.style.min_width.tick(time);
-    cx.style.min_height.tick(time);
-    cx.style.min_left.tick(time);
-    cx.style.max_left.tick(time);
-    cx.style.min_right.tick(time);
-    cx.style.max_right.tick(time);
-    cx.style.min_top.tick(time);
-    cx.style.max_top.tick(time);
-    cx.style.min_bottom.tick(time);
-    cx.style.max_bottom.tick(time);
-    cx.style.row_between.tick(time);
-    cx.style.col_between.tick(time);
-    cx.style.child_left.tick(time);
-    cx.style.child_right.tick(time);
-    cx.style.child_top.tick(time);
-    cx.style.child_bottom.tick(time);
+    // Properties which affect rendering
+    let needs_redraw = cx.style.display.tick(time)
+        | cx.style.visibility.tick(time)
+        | cx.style.opacity.tick(time)
+        | cx.style.rotate.tick(time)
+        | cx.style.translate.tick(time)
+        | cx.style.scale.tick(time)
+        | cx.style.border_color.tick(time)
+        | cx.style.border_radius_top_left.tick(time)
+        | cx.style.border_radius_top_right.tick(time)
+        | cx.style.border_radius_bottom_left.tick(time)
+        | cx.style.border_radius_bottom_right.tick(time)
+        | cx.style.background_color.tick(time)
+        | cx.style.outer_shadow_h_offset.tick(time)
+        | cx.style.outer_shadow_v_offset.tick(time)
+        | cx.style.outer_shadow_blur.tick(time)
+        | cx.style.outer_shadow_color.tick(time)
+        | cx.style.font_color.tick(time);
 
-    cx.style.needs_relayout = true;
+    // Properties which affect layout
+    let needs_relayout = cx.style.border_width.tick(time)
+        | cx.style.font_size.tick(time)
+        | cx.style.left.tick(time)
+        | cx.style.right.tick(time)
+        | cx.style.top.tick(time)
+        | cx.style.bottom.tick(time)
+        | cx.style.width.tick(time)
+        | cx.style.height.tick(time)
+        | cx.style.max_width.tick(time)
+        | cx.style.max_height.tick(time)
+        | cx.style.min_width.tick(time)
+        | cx.style.min_height.tick(time)
+        | cx.style.min_left.tick(time)
+        | cx.style.max_left.tick(time)
+        | cx.style.min_right.tick(time)
+        | cx.style.max_right.tick(time)
+        | cx.style.min_top.tick(time)
+        | cx.style.max_top.tick(time)
+        | cx.style.min_bottom.tick(time)
+        | cx.style.max_bottom.tick(time)
+        | cx.style.row_between.tick(time)
+        | cx.style.col_between.tick(time)
+        | cx.style.child_left.tick(time)
+        | cx.style.child_right.tick(time)
+        | cx.style.child_top.tick(time)
+        | cx.style.child_bottom.tick(time);
+
+    cx.style.needs_redraw |= needs_redraw | needs_relayout;
+    cx.style.needs_relayout |= needs_relayout;
+
+    return needs_redraw | needs_relayout;
 }

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -6,6 +6,7 @@ use super::text_constraints_system;
 
 pub(crate) fn layout_system(cx: &mut Context, tree: &Tree<Entity>) {
     if cx.style.needs_relayout {
+        println!("Relayout");
         text_constraints_system(cx, tree);
 
         layout(&mut cx.cache, &cx.tree, &cx.style, &mut cx.text_context);

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -8,10 +8,10 @@ pub(crate) fn layout_system(cx: &mut Context, tree: &Tree<Entity>) {
     text_constraints_system(cx, tree);
 
     if cx.style.needs_relayout {
-        println!("Relayout");
         layout(&mut cx.cache, &cx.tree, &cx.style, &mut cx.text_context);
 
         cx.style.needs_relayout = false;
+        cx.style.needs_redraw = true;
 
         for entity in cx.tree.into_iter() {
             if cx.text_context.has_buffer(entity) {

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -5,10 +5,10 @@ use crate::prelude::*;
 use super::text_constraints_system;
 
 pub(crate) fn layout_system(cx: &mut Context, tree: &Tree<Entity>) {
+    text_constraints_system(cx, tree);
+
     if cx.style.needs_relayout {
         println!("Relayout");
-        text_constraints_system(cx, tree);
-
         layout(&mut cx.cache, &cx.tree, &cx.style, &mut cx.text_context);
 
         cx.style.needs_relayout = false;

--- a/crates/vizia_core/src/systems/mod.rs
+++ b/crates/vizia_core/src/systems/mod.rs
@@ -11,7 +11,6 @@ pub(crate) mod visibility;
 pub(crate) mod z_order;
 
 pub(crate) use self::image::*;
-pub use animation::has_animations;
 pub(crate) use animation::*;
 pub(crate) use clipping::*;
 pub(crate) use draw::*;

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -222,19 +222,19 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Display
     if cx.style.display.link(entity, &matched_rules) {
-        //println!("1");
+        println!("1");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.visibility.link(entity, &matched_rules) {
-        //println!("2");
+        println!("2");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.z_order.link(entity, &matched_rules) {
-        //println!("3");
+        println!("3");
         should_redraw = true;
     }
 
@@ -244,81 +244,81 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Opacity
     if cx.style.opacity.link(entity, &matched_rules) {
-        //println!("4");
+        println!("4");
         should_redraw = true;
     }
 
     if cx.style.left.link(entity, &matched_rules) {
-        //println!("6");
+        println!("5");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.right.link(entity, &matched_rules) {
-        //println!("7");
+        println!("6");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.top.link(entity, &matched_rules) {
-        //println!("8");
+        println!("7");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.bottom.link(entity, &matched_rules) {
-        //println!("9");
+        println!("8");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Size
     if cx.style.width.link(entity, &matched_rules) {
-        //println!("10");
+        println!("9");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.height.link(entity, &matched_rules) {
-        //println!("11");
+        println!("10");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Size Constraints
     if cx.style.max_width.link(entity, &matched_rules) {
-        //println!("12");
+        println!("11");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.min_width.link(entity, &matched_rules) {
-        //println!("13");
+        println!("13");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.max_height.link(entity, &matched_rules) {
-        //println!("14");
+        println!("14");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.min_height.link(entity, &matched_rules) {
-        //println!("15");
+        println!("15");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Border
     if cx.style.border_width.link(entity, &matched_rules) {
-        //println!("24");
+        println!("24");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.border_color.link(entity, &matched_rules) {
-        //println!("25");
+        println!("25");
         should_redraw = true;
     }
 
@@ -339,22 +339,22 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if cx.style.border_radius_top_left.link(entity, &matched_rules) {
-        //println!("26");
+        println!("26");
         should_redraw = true;
     }
 
     if cx.style.border_radius_top_right.link(entity, &matched_rules) {
-        //println!("27");
+        println!("27");
         should_redraw = true;
     }
 
     if cx.style.border_radius_bottom_left.link(entity, &matched_rules) {
-        //println!("28");
+        println!("28");
         should_redraw = true;
     }
 
     if cx.style.border_radius_bottom_right.link(entity, &matched_rules) {
-        //println!("29");
+        println!("29");
         should_redraw = true;
     }
 
@@ -371,42 +371,42 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if cx.style.layout_type.link(entity, &matched_rules) {
-        //println!("30");
+        println!("30");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.position_type.link(entity, &matched_rules) {
-        //println!("30");
+        println!("30");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Background
     if cx.style.background_color.link(entity, &matched_rules) {
-        //println!("41");
+        println!("41");
         should_redraw = true;
     }
 
     if cx.style.background_image.link(entity, &matched_rules) {
-        //println!("42");
+        println!("42");
         should_redraw = true;
     }
 
     // Font
     if cx.style.font_color.link(entity, &matched_rules) {
-        //println!("43");
+        println!("43");
         should_redraw = true;
     }
 
     if cx.style.font_size.link(entity, &matched_rules) {
-        //println!("44");
+        println!("44");
         should_redraw = true;
         should_relayout = true;
     }
 
     if cx.style.font_family.link(entity, &matched_rules) {
-        //println!("44");
+        println!("44");
         should_redraw = true;
         should_relayout = true;
     }
@@ -436,43 +436,43 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Outer Shadow
     if cx.style.outer_shadow_h_offset.link(entity, &matched_rules) {
-        //println!("45");
+        println!("45");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_v_offset.link(entity, &matched_rules) {
-        //println!("46");
+        println!("46");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_blur.link(entity, &matched_rules) {
-        //println!("47");
+        println!("47");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_color.link(entity, &matched_rules) {
-        //println!("48");
+        println!("48");
         should_redraw = true;
     }
 
     // Inner Shadow
     if cx.style.inner_shadow_h_offset.link(entity, &matched_rules) {
-        //println!("45");
+        println!("45");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_v_offset.link(entity, &matched_rules) {
-        //println!("46");
+        println!("46");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_blur.link(entity, &matched_rules) {
-        //println!("47");
+        println!("47");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_color.link(entity, &matched_rules) {
-        //println!("48");
+        println!("48");
         should_redraw = true;
     }
 
@@ -511,6 +511,7 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if should_relayout {
+        println!("should relayout");
         cx.style.needs_relayout = true;
     }
 

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -222,19 +222,19 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Display
     if cx.style.display.link(entity, &matched_rules) {
-        println!("1");
+        //println!("1");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.visibility.link(entity, &matched_rules) {
-        println!("2");
+        //println!("2");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.z_order.link(entity, &matched_rules) {
-        println!("3");
+        //println!("3");
         should_redraw = true;
     }
 
@@ -244,81 +244,81 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Opacity
     if cx.style.opacity.link(entity, &matched_rules) {
-        println!("4");
+        //println!("4");
         should_redraw = true;
     }
 
     if cx.style.left.link(entity, &matched_rules) {
-        println!("5");
+        //println!("5");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.right.link(entity, &matched_rules) {
-        println!("6");
+        //println!("6");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.top.link(entity, &matched_rules) {
-        println!("7");
+        //println!("7");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.bottom.link(entity, &matched_rules) {
-        println!("8");
+        //println!("8");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Size
     if cx.style.width.link(entity, &matched_rules) {
-        println!("9");
+        //println!("9");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.height.link(entity, &matched_rules) {
-        println!("10");
+        //println!("10");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Size Constraints
     if cx.style.max_width.link(entity, &matched_rules) {
-        println!("11");
+        //println!("11");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.min_width.link(entity, &matched_rules) {
-        println!("13");
+        //println!("13");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.max_height.link(entity, &matched_rules) {
-        println!("14");
+        //println!("14");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.min_height.link(entity, &matched_rules) {
-        println!("15");
+        //println!("15");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Border
     if cx.style.border_width.link(entity, &matched_rules) {
-        println!("24");
+        //println!("24");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.border_color.link(entity, &matched_rules) {
-        println!("25");
+        //println!("25");
         should_redraw = true;
     }
 
@@ -339,22 +339,22 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if cx.style.border_radius_top_left.link(entity, &matched_rules) {
-        println!("26");
+        //println!("26");
         should_redraw = true;
     }
 
     if cx.style.border_radius_top_right.link(entity, &matched_rules) {
-        println!("27");
+        //println!("27");
         should_redraw = true;
     }
 
     if cx.style.border_radius_bottom_left.link(entity, &matched_rules) {
-        println!("28");
+        //println!("28");
         should_redraw = true;
     }
 
     if cx.style.border_radius_bottom_right.link(entity, &matched_rules) {
-        println!("29");
+        //println!("29");
         should_redraw = true;
     }
 
@@ -371,42 +371,42 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if cx.style.layout_type.link(entity, &matched_rules) {
-        println!("30");
+        //println!("30");
         should_relayout = true;
         should_redraw = true;
     }
 
     if cx.style.position_type.link(entity, &matched_rules) {
-        println!("30");
+        //println!("30");
         should_relayout = true;
         should_redraw = true;
     }
 
     // Background
     if cx.style.background_color.link(entity, &matched_rules) {
-        println!("41");
+        //println!("41");
         should_redraw = true;
     }
 
     if cx.style.background_image.link(entity, &matched_rules) {
-        println!("42");
+        //println!("42");
         should_redraw = true;
     }
 
     // Font
     if cx.style.font_color.link(entity, &matched_rules) {
-        println!("43");
+        //println!("43");
         should_redraw = true;
     }
 
     if cx.style.font_size.link(entity, &matched_rules) {
-        println!("44");
+        //println!("44");
         should_redraw = true;
         should_relayout = true;
     }
 
     if cx.style.font_family.link(entity, &matched_rules) {
-        println!("44");
+        //println!("44");
         should_redraw = true;
         should_relayout = true;
     }
@@ -436,43 +436,43 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
 
     // Outer Shadow
     if cx.style.outer_shadow_h_offset.link(entity, &matched_rules) {
-        println!("45");
+        //println!("45");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_v_offset.link(entity, &matched_rules) {
-        println!("46");
+        //println!("46");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_blur.link(entity, &matched_rules) {
-        println!("47");
+        //println!("47");
         should_redraw = true;
     }
 
     if cx.style.outer_shadow_color.link(entity, &matched_rules) {
-        println!("48");
+        //println!("48");
         should_redraw = true;
     }
 
     // Inner Shadow
     if cx.style.inner_shadow_h_offset.link(entity, &matched_rules) {
-        println!("45");
+        //println!("45");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_v_offset.link(entity, &matched_rules) {
-        println!("46");
+        //println!("46");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_blur.link(entity, &matched_rules) {
-        println!("47");
+        //println!("47");
         should_redraw = true;
     }
 
     if cx.style.inner_shadow_color.link(entity, &matched_rules) {
-        println!("48");
+        //println!("48");
         should_redraw = true;
     }
 
@@ -511,7 +511,7 @@ fn link_style_data(cx: &mut Context, entity: Entity, matched_rules: &Vec<Rule>) 
     }
 
     if should_relayout {
-        println!("should relayout");
+        //println!("should relayout");
         cx.style.needs_relayout = true;
     }
 

--- a/crates/vizia_core/src/systems/text_constraints.rs
+++ b/crates/vizia_core/src/systems/text_constraints.rs
@@ -117,10 +117,16 @@ pub fn text_constraints_system(cx: &mut Context, tree: &Tree<Entity>) {
                 }
             }
 
-            cx.style.content_width.insert(entity, content_width / cx.style.dpi_factor as f32);
-            cx.style.content_height.insert(entity, content_height / cx.style.dpi_factor as f32);
+            let bounds = cx.cache.get_bounds(entity);
 
-            cx.style.needs_relayout = true;
+            if (desired_width == Auto && content_width != bounds.w)
+                || (desired_height == Auto && content_height != bounds.h)
+            {
+                cx.style.content_width.insert(entity, content_width / cx.style.dpi_factor as f32);
+                cx.style.content_height.insert(entity, content_height / cx.style.dpi_factor as f32);
+
+                cx.style.needs_relayout = true;
+            }
         }
     }
 }

--- a/crates/vizia_core/src/systems/text_constraints.rs
+++ b/crates/vizia_core/src/systems/text_constraints.rs
@@ -8,6 +8,11 @@ pub fn text_constraints_system(cx: &mut Context, tree: &Tree<Entity>) {
     draw_tree.sort_by_cached_key(|entity| cx.cache.get_z_index(*entity));
 
     for entity in draw_tree.into_iter() {
+        // Skip if the entity isn't marked as having its text modified
+        if !cx.style.needs_text_layout.get(entity).copied().unwrap_or_default() {
+            continue;
+        }
+
         if entity == Entity::root() {
             continue;
         }
@@ -91,6 +96,10 @@ pub fn text_constraints_system(cx: &mut Context, tree: &Tree<Entity>) {
                 if content_height < text_height {
                     content_height = text_height;
                 }
+
+                if let Some(needs_text_layout) = cx.style.needs_text_layout.get_mut(entity) {
+                    *needs_text_layout = false;
+                }
             }
 
             if let Some(image_name) = cx.style.image.get(entity) {
@@ -110,6 +119,8 @@ pub fn text_constraints_system(cx: &mut Context, tree: &Tree<Entity>) {
 
             cx.style.content_width.insert(entity, content_width / cx.style.dpi_factor as f32);
             cx.style.content_height.insert(entity, content_height / cx.style.dpi_factor as f32);
+
+            cx.style.needs_relayout = true;
         }
     }
 }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -74,7 +74,7 @@ impl TextboxData {
         cx.text_context.with_editor(self.content_entity, |buf| {
             buf.insert_string(text, None);
         });
-        cx.needs_relayout();
+        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
     }
 
     pub fn delete_text(&mut self, cx: &mut EventContext, movement: Movement) {
@@ -84,14 +84,14 @@ impl TextboxData {
                 buf.delete_selection();
             });
         }
-        cx.needs_relayout();
+        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
     }
 
     pub fn reset_text(&mut self, cx: &mut EventContext, text: &str) {
         cx.text_context.with_buffer(self.content_entity, |buf| {
             buf.set_text(text, Attrs::new());
         });
-        cx.needs_relayout();
+        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
     }
 
     pub fn move_cursor(&mut self, cx: &mut EventContext, movement: Movement, selection: bool) {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -74,7 +74,7 @@ impl TextboxData {
         cx.text_context.with_editor(self.content_entity, |buf| {
             buf.insert_string(text, None);
         });
-        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
+        cx.style.needs_text_layout.insert(self.content_entity, true).unwrap();
     }
 
     pub fn delete_text(&mut self, cx: &mut EventContext, movement: Movement) {
@@ -84,14 +84,14 @@ impl TextboxData {
                 buf.delete_selection();
             });
         }
-        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
+        cx.style.needs_text_layout.insert(self.content_entity, true).unwrap();
     }
 
     pub fn reset_text(&mut self, cx: &mut EventContext, text: &str) {
         cx.text_context.with_buffer(self.content_entity, |buf| {
             buf.set_text(text, Attrs::new());
         });
-        cx.style.needs_text_layout.insert(cx.current, true).unwrap();
+        cx.style.needs_text_layout.insert(self.content_entity, true).unwrap();
     }
 
     pub fn move_cursor(&mut self, cx: &mut EventContext, movement: Movement, selection: bool) {

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -204,7 +204,7 @@ impl Application {
                     cx.process_data_updates();
                     cx.process_style_updates();
 
-                    if has_animations(&cx.0) {
+                    if cx.process_animations() {
                         *stored_control_flow.borrow_mut() = ControlFlow::Poll;
 
                         event_loop_proxy.send_event(Event::new(WindowEvent::Redraw)).unwrap();

--- a/examples/7GUIs/crud.rs
+++ b/examples/7GUIs/crud.rs
@@ -136,21 +136,14 @@ fn main() {
                     });
 
                     List::new(cx, AppData::list, |cx, index, item| {
-                        Binding::new(cx, AppData::selected, move |cx, selected| {
-                            let is_selected = if let Some(selected) = selected.get(cx) {
-                                selected == index
-                            } else {
-                                false
-                            };
-                            Binding::new(cx, item, move |cx, item| {
-                                let (name, surname) = item.get(cx).clone();
-                                Label::new(cx, &format!("{}, {}", surname, name))
-                                    .on_press(move |cx| {
-                                        cx.emit(AppEvent::SetSelected(index));
-                                    })
-                                    .checked(is_selected);
-                            });
-                        });
+                        Label::new(
+                            cx,
+                            item.map(|(name, surname)| format!("{}, {}", surname, name)),
+                        )
+                        .on_press(move |cx| {
+                            cx.emit(AppEvent::SetSelected(index));
+                        })
+                        .checked(AppData::selected.map(move |selected| *selected == Some(index)));
                     });
                 });
 

--- a/examples/lists/editable_list.rs
+++ b/examples/lists/editable_list.rs
@@ -82,19 +82,15 @@ fn main() {
             );
 
             List::new(cx, AppData::list, move |cx, index, item| {
-                Binding::new(cx, AppData::selected, move |cx, selected| {
-                    let selected = selected.get(cx);
-
-                    Label::new(cx, item)
-                        .width(Pixels(100.0))
-                        .height(Pixels(30.0))
-                        .border_color(Color::black())
-                        .border_width(Pixels(1.0))
-                        // Set the checked state based on whether this item is selected
-                        .checked(if selected == index { true } else { false })
-                        // Set the selected item to this one if pressed
-                        .on_press(move |cx| cx.emit(AppEvent::Select(index)));
-                });
+                Label::new(cx, item)
+                    .width(Pixels(100.0))
+                    .height(Pixels(30.0))
+                    .border_color(Color::black())
+                    .border_width(Pixels(1.0))
+                    // Set the checked state based on whether this item is selected
+                    .checked(AppData::selected.map(move |selected| *selected == index))
+                    // Set the selected item to this one if pressed
+                    .on_press(move |cx| cx.emit(AppEvent::Select(index)));
             })
             .row_between(Pixels(5.0))
             .on_increment(move |cx| cx.emit(AppEvent::IncrementSelection))

--- a/examples/lists/multiselectable_list.rs
+++ b/examples/lists/multiselectable_list.rs
@@ -40,15 +40,11 @@ fn main() {
         List::new(cx, AppData::list, |cx, index, item| {
             // This vstack shouldn't be necessary but because of how bindings work it's required
             VStack::new(cx, move |cx| {
-                Binding::new(cx, AppData::selected, move |cx, selected| {
-                    let selected = selected.get(cx).contains(&index);
-
-                    Label::new(cx, item)
-                        // Set the checked state based on whether this item is selected
-                        .checked(selected)
-                        // Set the selected item to this one if pressed
-                        .on_press(move |cx| cx.emit(AppEvent::Select(index)));
-                });
+                Label::new(cx, item)
+                    // Set the checked state based on whether this item is selected
+                    .checked(AppData::selected.map(move |selected| selected.contains(&index)))
+                    // Set the selected item to this one if pressed
+                    .on_press(move |cx| cx.emit(AppEvent::Select(index)));
             });
         })
         .space(Stretch(1.0))

--- a/examples/lists/selectable_list.rs
+++ b/examples/lists/selectable_list.rs
@@ -44,22 +44,22 @@ fn main() {
                 let item_text = item.get(cx).to_string();
                 //let item_index = item.idx();
                 VStack::new(cx, move |cx| {
-                    Binding::new(cx, AppData::selected, move |cx, selected| {
-                        let selected = selected.get(cx);
-                        Label::new(cx, &item_text)
-                            // Set the checked state based on whether this item is selected
-                            .checked(if selected == index { true } else { false })
-                            // Set the selected item to this one if pressed
-                            .on_press(move |cx| cx.emit(AppEvent::Select(index)));
-                    });
+                    Label::new(cx, &item_text)
+                        // Set the checked state based on whether this item is selected
+                        .checked(AppData::selected.map(move |selected| *selected == index))
+                        // Set the selected item to this one if pressed
+                        .on_press(move |cx| cx.emit(AppEvent::Select(index)));
                 });
             })
             .on_increment(move |cx| cx.emit(AppEvent::IncrementSelection))
             .on_decrement(move |cx| cx.emit(AppEvent::DecrementSelection));
 
-            Binding::new(cx, AppData::selected, move |cx, selected_item| {
-                Label::new(cx, &format!("You have selected: {}", selected_item.get(cx),));
-            });
+            Label::new(
+                cx,
+                AppData::selected.map(|selected| format!("You have selected: {}", selected)),
+            )
+            .height(Pixels(30.0))
+            .width(Pixels(200.0));
         })
         .class("container");
     })

--- a/examples/lists/static_list.rs
+++ b/examples/lists/static_list.rs
@@ -47,15 +47,12 @@ fn main() {
         VStack::new(cx, move |cx| {
             List::new(cx, StaticLens::new(STATIC_LIST.as_ref()), move |cx, index, item| {
                 VStack::new(cx, move |cx| {
-                    Binding::new(cx, AppData::selected, move |cx, selected| {
-                        let selected = selected.get(cx);
-                        Label::new(cx, item)
-                            .class("list_item")
-                            // Set the checked state based on whether this item is selected
-                            .checked(if selected == index { true } else { false })
-                            // Set the selected item to this one if pressed
-                            .on_press(move |cx| cx.emit(AppEvent::Select(index)));
-                    });
+                    Label::new(cx, item)
+                        .class("list_item")
+                        // Set the checked state based on whether this item is selected
+                        .checked(AppData::selected.map(move |selected| *selected == index))
+                        // Set the selected item to this one if pressed
+                        .on_press(move |cx| cx.emit(AppEvent::Select(index)));
                 });
             })
             .on_increment(move |cx| cx.emit(AppEvent::IncrementSelection))

--- a/examples/views/radiobutton.rs
+++ b/examples/views/radiobutton.rs
@@ -38,7 +38,7 @@ fn main() {
                         cx,
                         AppData::option.map(move |option| *option == current_option),
                     )
-                    .disabled(if i == 2 { true } else { false })
+                    .disabled(i == 2)
                     .on_select(move |cx| cx.emit(AppDataSetter::Option(current_option)));
                 }
             })
@@ -57,7 +57,7 @@ fn main() {
                     .id(format!("button_{i}"));
                     Label::new(cx, &current_option.to_string()).describing(format!("button_{i}"));
                 })
-                .disabled(if i == 2 { true } else { false })
+                .disabled(i == 2)
                 .size(Auto)
                 .child_top(Stretch(1.0))
                 .child_bottom(Stretch(1.0))


### PR DESCRIPTION
- Prevents animation system from triggering relayout all the time
- Splits the text constraints system from layout so that only text which has changed causes content-size computation, and then only content size which is different to bounds results in relayout.
- Update some examples to use property bindings instead of the `Binding` view to prevent unnecessary relayout.