### PR TITLE
Fix parsing short color codes with alpha

### DIFF
--- a/crates/vizia_core/src/style/color.rs
+++ b/crates/vizia_core/src/style/color.rs
@@ -103,18 +103,16 @@ impl From<&str> for Color {
         match clean_hex.len() {
             3 | 4 => {
                 let hex = clean_hex.as_bytes();
-                let r = (hex[0] as char).to_digit(16).unwrap() as u8 * 17;
-                let g = (hex[1] as char).to_digit(16).unwrap() as u8 * 17;
-                let b = (hex[2] as char).to_digit(16).unwrap() as u8 * 17;
-
-                let mut data = ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8);
-
-                if clean_hex.len() == 3 {
-                    data |= 0x00_000_0FF;
-                } else {
-                    let a = (hex[0] as char).to_digit(16).unwrap() as u8 * 17;
-                    data |= a as u32;
+                fn digit_to_u8(digit: u8) -> u8 {
+                    (digit as char).to_digit(16).unwrap() as u8 * 0x11
                 }
+                let r = digit_to_u8(hex[0]);
+                let g = digit_to_u8(hex[1]);
+                let b = digit_to_u8(hex[2]);
+
+                let a = hex.get(3).copied().map_or(0xFF, digit_to_u8);
+
+                let data = ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32);
 
                 Color { data }
             }
@@ -249,5 +247,13 @@ mod tests {
         let color = Color::from(hex_color);
 
         assert_eq!(color, Color::rgba(255, 255, 255, 255));
+    }
+
+    #[test]
+    fn test_short_hex_with_alpha() {
+        let hex_color = "#1234";
+        let color = Color::from(hex_color);
+
+        assert_eq!(color, Color::rgba(0x11, 0x22, 0x33, 0x44));
     }
 }


### PR DESCRIPTION
Previously, when parsing a short color code with alpha, it read byte 0 into the alpha, which is actually the red channel. This fixes that, as well as refactors the surrounding code for clarity and adds a test.