### PR TITLE
Add tuple lens and boolean or & and lenses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,10 @@ path = "examples/style/outline.rs"
 name = "save_dialog"
 path = "examples/save_dialog.rs"
 
+[[example]]
+name = "boolean"
+path = "examples/binding/boolean.rs"
+
 [features]
 default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]
 clipboard = ["vizia_core/clipboard", "vizia_winit/clipboard"]

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -1,3 +1,4 @@
+use crate::prelude::Wrapper;
 use unic_langid::LanguageIdentifier;
 use vizia_derive::Lens;
 

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -51,7 +51,7 @@ pub mod prelude {
     pub use super::modifiers::{
         AbilityModifiers, ActionModifiers, LayoutModifiers, StyleModifiers, TextModifiers,
     };
-    pub use super::state::{Binding, Data, Lens, LensExt, Model, Res, Setter};
+    pub use super::state::{Binding, Data, Lens, LensExt, Model, OrLens, Res, Setter, Wrapper};
     pub use super::view::{Canvas, View};
     pub use super::views::*;
     pub use super::window::WindowModifiers;

--- a/crates/vizia_core/src/state/lens.rs
+++ b/crates/vizia_core/src/state/lens.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::ops::Deref;
+use std::ops::{BitAnd, BitOr, Deref};
 
 use crate::prelude::*;
 
@@ -68,6 +68,22 @@ pub trait LensExt: Lens {
             cx.data().expect("Failed to get data from context. Has it been built into the tree?"),
             |t| t.cloned().map(|v| v),
         )
+    }
+
+    fn or<Other>(self, other: Other) -> OrLens<Self, Other>
+    where
+        Other: Lens<Target = bool>,
+        Self: Lens<Target = bool>,
+    {
+        OrLens::new(self, other)
+    }
+
+    fn and<Other>(self, other: Other) -> AndLens<Self, Other>
+    where
+        Other: Lens<Target = bool>,
+        Self: Lens<Target = bool>,
+    {
+        AndLens::new(self, other)
     }
 
     /// Used to construct a lens to some data contained within some other lensed data.
@@ -363,5 +379,239 @@ where
         } else {
             map(None)
         }
+    }
+}
+
+pub struct OrLens<L1, L2> {
+    lens1: L1,
+    lens2: L2,
+}
+
+impl<L1, L2> OrLens<L1, L2> {
+    pub fn new(lens1: L1, lens2: L2) -> Self
+    where
+        L1: Lens<Target = bool>,
+        L2: Lens<Target = bool>,
+    {
+        Self { lens1, lens2 }
+    }
+}
+
+impl<L1, L2> Lens for OrLens<L1, L2>
+where
+    L1: Lens<Source = L2::Source, Target = bool>,
+    L2: Lens<Target = bool>,
+{
+    type Source = L1::Source;
+    type Target = bool;
+
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        self.lens1.view(source, |t1| {
+            if let Some(l1) = t1 {
+                self.lens2.view(source, |t2| {
+                    if let Some(l2) = t2 {
+                        return map(Some(&(*l1 | *l2)));
+                    } else {
+                        map(None)
+                    }
+                })
+            } else {
+                map(None)
+            }
+        })
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        self.lens1.name()
+    }
+}
+
+impl<L1: Clone, L2: Clone> Clone for OrLens<L1, L2> {
+    fn clone(&self) -> Self {
+        Self { lens1: self.lens1.clone(), lens2: self.lens2.clone() }
+    }
+}
+
+#[derive(Clone)]
+pub struct Wrapper<L>(pub L);
+
+impl<L: Copy> Copy for Wrapper<L> {}
+
+impl<L: Lens> Lens for Wrapper<L> {
+    type Source = L::Source;
+    type Target = L::Target;
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        self.0.view(source, map)
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        self.0.name()
+    }
+}
+
+impl<L1: Lens<Target = bool>, L2: Lens<Target = bool>> BitOr<L2> for Wrapper<L1>
+where
+    L1: Lens<Source = L2::Source>,
+{
+    type Output = OrLens<Self, L2>;
+    fn bitor(self, rhs: L2) -> Self::Output {
+        OrLens::new(self, rhs)
+    }
+}
+
+impl<L1, L2, L3: Lens<Target = bool>> BitOr<L3> for OrLens<L1, L2>
+where
+    Self: Lens<Target = bool>,
+    Self: Lens<Source = L3::Source>,
+{
+    type Output = OrLens<Self, L3>;
+    fn bitor(self, rhs: L3) -> Self::Output {
+        OrLens::new(self, rhs)
+    }
+}
+
+impl<A: Lens, L1: Lens<Target = bool>, L2: Lens<Target = bool>> BitOr<L2> for Then<A, L1>
+where
+    A: Lens<Source = L2::Source>,
+    L1: Lens<Source = A::Target>,
+{
+    type Output = OrLens<Self, L2>;
+    fn bitor(self, rhs: L2) -> Self::Output {
+        OrLens::new(self, rhs)
+    }
+}
+
+impl<G: 'static + Clone + Fn(&I) -> bool, I: 'static, L2: Lens<Target = bool>> BitOr<L2>
+    for Map<G, I, bool>
+where
+    I: Lens<Source = L2::Source>,
+{
+    type Output = OrLens<Self, L2>;
+    fn bitor(self, rhs: L2) -> Self::Output {
+        OrLens::new(self, rhs)
+    }
+}
+
+pub struct AndLens<L1, L2> {
+    lens1: L1,
+    lens2: L2,
+}
+
+impl<L1, L2> AndLens<L1, L2> {
+    pub fn new(lens1: L1, lens2: L2) -> Self
+    where
+        L1: Lens<Target = bool>,
+        L2: Lens<Target = bool>,
+    {
+        Self { lens1, lens2 }
+    }
+}
+
+impl<L1, L2> Lens for AndLens<L1, L2>
+where
+    L1: Lens<Source = L2::Source, Target = bool>,
+    L2: Lens<Target = bool>,
+{
+    type Source = L1::Source;
+    type Target = bool;
+
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        self.lens1.view(source, |t1| {
+            if let Some(l1) = t1 {
+                self.lens2.view(source, |t2| {
+                    if let Some(l2) = t2 {
+                        return map(Some(&(*l1 & *l2)));
+                    } else {
+                        map(None)
+                    }
+                })
+            } else {
+                map(None)
+            }
+        })
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        self.lens1.name()
+    }
+}
+
+impl<L1: Clone, L2: Clone> Clone for AndLens<L1, L2> {
+    fn clone(&self) -> Self {
+        Self { lens1: self.lens1.clone(), lens2: self.lens2.clone() }
+    }
+}
+
+impl<L1: Lens<Target = bool>, L2: Lens<Target = bool>> BitAnd<L2> for Wrapper<L1>
+where
+    L1: Lens<Source = L2::Source>,
+{
+    type Output = AndLens<Self, L2>;
+    fn bitand(self, rhs: L2) -> Self::Output {
+        AndLens::new(self, rhs)
+    }
+}
+
+impl<L1, L2, L3: Lens<Target = bool>> BitAnd<L3> for AndLens<L1, L2>
+where
+    Self: Lens<Target = bool>,
+    Self: Lens<Source = L3::Source>,
+{
+    type Output = AndLens<Self, L3>;
+    fn bitand(self, rhs: L3) -> Self::Output {
+        AndLens::new(self, rhs)
+    }
+}
+
+impl<A: Lens, L1: Lens<Target = bool>, L2: Lens<Target = bool>> BitAnd<L2> for Then<A, L1>
+where
+    A: Lens<Source = L2::Source>,
+    L1: Lens<Source = A::Target>,
+{
+    type Output = AndLens<Self, L2>;
+    fn bitand(self, rhs: L2) -> Self::Output {
+        AndLens::new(self, rhs)
+    }
+}
+
+impl<G: 'static + Clone + Fn(&I) -> bool, I: 'static, L2: Lens<Target = bool>> BitAnd<L2>
+    for Map<G, I, bool>
+where
+    I: Lens<Source = L2::Source>,
+{
+    type Output = AndLens<Self, L2>;
+    fn bitand(self, rhs: L2) -> Self::Output {
+        AndLens::new(self, rhs)
+    }
+}
+
+impl<L1, L2> Lens for (L1, L2)
+where
+    L1: Lens<Source = L2::Source>,
+    L2: Lens,
+    L1::Target: Clone,
+    L2::Target: Clone,
+{
+    type Source = L1::Source;
+    type Target = (L1::Target, L2::Target);
+
+    fn view<O, F: FnOnce(Option<&Self::Target>) -> O>(&self, source: &Self::Source, map: F) -> O {
+        self.0.view(source, |t1| {
+            if let Some(l1) = t1 {
+                self.1.view(source, |t2| {
+                    if let Some(l2) = t2 {
+                        return map(Some(&(l1.clone(), l2.clone())));
+                    } else {
+                        map(None)
+                    }
+                })
+            } else {
+                map(None)
+            }
+        })
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        self.0.name()
     }
 }

--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -183,8 +183,8 @@ impl Res<PositionType> for PositionType {
     }
 }
 
-impl<T: Copy> Res<(T, T)> for (T, T) {
-    fn get_val(&self, _: &Context) -> (T, T) {
+impl Res<(u32, u32)> for (u32, u32) {
+    fn get_val(&self, _: &Context) -> (u32, u32) {
         *self
     }
 

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -66,7 +66,7 @@ pub struct ScrollView<L> {
     data: L,
 }
 
-impl ScrollView<scroll_data_derived_lenses::root> {
+impl ScrollView<Wrapper<scroll_data_derived_lenses::root>> {
     pub fn new<F>(
         cx: &mut Context,
         initial_x: f32,

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -177,7 +177,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
         quote! {
             /// Lens for the corresponding field.
-            #field_vis const #lens_field_name: #twizzled_name::#field_name#lens_ty_generics = #twizzled_name::#field_name::new();
+            #field_vis const #lens_field_name: Wrapper<#twizzled_name::#field_name#lens_ty_generics> = Wrapper(#twizzled_name::#field_name::new());
         }
     });
 
@@ -212,7 +212,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         impl #impl_generics #struct_type #ty_generics #where_clause {
             #(#associated_items)*
 
-            pub const root: #twizzled_name::root#lens_ty_generics = #twizzled_name::root::new();
+            pub const root: Wrapper<#twizzled_name::root#lens_ty_generics> = Wrapper(#twizzled_name::root::new());
         }
     };
 

--- a/examples/binding/boolean.rs
+++ b/examples/binding/boolean.rs
@@ -1,0 +1,55 @@
+use vizia::prelude::*;
+
+#[derive(Debug, Lens)]
+pub struct ModelOne {
+    flag1: bool,
+    flag2: bool,
+    flag3: bool,
+}
+
+pub enum AppEvent {
+    ToggleOne,
+    ToggleTwo,
+    ToggleThree,
+}
+
+impl Model for ModelOne {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
+        event.map(|app_event, _| match app_event {
+            AppEvent::ToggleOne => {
+                self.flag1 ^= true;
+            }
+
+            AppEvent::ToggleTwo => {
+                self.flag2 ^= true;
+            }
+
+            AppEvent::ToggleThree => {
+                self.flag3 ^= true;
+            }
+        });
+    }
+}
+
+fn main() {
+    Application::new(|cx| {
+        ModelOne { flag1: true, flag2: false, flag3: false }.build(cx);
+
+        Checkbox::new(cx, ModelOne::flag1).on_toggle(|cx| cx.emit(AppEvent::ToggleOne));
+        Checkbox::new(cx, ModelOne::flag2).on_toggle(|cx| cx.emit(AppEvent::ToggleTwo));
+        Checkbox::new(cx, ModelOne::flag3).on_toggle(|cx| cx.emit(AppEvent::ToggleThree));
+
+        Element::new(cx).height(Pixels(30.0));
+
+        Checkbox::new(cx, ModelOne::flag1.or(ModelOne::flag2));
+        Checkbox::new(cx, ModelOne::flag1 | ModelOne::flag2 | ModelOne::flag3);
+        Checkbox::new(cx, ModelOne::flag1.and(ModelOne::flag2));
+        Checkbox::new(cx, ModelOne::flag1 & ModelOne::flag2 & ModelOne::flag3);
+
+        Checkbox::new(
+            cx,
+            (ModelOne::flag1, ModelOne::flag2).map(|(f1, f2)| !(*f1 | *f2)) | ModelOne::flag3,
+        );
+    })
+    .run();
+}


### PR DESCRIPTION
This PR adds three new lenses:

- The first is a tuple lens which can be used like so in a binding view:
```rust
// Rebuilds if either target data of lens1 or lens2 changes.
Binding::new(cx, (lens1, lens2), |cx, (l1, l2)|{

});
```
Or like so with a `map`:
```rust
(lens1, lens2).map(|(l1, l2)|{...});
```
This currently only works if the `Source` of lens1 is the same as the `Source` of lens2. 

This gets us one small step closer to 'derived data', which is data we can bind to that doesn't exist in a model(s) but is derived from data which does. `Map` allows us to derive data from a single lens, and now the tuple lens, combined with `map`, lets us derive data from multiple lenses of the same model (tuple lenses can be combined with other tuple lenses). Ideally in the future we would like to add what I'm calling 'multibinding', which would let us derive data from multiple lenses to different models.

- The second lens added is the `OrLens` and the third is the `AndLens`. These can be constructed from lenses which have a `Target` type of `bool` and will perform the `OR` or `AND` operation on the target values when the lens resolves. These can be used like so:
```rust
lens1.or(lens2)
lens.and(lens2)
```
Or like so:
```rust
lens1 | lens2
lens1 & lens2
```

To get that last part to work with the `|` and `&` operators I had to add a `Wrapper` type around derived lenses. This shouldn't make any practical difference to users of the crate as `Lens` is implemented for the `Wrapper`. The `BitOr` and `BitAnd` traits are then implemented for `Wrapper` lens, as well as `Then` and `Map` lenses.

The last part is maybe a little controvercial but it does allow you to do something like this:
```rust
// The HStack will be visible if either of the boolean values lensed by AppData::flag1 OR AppData::flag2 are true.
HStack::new(cx, |cx|{
    ...
})
.visibility(AppData::flag1 | AppData::flag2);
```