### PR TITLE
Changes to allow nih-plug to depend on vizia main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,13 +213,14 @@ name = "save_dialog"
 path = "examples/save_dialog.rs"
 
 [features]
-default = ["winit", "clipboard", "x11", "wayland"]
+default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]
 clipboard = ["vizia_core/clipboard", "vizia_winit/clipboard"]
 serde = ["vizia_core/serde"]
 winit = ["vizia_winit"]
 baseview = ["vizia_baseview"]
 x11 = ["vizia_winit?/x11", "vizia_core/x11"]
 wayland = ["vizia_winit?/wayland", "vizia_core/wayland"]
+embedded_fonts = ["vizia_core/embedded_fonts"]
 
 [dependencies]
 vizia_core = { version = "0.1.0", path = "crates/vizia_core"}

--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -14,6 +14,7 @@ vizia_id = { path = "../vizia_id" }
 
 baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "7001c2521fa1a439a01967cb881b411cd75d9ee0", features = ["opengl"] }
 raw-window-handle = "0.4.2"
-femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false }
+femtovg = "0.4.0"
+# femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false }
 #femtovg = { path = "../../../femtovg", default-features = false }
 lazy_static = "1.4.0"

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -18,6 +18,7 @@ where
     window_scale_policy: WindowScalePolicy,
     on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
     ignore_default_theme: bool,
+    text_config: TextConfig,
 }
 
 impl<F> Application<F>
@@ -32,6 +33,7 @@ where
             window_scale_policy: WindowScalePolicy::SystemScaleFactor,
             on_idle: None,
             ignore_default_theme: false,
+            text_config: TextConfig::default(),
         }
     }
 
@@ -45,6 +47,12 @@ where
     /// [`WindowDescription::scale_factor`] to set a separate arbitrary scale factor.
     pub fn with_scale_policy(mut self, scale_policy: WindowScalePolicy) -> Self {
         self.window_scale_policy = scale_policy;
+        self
+    }
+
+    pub fn with_text_config(mut self, text_config: TextConfig) -> Self {
+        self.text_config = text_config;
+
         self
     }
 
@@ -80,6 +88,7 @@ where
             self.app,
             self.on_idle,
             self.ignore_default_theme,
+            self.text_config,
         )
     }
 
@@ -98,6 +107,7 @@ where
             self.app,
             self.on_idle,
             self.ignore_default_theme,
+            self.text_config,
         )
     }
 
@@ -114,6 +124,7 @@ where
             self.app,
             self.on_idle,
             self.ignore_default_theme,
+            self.text_config,
         )
     }
 

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -68,6 +68,7 @@ impl ViziaWindow {
         app: F,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
         ignore_default_theme: bool,
+        text_config: TextConfig,
     ) -> WindowHandle
     where
         P: HasRawWindowHandle,
@@ -96,6 +97,7 @@ impl ViziaWindow {
                 context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
+                cx.set_text_config(text_config);
 
                 cx.set_event_proxy(Box::new(BaseviewProxy()));
                 ViziaWindow::new(
@@ -119,6 +121,7 @@ impl ViziaWindow {
         app: F,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
         ignore_default_theme: bool,
+        text_config: TextConfig,
     ) -> WindowHandle
     where
         F: Fn(&mut Context),
@@ -143,6 +146,7 @@ impl ViziaWindow {
                 context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
+                cx.set_text_config(text_config);
 
                 cx.set_event_proxy(Box::new(BaseviewProxy()));
                 ViziaWindow::new(
@@ -166,6 +170,7 @@ impl ViziaWindow {
         app: F,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
         ignore_default_theme: bool,
+        text_config: TextConfig,
     ) where
         F: Fn(&mut Context),
         F: 'static + Send,
@@ -189,6 +194,7 @@ impl ViziaWindow {
                 context.remove_user_themes();
 
                 let mut cx = BackendContext::new(&mut context);
+                cx.set_text_config(text_config);
 
                 cx.set_event_proxy(Box::new(BaseviewProxy()));
                 ViziaWindow::new(

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -21,7 +21,8 @@ vizia_id = { path = "../vizia_id" }
 vizia_input = { path = "../vizia_input" }
 vizia_window = { path = "../vizia_window" }
 
-femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false, features = ["image-loading"] }
+femtovg = "0.4.0"
+# femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false, features = ["image-loading"] }
 #femtovg = { path = "../../../femtovg", default-features = false, features = ["image-loading"] }
 image = { version = "0.24.0", default-features = false, features = ["png"] } # inherited from femtovg
 morphorm = {git = "https://github.com/vizia/morphorm", features = ["rounding"], rev = "3d74358fe976249738f58724854270aa2f0fdb4a" }

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.60"
 clipboard = ["copypasta"]
 x11 = ["copypasta?/x11"]
 wayland = ["copypasta?/wayland"]
+embedded_fonts = []
 
 [dependencies]
 vizia_derive = { path = "../vizia_derive" }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 use vizia_id::GenerationalId;
 
+pub use crate::text::cosmic::TextConfig;
+
 #[cfg(feature = "clipboard")]
 use copypasta::ClipboardProvider;
 
@@ -129,6 +131,11 @@ impl<'a> BackendContext<'a> {
     /// tree.
     pub fn set_current(&mut self, e: Entity) {
         self.0.current = e;
+    }
+
+    /// Sets the default text configuration to use for text rendering.
+    pub fn set_text_config(&mut self, text_config: TextConfig) {
+        self.0.text_config = text_config;
     }
 
     /// Temporarily sets the current entity, calls the provided closure, and then resets the current entity back to previous.

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 use crate::resource::ResourceManager;
 use crate::state::ModelDataStore;
 use crate::style::{LinearGradient, Style};
-use crate::text::TextContext;
+use crate::text::{TextConfig, TextContext};
 use vizia_input::{Modifiers, MouseState};
 use vizia_storage::SparseSet;
 
@@ -47,6 +47,7 @@ pub struct DrawContext<'a> {
     pub views: &'a FnvHashMap<Entity, Box<dyn ViewHandler>>,
     pub resource_manager: &'a ResourceManager,
     pub text_context: &'a mut TextContext,
+    pub text_config: &'a TextConfig,
     pub modifiers: &'a Modifiers,
     pub mouse: &'a MouseState<Entity>,
 }
@@ -88,6 +89,7 @@ impl<'a> DrawContext<'a> {
             views: &cx.views,
             resource_manager: &cx.resource_manager,
             text_context: &mut cx.text_context,
+            text_config: &cx.text_config,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
         }
@@ -164,7 +166,7 @@ impl<'a> DrawContext<'a> {
 
     pub fn draw_text(&mut self, canvas: &mut Canvas, origin: (f32, f32), justify: (f32, f32)) {
         if let Ok(draw_commands) =
-            self.text_context.fill_to_cmds(canvas, self.current, origin, justify)
+            self.text_context.fill_to_cmds(canvas, self.current, origin, justify, *self.text_config)
         {
             for (color, cmds) in draw_commands.into_iter() {
                 let temp_paint =

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -171,7 +171,7 @@ impl<'a> DrawContext<'a> {
             for (color, cmds) in draw_commands.into_iter() {
                 let temp_paint =
                     Paint::color(femtovg::Color::rgba(color.r(), color.g(), color.b(), color.a()));
-                canvas.draw_glyph_cmds(cmds, &temp_paint);
+                canvas.draw_glyph_cmds(cmds, &temp_paint, 1.0);
             }
         }
     }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -27,12 +27,13 @@ pub use proxy::*;
 use crate::cache::CachedData;
 use crate::environment::Environment;
 use crate::events::ViewHandler;
+#[cfg(feature = "embedded_fonts")]
 use crate::fonts;
 use crate::prelude::*;
 use crate::resource::{ImageOrId, ImageRetentionPolicy, ResourceManager, StoredImage};
 use crate::state::{BindingHandler, ModelDataStore};
 use crate::style::Style;
-use crate::text::TextContext;
+use crate::text::{TextConfig, TextContext};
 use vizia_id::{GenerationalId, IdManager};
 use vizia_input::{Modifiers, MouseState};
 use vizia_storage::SparseSet;
@@ -76,6 +77,7 @@ pub struct Context {
     pub(crate) resource_manager: ResourceManager,
 
     pub(crate) text_context: TextContext,
+    pub(crate) text_config: TextConfig,
 
     pub(crate) event_proxy: Option<Box<dyn EventProxy>>,
 
@@ -114,13 +116,17 @@ impl Context {
         // Add default fonts
         let mut db = Database::new();
         db.load_system_fonts();
-        db.load_font_data(Vec::from(fonts::ROBOTO_REGULAR));
-        db.load_font_data(Vec::from(fonts::ROBOTO_BOLD));
-        db.load_font_data(Vec::from(fonts::ROBOTO_ITALIC));
-        db.load_font_data(Vec::from(fonts::ENTYPO));
-        db.load_font_data(Vec::from(fonts::OPEN_SANS_EMOJI));
-        db.load_font_data(Vec::from(fonts::AMIRI_REGULAR));
-        db.load_font_data(Vec::from(fonts::MATERIAL_ICONS_REGULAR));
+
+        #[cfg(feature = "embedded_fonts")]
+        {
+            db.load_font_data(Vec::from(fonts::ROBOTO_REGULAR));
+            db.load_font_data(Vec::from(fonts::ROBOTO_BOLD));
+            db.load_font_data(Vec::from(fonts::ROBOTO_ITALIC));
+            db.load_font_data(Vec::from(fonts::ENTYPO));
+            db.load_font_data(Vec::from(fonts::OPEN_SANS_EMOJI));
+            db.load_font_data(Vec::from(fonts::AMIRI_REGULAR));
+            db.load_font_data(Vec::from(fonts::MATERIAL_ICONS_REGULAR));
+        }
 
         let mut result = Self {
             entity_manager: IdManager::new(),
@@ -151,6 +157,8 @@ impl Context {
                 sys_locale::get_locale().unwrap_or_else(|| "en-US".to_owned()),
                 db,
             ),
+
+            text_config: TextConfig::default(),
 
             event_proxy: None,
 

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -76,6 +76,7 @@ pub fn draw_system(cx: &mut Context) {
                     views: &cx.views,
                     resource_manager: &cx.resource_manager,
                     text_context: &mut cx.text_context,
+                    text_config: &cx.text_config,
                     modifiers: &cx.modifiers,
                     mouse: &cx.mouse,
                 },

--- a/crates/vizia_core/src/text/cosmic.rs
+++ b/crates/vizia_core/src/text/cosmic.rs
@@ -223,12 +223,11 @@ impl TextContext {
                                         src_buf.push(RGBA8::new(chunk[0], 0, 0, 0));
                                     }
                                 }
-                                Content::Color => {
+                                Content::Color | Content::SubpixelMask => {
                                     for chunk in rendered.data.chunks_exact(4) {
                                         src_buf.push(RGBA8::new(chunk[0], chunk[1], chunk[2], chunk[3]));
                                     }
                                 }
-                                Content::SubpixelMask => unreachable!(),
                             }
                             canvas.update_image::<ImageSource>(int.glyph_textures[texture_index].image_id, ImgRef::new(&src_buf, content_w, content_h).into(), atlas_content_x as usize, atlas_content_y as usize).unwrap();
 

--- a/crates/vizia_core/src/text/cosmic.rs
+++ b/crates/vizia_core/src/text/cosmic.rs
@@ -23,6 +23,18 @@ const GLYPH_PADDING: u32 = 1;
 const GLYPH_MARGIN: u32 = 1;
 const TEXTURE_SIZE: usize = 512;
 
+#[derive(Debug, Clone, Copy)]
+pub struct TextConfig {
+    pub hint: bool,
+    pub subpixel: bool,
+}
+
+impl Default for TextConfig {
+    fn default() -> Self {
+        Self { hint: true, subpixel: false }
+    }
+}
+
 #[self_referencing]
 pub struct TextContext {
     font_system: FontSystem,
@@ -41,6 +53,7 @@ struct TextContextInternal<'a> {
 }
 
 impl TextContext {
+    #[allow(dead_code)]
     pub(crate) fn font_system(&self) -> &FontSystem {
         self.borrow_font_system()
     }
@@ -124,6 +137,7 @@ impl TextContext {
         entity: Entity,
         position: (f32, f32),
         justify: (f32, f32),
+        config: TextConfig,
     ) -> Result<Vec<(FontColor, GlyphDrawCommands)>, ErrorKind> {
         if !self.has_buffer(entity) {
             return Ok(vec![]);
@@ -163,7 +177,7 @@ impl TextContext {
                             Source::ColorBitmap(StrikeWith::BestFit),
                             Source::Outline,
                         ])
-                            .format(Format::Alpha)
+                            .format(if config.subpixel {Format::Subpixel} else {Format::Alpha})
                             .offset(offset)
                             .render(&mut scaler, cache_key.glyph_id);
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -211,6 +211,7 @@ impl TextboxData {
         self.transform = (tx / scale, ty / scale);
     }
 
+    #[allow(dead_code)]
     pub fn clone_selected(&self, cx: &mut EventContext) -> Option<String> {
         cx.text_context.with_editor(self.content_entity, |buf| buf.copy_selection())
     }

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -20,14 +20,16 @@ vizia_id = { path = "../vizia_id" }
 vizia_window = { path = "../vizia_window" }
 
 winit = { version = "0.27.2", default-features = false }
-femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false }
+femtovg = "0.4.0"
+# femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", default-features = false }
 #femtovg = { path = "../../../femtovg", default-features = false }
 glutin = { version = "0.29.1", default-features = false, optional = true }
 copypasta = {version = "0.8.1", optional = true, default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.29.1", default-features = false }
-femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", features = ["glutin"] }
+femtovg = "0.4.0"
+# femtovg = { git = "https://github.com/rhelmot/femtovg", rev = "09f4837fff4d2cd58ddc4674d0d7e1296a4123aa", features = ["glutin"] }
 #femtovg = { path = "../../../femtovg", default-features = false, features = ["glutin"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -92,6 +92,11 @@ impl Application {
         self
     }
 
+    pub fn set_text_config(mut self, text_config: TextConfig) -> Self {
+        BackendContext::new(&mut self.context).set_text_config(text_config);
+        self
+    }
+
     pub fn should_poll(mut self) -> Self {
         self.should_poll = true;
 

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -116,7 +116,10 @@ impl Window {
         };
 
         // Build the femtovg renderer
-        let renderer = OpenGl::new_from_glutin_context(&handle).expect("Cannot create renderer");
+        let renderer = unsafe {
+            OpenGl::new_from_function(|s| handle.get_proc_address(s) as *const _)
+                .expect("Cannot create renderer")
+        };
 
         let mut canvas = Canvas::new(renderer).expect("Failed to create canvas");
 


### PR DESCRIPTION
As far as I can tell these are the minimal set of changes required for [nih-plug](https://github.com/robbert-vdh/nih-plug) to depend on vizia main rather than a fork of vizia, which will make it easier for nih-plug to adopt changes to vizia.

- Added feature to allow disabling the default fonts from bein embedded into the binary.
- Added `set_text_config()` method on `Application` to allow configuring the hinting and subpixel rendering of text using a new `TextConfig` type.
- Updated femtovg to v0.4.0