### PR TITLE
add Res impl for (f32, f32)

### DIFF
--- a/crates/vizia_core/src/state/res.rs
+++ b/crates/vizia_core/src/state/res.rs
@@ -196,6 +196,18 @@ impl Res<(u32, u32)> for (u32, u32) {
     }
 }
 
+impl Res<(f32, f32)> for (f32, f32) {
+    fn get_val(&self, _: &Context) -> (f32, f32) {
+        *self
+    }
+
+    fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F)
+    where
+        F: 'static + Fn(&mut Context, Entity, Self),
+    {
+        (closure)(cx, entity, *self);
+    }
+}
 impl<T: Clone + Res<T>> Res<Option<T>> for Option<T> {
     fn get_val(&self, _: &Context) -> Option<T> {
         self.clone()


### PR DESCRIPTION
This commit:
https://github.com/vizia/vizia/commit/4a638441a98af74c4719400897077ae479eda8ae 
broke code using the `translate( (f32, f32))` modifier, adding a Res impl like this seems to fix it