### PR TITLE
Don't unconditionally require winit for the clipboard feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,7 @@ path = "examples/binding/boolean.rs"
 
 [features]
 default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]
-clipboard = ["vizia_core/clipboard", "vizia_winit/clipboard"]
+clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
 serde = ["vizia_core/serde"]
 winit = ["vizia_winit"]
 baseview = ["vizia_baseview"]


### PR DESCRIPTION
This meant that winit was always compiled in, even when using baseview. I noticed that my NIH-plug builds suddenly started requiring a bunch of wayland libs to be installed.