### PR TITLE
Documenting and renaming fields in Scrollview

### DIFF
--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -10,36 +10,49 @@ pub(crate) const SCROLL_SENSITIVITY: f32 = 35.0;
 
 #[derive(Lens, Data, Clone)]
 pub struct ScrollData {
+    /// Progress of scroll position between 0 and 1 for the x axis
     pub scroll_x: f32,
+    /// Progress of scroll position between 0 and 1 for the y axis
     pub scroll_y: f32,
-    pub child_x: f32,
-    pub child_y: f32,
-    pub parent_x: f32,
-    pub parent_y: f32,
 
+    /// Callback called when the scrollview is scrolled.
     #[lens(ignore)]
     pub on_scroll: Option<Arc<dyn Fn(&mut EventContext, f32, f32) + Send + Sync>>,
+
+    /// Width of the inner VStack which holds the content (typically bigger than container_width)
+    pub inner_width: f32,
+    /// Height of the inner VStack which holds the content (typically bigger than container_height)
+    pub inner_height: f32,
+    /// Width of the outer `ScrollView` which wraps the inner (typically smaller than inner_width)
+    pub container_width: f32,
+    /// Height of the outer `ScrollView` which wraps the inner (typically smaller than inner_height)
+    pub container_height: f32,
 }
 
 pub enum ScrollEvent {
+    /// Sets the progress of scroll position between 0 and 1 for the x axis
     SetX(f32),
+    /// Sets the progress of scroll position between 0 and 1 for the y axis
     SetY(f32),
+    /// Adds given progress to scroll position for the x axis and clamps between 0 and 1
     ScrollX(f32),
+    /// Adds given progress to scroll position for the y axis and clamps between 0 and 1
     ScrollY(f32),
-    ScrollXPx(f32),
-    ScrollYPx(f32),
+    /// Sets the Size for the inner VStack which holds the content (typically bigger than `ParentGeo(f32, f32)`)
     ChildGeo(f32, f32),
+    /// Sets the Size for the outer `ScrollView` which wraps the inner (typically smaller than `ChildGeo(f32, f32)`)
     ParentGeo(f32, f32),
+    /// Sets the `on_scroll` callback.
     SetOnScroll(Option<Arc<dyn Fn(&mut EventContext, f32, f32) + Send + Sync>>),
 }
 
 impl ScrollData {
     fn reset(&mut self) {
-        if self.child_x == self.parent_x {
+        if self.inner_width == self.container_width {
             self.scroll_x = 0.0;
         }
 
-        if self.child_y == self.parent_y {
+        if self.inner_height == self.container_height {
             self.scroll_y = 0.0;
         }
     }
@@ -56,47 +69,47 @@ impl Model for ScrollData {
                         (callback)(cx, self.scroll_x, self.scroll_y);
                     }
                 }
+
                 ScrollEvent::ScrollY(f) => {
                     self.scroll_y = (self.scroll_y + *f).clamp(0.0, 1.0);
                     if let Some(callback) = &self.on_scroll {
                         (callback)(cx, self.scroll_x, self.scroll_y);
                     }
                 }
+
                 ScrollEvent::SetX(f) => {
                     self.scroll_x = *f;
                     if let Some(callback) = &self.on_scroll {
                         (callback)(cx, self.scroll_x, self.scroll_y);
                     }
                 }
+
                 ScrollEvent::SetY(f) => {
                     self.scroll_y = *f;
                     if let Some(callback) = &self.on_scroll {
                         (callback)(cx, self.scroll_x, self.scroll_y);
                     }
                 }
+
                 ScrollEvent::ChildGeo(x, y) => {
-                    self.child_x = *x;
-                    self.child_y = *y;
+                    self.inner_width = *x;
+                    self.inner_height = *y;
                     self.reset();
                 }
-                ScrollEvent::ParentGeo(x, y) => {
-                    self.parent_x = *x;
-                    self.parent_y = *y;
+
+                ScrollEvent::ParentGeo(w, h) => {
+                    self.container_width = *w;
+                    self.container_height = *h;
                     self.reset();
                 }
-                ScrollEvent::ScrollXPx(delta) => {
-                    self.scroll_x = delta / self.parent_x - self.child_x;
-                }
-                ScrollEvent::ScrollYPx(delta) => {
-                    let d = delta / (self.child_y - self.parent_y);
-                    self.scroll_y += d;
-                    self.scroll_y = self.scroll_y.clamp(0.0, 1.0);
-                }
+
                 ScrollEvent::SetOnScroll(on_scroll) => {
                     self.on_scroll = on_scroll.clone();
                 }
             }
 
+            // Prevent scroll events propagating to any parent scrollviews.
+            // TODO: This might be desired behavior when the scrollview is scrolled all the way.
             meta.consume();
         });
     }
@@ -123,17 +136,20 @@ impl ScrollView<Wrapper<scroll_data_derived_lenses::root>> {
                 ScrollData {
                     scroll_x: initial_x,
                     scroll_y: initial_y,
-                    child_x: 0.0,
-                    child_y: 0.0,
-                    parent_x: 0.0,
-                    parent_y: 0.0,
+                    inner_width: 0.0,
+                    inner_height: 0.0,
+                    container_width: 0.0,
+                    container_height: 0.0,
                     on_scroll: None,
                 }
                 .build(cx);
 
                 Self::common_builder(cx, ScrollData::root, content, scroll_x, scroll_y);
             })
-            .checked(ScrollData::root.map(|data| data.parent_y != data.child_y))
+            .checked(ScrollData::root.map(|data| {
+                (data.container_height != data.inner_height)
+                    || (data.container_width != data.inner_width)
+            }))
     }
 }
 
@@ -165,9 +181,9 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
             let dpi_factor = handle.scale_factor();
             if dpi_factor > 0.0 {
                 let data = data.get(handle.cx);
-                let left = ((data.child_x - data.parent_x) * data.scroll_x).round()
+                let left = ((data.inner_width - data.container_width) * data.scroll_x).round()
                     / handle.cx.style.dpi_factor as f32;
-                let top = ((data.child_y - data.parent_y) * data.scroll_y).round()
+                let top = ((data.inner_height - data.container_height) * data.scroll_y).round()
                     / handle.cx.style.dpi_factor as f32;
                 handle.left(Units::Pixels(-left.abs())).top(Units::Pixels(-top.abs()));
             }
@@ -177,7 +193,8 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
             Scrollbar::new(
                 cx,
                 data.clone().then(ScrollData::scroll_y),
-                data.clone().then(RatioLens::new(ScrollData::parent_y, ScrollData::child_y)),
+                data.clone()
+                    .then(RatioLens::new(ScrollData::container_height, ScrollData::inner_height)),
                 Orientation::Vertical,
                 |cx, value| {
                     cx.emit(ScrollEvent::SetY(value));
@@ -190,7 +207,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
             Scrollbar::new(
                 cx,
                 data.clone().then(ScrollData::scroll_x),
-                data.then(RatioLens::new(ScrollData::parent_x, ScrollData::child_x)),
+                data.then(RatioLens::new(ScrollData::container_width, ScrollData::inner_width)),
                 Orientation::Horizontal,
                 |cx, value| {
                     cx.emit(ScrollEvent::SetX(value));
@@ -222,16 +239,15 @@ impl<L: Lens<Target = ScrollData>> View for ScrollView<L> {
                 let (x, y) =
                     if cx.modifiers.contains(Modifiers::SHIFT) { (-*y, -*x) } else { (-*x, -*y) };
 
-                // what percentage of the negative space does this cross?
+                // What percentage of the negative space does this cross?
                 let data = self.data.get(cx);
-                if x != 0.0 && data.child_x > data.parent_x {
-                    let negative_space = data.child_x - data.parent_x;
+                if x != 0.0 && data.inner_width > data.container_width {
+                    let negative_space = data.inner_width - data.container_width;
                     let logical_delta = x * SCROLL_SENSITIVITY / negative_space;
                     cx.emit(ScrollEvent::ScrollX(logical_delta));
                 }
-                let data = cx.data::<ScrollData>().unwrap();
-                if y != 0.0 && data.child_y > data.parent_y {
-                    let negative_space = data.child_y - data.parent_y;
+                if y != 0.0 && data.inner_height > data.container_height {
+                    let negative_space = data.inner_height - data.container_height;
                     let logical_delta = y * SCROLL_SENSITIVITY / negative_space;
                     cx.emit(ScrollEvent::ScrollY(logical_delta));
                 }
@@ -247,6 +263,7 @@ impl<L: Lens<Target = ScrollData>> View for ScrollView<L> {
 }
 
 impl<'a, L: Lens> Handle<'a, ScrollView<L>> {
+    /// Sets a callback which will be called when a scrollview is scrolled, either with the mouse wheel, touchpad, or using the scroll bars.
     pub fn on_scroll(
         self,
         callback: impl Fn(&mut EventContext, f32, f32) + 'static + Send + Sync,
@@ -256,7 +273,7 @@ impl<'a, L: Lens> Handle<'a, ScrollView<L>> {
     }
 }
 
-pub struct ScrollContent {}
+struct ScrollContent {}
 
 impl ScrollContent {
     pub fn new(cx: &mut Context, content: impl FnOnce(&mut Context)) -> Handle<Self> {
@@ -276,6 +293,7 @@ impl View for ScrollContent {
                     || geo.contains(GeoChanged::HEIGHT_CHANGED)
                 {
                     let bounds = cx.bounds();
+                    // If the width or height have changed then send this back up to the ScrollData.
                     cx.emit(ScrollEvent::ChildGeo(bounds.w, bounds.h));
                 }
             }


### PR DESCRIPTION
I tried to reverse engineer some fields in Scrollview as preparation work for #74.
@geom3trik would you check over this and say if this is correct? Thanks :D

Other naming idea:
* `content_(width/height)` and `(width/height)`