### PR TITLE
Optimize vizia_core::state::binding::Binding::remove() to not iterate…

### DIFF
--- a/crates/vizia_core/src/state/binding.rs
+++ b/crates/vizia_core/src/state/binding.rs
@@ -13,6 +13,7 @@ where
 {
     entity: Entity,
     lens: L,
+    #[allow(clippy::type_complexity)]
     content: Option<Box<dyn Fn(&mut Context, L)>>,
 }
 
@@ -34,6 +35,7 @@ where
     ///     let value = *lens.get(cx);
     ///     Label::new(cx, value.to_string());
     /// });
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<F>(cx: &mut Context, lens: L, builder: F)
     where
         F: 'static + Fn(&mut Context, L),
@@ -129,13 +131,13 @@ where
 }
 
 pub trait BindingHandler {
-    fn update<'a>(&mut self, cx: &'a mut Context);
+    fn update(&mut self, cx: &mut Context);
     fn remove(&self, cx: &mut Context);
     fn name(&self) -> Option<&'static str>;
 }
 
 impl<L: 'static + Lens> BindingHandler for Binding<L> {
-    fn update<'a>(&mut self, cx: &'a mut Context) {
+    fn update(&mut self, cx: &mut Context) {
         cx.remove_children(cx.current());
         if let Some(builder) = &self.content {
             (builder)(cx, self.lens.clone());
@@ -152,7 +154,9 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
                     if let Some(store) = model_data_store.stores.get_mut(&key) {
                         store.remove_observer(&self.entity);
 
-                        model_data_store.stores.retain(|_, store| store.num_observers() != 0);
+                        if store.num_observers() == 0 {
+                            model_data_store.stores.remove(&key);
+                        }
                     }
 
                     break;
@@ -166,7 +170,9 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
                         if let Some(store) = model_data_store.stores.get_mut(&key) {
                             store.remove_observer(&self.entity);
 
-                            model_data_store.stores.retain(|_, store| store.num_observers() != 0);
+                            if store.num_observers() == 0 {
+                                model_data_store.stores.remove(&key);
+                            }
                         }
 
                         break;


### PR DESCRIPTION
… through entire store on every remove. Additionally, fix or silence clippy warnings through the rest of binding.rs

I was profiling [Arborio](https://github.com/rhelmot/arborio)'s opening and closing maps and noticed a rather significant portion of time was spent removing children from bindings. Looking into the remove function, the entire model data store hashmap is iterated over when only a single element in it was mutated, which we still have a reference to. This change checks only that single store, and if appropriate, removes it.

This brought closing maps in Arborio down from sometimes almost half a second to basically instantaneous.


Additionally since I was looking at the file, I addressed all of the clippy warnings in it. The explicit lifetime in BindingHandler::update was pointless, so I removed it. The new() method not returning Self makes sense within this context, and I don't think a type alias for Binding::content would improve readability, so I silenced those warnings.