### PR TITLE
Fix for panic when minimizing window

### DIFF
--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -192,11 +192,13 @@ impl Window {
     }
 
     pub fn resize(&self, size: PhysicalSize<u32>) {
-        self.surface.resize(
-            &self.context,
-            size.width.try_into().unwrap(),
-            size.height.try_into().unwrap(),
-        );
+        if size.width != 0 && size.height != 0 {
+            self.surface.resize(
+                &self.context,
+                size.width.try_into().unwrap(),
+                size.height.try_into().unwrap(),
+            );
+        }
     }
 
     pub fn swap_buffers(&self) {


### PR DESCRIPTION
Don't know if this is just a windows thing but apparenty minimizing the window sends a resize event with 0 size. Which is just weird... Anyway this fixes a panic caused by the `try_into` conversion from u32 to NonZeroU32.