### PR TITLE
Implement `is_empty`

### DIFF
--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -78,7 +78,7 @@ impl<'s, 't, 'v> Element for Node<'s, 't, 'v> {
     }
 
     fn is_empty(&self) -> bool {
-        self.tree.has_children(self.entity)
+        !self.tree.has_children(self.entity)
     }
 
     fn is_root(&self) -> bool {

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -78,7 +78,7 @@ impl<'s, 't, 'v> Element for Node<'s, 't, 'v> {
     }
 
     fn is_empty(&self) -> bool {
-        true
+        self.tree.has_children(self.entity)
     }
 
     fn is_root(&self) -> bool {


### PR DESCRIPTION
Ok thats a small line of code but i think that should do it. I didn't found any tests so on your risk 😅
Also: from lines like https://github.com/vizia/vizia/blob/new-style-system/crates/vizia_style/selectors/matching.rs#L993 i think selectors like `:first-child` and `:last-child` should be also done but ill check on this again.