### PR TITLE
Make `Lens` `Copy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,10 @@ path = "examples/custom_modifiers.rs"
 name = "keyframes"
 path = "examples/keyframes.rs"
 
+[[example]]
+name = "lens_map"
+path = "examples/lens_map.rs"
+
 
 [features]
 default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]

--- a/crates/vizia_core/src/binding/binding_view.rs
+++ b/crates/vizia_core/src/binding/binding_view.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 
-use crate::binding::{BasicStore, LensCache, Store, StoreId};
+use crate::binding::{BasicStore, Store, StoreId};
 use crate::context::{CURRENT, MAPS, MAP_MANAGER};
 use crate::model::ModelOrView;
 use crate::prelude::*;
@@ -68,7 +68,7 @@ where
         ) where
             L::Target: Data,
         {
-            let key = lens.cache_key();
+            let key = lens.id();
 
             if let Some(store) = stores.get_mut(&key) {
                 let observers = store.observers();
@@ -179,7 +179,7 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
             if let Some(model_data_store) = cx.data.get_mut(entity) {
                 // Check for model store
                 if model_data_store.models.get(&TypeId::of::<L::Source>()).is_some() {
-                    let key = self.lens.cache_key();
+                    let key = self.lens.id();
 
                     if let Some(store) = model_data_store.stores.get_mut(&key) {
                         store.remove_observer(&self.entity);
@@ -195,7 +195,7 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
                 // Check for view store
                 if let Some(view_handler) = cx.views.get(&entity) {
                     if view_handler.as_any_ref().is::<L::Source>() {
-                        let key = self.lens.cache_key();
+                        let key = self.lens.id();
 
                         if let Some(store) = model_data_store.stores.get_mut(&key) {
                             store.remove_observer(&self.entity);

--- a/crates/vizia_core/src/binding/binding_view.rs
+++ b/crates/vizia_core/src/binding/binding_view.rs
@@ -52,7 +52,7 @@ where
         cx.style.add(id);
         cx.tree.set_ignored(id, true);
 
-        let binding = Self { entity: id, lens: lens.clone(), content: Some(Box::new(builder)) };
+        let binding = Self { entity: id, lens, content: Some(Box::new(builder)) };
 
         let ancestors = cx.current().parent_iter(&cx.tree).collect::<HashSet<_>>();
         let new_ancestors = id.parent_iter(&cx.tree).collect::<Vec<_>>();
@@ -153,7 +153,7 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
 
         if let Some(builder) = &self.content {
             CURRENT.with(|f| *f.borrow_mut() = self.entity);
-            (builder)(cx, self.lens.clone());
+            (builder)(cx, self.lens);
         }
     }
 

--- a/crates/vizia_core/src/binding/binding_view.rs
+++ b/crates/vizia_core/src/binding/binding_view.rs
@@ -2,7 +2,7 @@ use std::any::TypeId;
 use std::collections::{HashMap, HashSet};
 
 use crate::binding::{BasicStore, LensCache, Store, StoreId};
-use crate::context::{CURRENT, MAPS};
+use crate::context::CURRENT;
 use crate::model::ModelOrView;
 use crate::prelude::*;
 
@@ -146,13 +146,10 @@ impl<L: 'static + Lens> BindingHandler for Binding<L> {
     fn update(&mut self, cx: &mut Context) {
         cx.remove_children(cx.current());
 
-        // Remove any maps associated with this binding
-        MAPS.with(|f| {
-            f.borrow_mut().retain(|map| map.0 != self.entity);
-        });
+        let parent = cx.tree.get_layout_parent(self.entity).unwrap();
 
         if let Some(builder) = &self.content {
-            CURRENT.with(|f| *f.borrow_mut() = self.entity);
+            CURRENT.with(|f| *f.borrow_mut() = parent);
             (builder)(cx, self.lens);
         }
     }

--- a/crates/vizia_core/src/binding/lens.rs
+++ b/crates/vizia_core/src/binding/lens.rs
@@ -107,13 +107,6 @@ pub trait LensExt: Lens {
         self.then(Index::new(index))
     }
 
-    // fn map<G: Clone, B: 'static + Clone>(self, get: G) -> Then<Self, Map<G, Self::Target, B>>
-    // where
-    //     G: 'static + Fn(&Self::Target) -> B,
-    // {
-    //     self.then(Map::new(get))
-    // }
-
     fn map<O: 'static, F: 'static + Fn(&Self::Target) -> O>(self, map: F) -> Map<Self, O> {
         let id = MAPS.with(|f| f.borrow().len());
         let entity = CURRENT.with(|f| *f.borrow());
@@ -159,7 +152,6 @@ impl<L: Lens, O: 'static> Clone for Map<L, O> {
 }
 
 impl<L: Lens, O: 'static> Lens for Map<L, O> {
-    // TODO can we get rid of these static bounds?
     type Source = L::Source;
     type Target = O;
 
@@ -173,6 +165,7 @@ impl<L: Lens, O: 'static> Lens for Map<L, O> {
             .view(source, |target| {
                 let mut value = None;
                 if let Some(t) = target {
+                    // Get and apply mapping function from thread local store.
                     MAPS.with(|f| {
                         if let Some(map) = f.borrow().get(self.id) {
                             if let Some(mapping) = map.1.downcast_ref::<MapState<L::Target, O>>() {

--- a/crates/vizia_core/src/binding/lens.rs
+++ b/crates/vizia_core/src/binding/lens.rs
@@ -147,7 +147,7 @@ impl<L: Lens, O: 'static> std::marker::Copy for Map<L, O> {}
 
 impl<L: Lens, O: 'static> Clone for Map<L, O> {
     fn clone(&self) -> Self {
-        Map { id: self.id, lens: self.lens, o: PhantomData }
+        *self
     }
 }
 

--- a/crates/vizia_core/src/binding/map.rs
+++ b/crates/vizia_core/src/binding/map.rs
@@ -1,0 +1,9 @@
+use vizia_id::{
+    impl_generational_id, GenerationalId, GENERATIONAL_ID_GENERATION_MASK,
+    GENERATIONAL_ID_INDEX_BITS, GENERATIONAL_ID_INDEX_MASK,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MapId(u32);
+
+impl_generational_id!(MapId);

--- a/crates/vizia_core/src/binding/mod.rs
+++ b/crates/vizia_core/src/binding/mod.rs
@@ -210,3 +210,6 @@ pub use res::*;
 
 mod ray;
 pub use ray::*;
+
+mod map;
+pub(crate) use map::MapId;

--- a/crates/vizia_core/src/binding/res.rs
+++ b/crates/vizia_core/src/binding/res.rs
@@ -114,7 +114,7 @@ where
         F: 'static + Fn(&mut EventContext, L::Target),
     {
         cx.with_current(entity, |cx| {
-            Binding::new(cx, self.clone(), move |cx, val| {
+            Binding::new(cx, *self, move |cx, val| {
                 if let Some(v) = val.get_val_fallible(cx) {
                     let cx = &mut EventContext::new_with_current(cx, entity);
                     (closure)(cx, v);

--- a/crates/vizia_core/src/binding/store.rs
+++ b/crates/vizia_core/src/binding/store.rs
@@ -10,8 +10,8 @@ pub(crate) fn next_uuid() -> u64 {
     UUID.fetch_add(1, Ordering::Relaxed)
 }
 
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum StoreId {
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum StoreId {
     Type(TypeId),
     Uuid(u64),
 }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -57,7 +57,9 @@ type Models = SparseSet<ModelDataStore>;
 type Bindings = FnvHashMap<Entity, Box<dyn BindingHandler>>;
 
 thread_local! {
+    // Store of mapping functions used for lens maps.
     pub static MAPS: RefCell<Vec<(Entity, Box<dyn Any>)>> = RefCell::new(Vec::new());
+    // The 'current' entity which is used for storing lens map mapping functions as per above.
     pub static CURRENT: RefCell<Entity> = RefCell::new(Entity::root());
 }
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -353,6 +353,21 @@ fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, met
             }
 
             #[cfg(debug_assertions)]
+            if *code == Code::KeyP && context.modifiers.contains(Modifiers::CTRL) {
+                for entity in TreeIterator::full(&context.tree) {
+                    if let Some(model_data_store) = context.data.get(entity) {
+                        print!(
+                            "{}{:?}",
+                            entity,
+                            model_data_store.models.keys().collect::<Vec<_>>()
+                        );
+                        print!("{:?}", model_data_store.stores.keys().collect::<Vec<_>>());
+                        println!();
+                    }
+                }
+            }
+
+            #[cfg(debug_assertions)]
             if *code == Code::KeyI && context.modifiers.contains(Modifiers::CTRL) {
                 println!("Entity tree");
                 let (tree, views, cache) = (&context.tree, &context.views, &context.cache);

--- a/crates/vizia_core/src/localization/mod.rs
+++ b/crates/vizia_core/src/localization/mod.rs
@@ -118,11 +118,11 @@ where
     }
 
     fn make_clone(&self) -> Box<dyn FluentStore> {
-        Box::new(self.clone())
+        Box::new(*self)
     }
 
     fn bind(&self, cx: &mut Context, closure: Box<dyn Fn(&mut Context)>) {
-        Binding::new(cx, self.lens.clone(), move |cx, _| closure(cx));
+        Binding::new(cx, self.lens, move |cx, _| closure(cx));
     }
 }
 

--- a/crates/vizia_core/src/view.rs
+++ b/crates/vizia_core/src/view.rs
@@ -131,6 +131,7 @@ pub trait View: 'static + Sized {
         let children =
             parent_id.child_iter(&cx.tree).map(|entity| entity.accesskit_id()).collect::<Vec<_>>();
 
+        // Set the current entity id so that any lens maps are associated with the right entity.
         CURRENT.with(|f| *f.borrow_mut() = id);
 
         let mut access_context = AccessContext {

--- a/crates/vizia_core/src/view.rs
+++ b/crates/vizia_core/src/view.rs
@@ -12,7 +12,7 @@
 //! .run();
 //! ```
 
-use crate::context::AccessNode;
+use crate::context::{AccessNode, CURRENT};
 use crate::model::ModelDataStore;
 use crate::prelude::*;
 use crate::systems::get_access_node;
@@ -130,6 +130,8 @@ pub trait View: 'static + Sized {
         let node_id = id.accesskit_id();
         let children =
             parent_id.child_iter(&cx.tree).map(|entity| entity.accesskit_id()).collect::<Vec<_>>();
+
+        CURRENT.with(|f| *f.borrow_mut() = id);
 
         let mut access_context = AccessContext {
             current: id,

--- a/crates/vizia_core/src/view.rs
+++ b/crates/vizia_core/src/view.rs
@@ -12,7 +12,7 @@
 //! .run();
 //! ```
 
-use crate::context::{AccessNode, CURRENT};
+use crate::context::AccessNode;
 use crate::model::ModelDataStore;
 use crate::prelude::*;
 use crate::systems::get_access_node;
@@ -130,9 +130,6 @@ pub trait View: 'static + Sized {
         let node_id = id.accesskit_id();
         let children =
             parent_id.child_iter(&cx.tree).map(|entity| entity.accesskit_id()).collect::<Vec<_>>();
-
-        // Set the current entity id so that any lens maps are associated with the right entity.
-        CURRENT.with(|f| *f.borrow_mut() = id);
 
         let mut access_context = AccessContext {
             current: id,

--- a/crates/vizia_core/src/views/checkbox.rs
+++ b/crates/vizia_core/src/views/checkbox.rs
@@ -138,7 +138,7 @@ impl Checkbox {
     pub fn new(cx: &mut Context, checked: impl Lens<Target = bool>) -> Handle<Self> {
         Self { on_toggle: None }
             .build(cx, |_| {})
-            .text(checked.clone().map(|flag| if *flag { ICON_CHECK } else { "" }))
+            .text(checked.map(|flag| if *flag { ICON_CHECK } else { "" }))
             .checked(checked)
             .role(Role::CheckBox)
             .default_action_verb(DefaultActionVerb::Click)
@@ -153,8 +153,7 @@ impl Checkbox {
     ) -> Handle<Self> {
         Self { on_toggle: None }
             .build(cx, |_| {})
-            .bind(checked.clone(), move |handle, c| {
-                let intermediate = intermediate.clone();
+            .bind(checked, move |handle, c| {
                 handle.bind(intermediate, move |handle, i| {
                     if c.get(handle.cx) {
                         handle.text(ICON_CHECK).toggle_class("intermediate", false);

--- a/crates/vizia_core/src/views/combobox.rs
+++ b/crates/vizia_core/src/views/combobox.rs
@@ -157,7 +157,7 @@ where
         event.map(|combobox_event, _| match combobox_event {
             ComboBoxEvent::SetOption(index) => {
                 // Set the placeholder text to the selected item.
-                let selected_item = self.list_lens.clone().index(*index).get(cx);
+                let selected_item = self.list_lens.index(*index).get(cx);
                 self.placeholder = selected_item.to_string();
 
                 // Call the on_select callback.
@@ -358,7 +358,7 @@ impl ComboPopup {
         Self {}
             .build(cx, |cx| {
                 let parent = cx.current;
-                Binding::new(cx, lens.clone(), move |cx, lens| {
+                Binding::new(cx, lens, move |cx, lens| {
                     if let Some(geo) = cx.cache.geo_changed.get_mut(parent) {
                         geo.set(GeoChanged::WIDTH_CHANGED, true);
                     }

--- a/crates/vizia_core/src/views/datepicker.rs
+++ b/crates/vizia_core/src/views/datepicker.rs
@@ -170,7 +170,6 @@ impl Datepicker {
                     for y in 0..6 {
                         HStack::new(cx, |cx| {
                             for x in 0..7 {
-                                let l = lens.clone();
                                 Label::new(cx, "").bind(
                                     Datepicker::view_date,
                                     move |handle, view_date| {
@@ -179,7 +178,7 @@ impl Datepicker {
                                         let (day_number, disabled) =
                                             Self::get_day_number(y, x, &view_date);
 
-                                        handle.bind(l.clone(), move |handle, selected_date| {
+                                        handle.bind(lens, move |handle, selected_date| {
                                             let selected_date = selected_date.get(handle.cx);
 
                                             handle

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -37,7 +37,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
         centered: bool,
     ) -> Handle<Self> {
         Self {
-            lens: lens.clone(),
+            lens,
             default_normal: normalized_default.get_val(cx),
 
             is_dragging: false,
@@ -62,7 +62,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
                     150.,
                     KnobMode::Continuous,
                 )
-                .value(lens.clone())
+                .value(lens)
                 .class("knob-track");
 
                 HStack::new(cx, |cx| {
@@ -85,7 +85,7 @@ impl<L: Lens<Target = f32>> Knob<L> {
         F: 'static + Fn(&mut Context, L) -> Handle<V>,
     {
         Self {
-            lens: lens.clone(),
+            lens,
             default_normal,
 
             is_dragging: false,

--- a/crates/vizia_core/src/views/list.rs
+++ b/crates/vizia_core/src/views/list.rs
@@ -29,13 +29,13 @@ impl<L: 'static + Lens<Target = Vec<T>>, T: Clone> List<L, T> {
         }
         .build(cx, move |cx| {
             // Bind to the list data
-            Binding::new(cx, lens.clone().map(|lst| lst.len()), move |cx, list_len| {
+            Binding::new(cx, lens.map(|lst| lst.len()), move |cx, list_len| {
                 // If the number of list items is different to the number of children of the ListView
                 // then remove and rebuild all the children
                 let list_len = list_len.get_fallible(cx).map_or(0, |d| d);
 
                 for index in 0..list_len {
-                    let ptr = lens.clone().index(index);
+                    let ptr = lens.index(index);
                     (item)(cx, index, ptr);
                 }
             });

--- a/crates/vizia_core/src/views/menu.rs
+++ b/crates/vizia_core/src/views/menu.rs
@@ -252,20 +252,20 @@ where
     where
         F: 'static + Fn(&mut Context),
     {
-        Self { lens: lens.clone() }
+        Self { lens }
             .build(cx, |cx| {
                 let parent = cx.current;
 
                 (content)(cx);
 
-                Binding::new(cx, lens.clone(), move |cx, _| {
+                Binding::new(cx, lens, move |cx, _| {
                     if let Some(geo) = cx.cache.geo_changed.get_mut(parent) {
                         geo.set(GeoChanged::WIDTH_CHANGED, true);
                     }
                 });
             })
             .role(Role::Dialog)
-            .checked(lens.clone())
+            .checked(lens)
             .position_type(PositionType::SelfDirected)
             .z_index(100)
     }

--- a/crates/vizia_core/src/views/picklist.rs
+++ b/crates/vizia_core/src/views/picklist.rs
@@ -22,22 +22,18 @@ impl PickList {
         L2: Lens<Target = usize>,
     {
         Self { on_select: None }.build(cx, |cx| {
-            let s = selected.clone();
-            let l = list_lens.clone();
             // Dropdown List
             Dropdown::new(
                 cx,
                 move |cx| {
-                    let l = l.clone();
-                    let s = s.clone();
                     // A Label and an Icon
                     HStack::new(cx, move |cx| {
                         Label::new(cx, "")
-                            .bind(l.clone(), move |handle, list| {
-                                handle.bind(s.clone(), move |handle, sel| {
+                            .bind(list_lens, move |handle, list| {
+                                handle.bind(selected, move |handle, sel| {
                                     let selected_index = sel.get(handle.cx);
 
-                                    handle.text(list.clone().index(selected_index));
+                                    handle.text(list.index(selected_index));
                                 });
                             })
                             .hoverable(false);
@@ -48,16 +44,14 @@ impl PickList {
                     .col_between(Stretch(1.0))
                 },
                 move |cx| {
-                    let s = selected.clone();
-                    let l = list_lens.clone();
                     let window_height = cx.cache.get_height(Entity::root());
                     let scale = cx.scale_factor();
                     ScrollView::new(cx, 0.0, 0.0, false, true, move |cx| {
-                        List::new(cx, l, move |cx, index, item| {
+                        List::new(cx, list_lens, move |cx, index, item| {
                             Label::new(cx, item)
                                 .child_top(Stretch(1.0))
                                 .child_bottom(Stretch(1.0))
-                                .checked(s.clone().map(move |selected| *selected == index))
+                                .checked(selected.map(move |selected| *selected == index))
                                 .navigable(true)
                                 .on_press(move |cx| {
                                     cx.emit(PickListEvent::SetOption(index));

--- a/crates/vizia_core/src/views/picklist.rs
+++ b/crates/vizia_core/src/views/picklist.rs
@@ -52,7 +52,7 @@ impl PickList {
                     let l = list_lens.clone();
                     let window_height = cx.cache.get_height(Entity::root());
                     let scale = cx.scale_factor();
-                    ScrollView::new(cx, 0.0, 0.0, false, true, |cx| {
+                    ScrollView::new(cx, 0.0, 0.0, false, true, move |cx| {
                         List::new(cx, l, move |cx, index, item| {
                             Label::new(cx, item)
                                 .child_top(Stretch(1.0))

--- a/crates/vizia_core/src/views/popup.rs
+++ b/crates/vizia_core/src/views/popup.rs
@@ -47,10 +47,10 @@ where
     where
         F: 'static + Fn(&mut Context),
     {
-        Self { lens: lens.clone() }
+        Self { lens }
             .build(cx, |cx| {
                 let parent = cx.current;
-                Binding::new(cx, lens.clone(), move |cx, lens| {
+                Binding::new(cx, lens, move |cx, lens| {
                     if let Some(geo) = cx.cache.geo_changed.get_mut(parent) {
                         geo.set(GeoChanged::WIDTH_CHANGED, true);
                     }

--- a/crates/vizia_core/src/views/rating.rs
+++ b/crates/vizia_core/src/views/rating.rs
@@ -26,7 +26,7 @@ impl Rating {
                         .role(Role::RadioButton)
                         .default_action_verb(DefaultActionVerb::Click)
                         .class("icon")
-                        .checked(lens.clone().map(move |val| *val >= i))
+                        .checked(lens.map(move |val| *val >= i))
                         .toggle_class("foo", Rating::rating.map(move |val| *val >= i))
                         .on_hover(move |ex| ex.emit(RatingEvent::SetRating(i)))
                         .on_press(|ex| ex.emit(RatingEvent::EmitRating));
@@ -35,7 +35,7 @@ impl Rating {
             .numeric_value(Self::rating)
             .navigable(true)
             .role(Role::RadioGroup)
-            .bind(lens.clone(), |handle, lens| {
+            .bind(lens, |handle, lens| {
                 let val = lens.get(handle.cx);
                 handle.modify(|rating| rating.rating = val);
             })

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -30,7 +30,7 @@ impl<L1: Lens<Target = f32>> Scrollbar<L1> {
         F: 'static + Fn(&mut EventContext, f32),
     {
         Self {
-            value: value.clone(),
+            value,
             orientation,
             reference_points: None,
             on_changing: Some(Box::new(callback)),

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -184,7 +184,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
             panic!("ScrollView::custom requires a ScrollData to be built into a parent");
         }
 
-        Self { data: data.clone(), scroll_to_cursor: false }.build(cx, |cx| {
+        Self { data, scroll_to_cursor: false }.build(cx, |cx| {
             Self::common_builder(cx, data, content, scroll_x, scroll_y);
         })
     }
@@ -193,7 +193,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
     where
         F: 'static + FnOnce(&mut Context),
     {
-        ScrollContent::new(cx, content).bind(data.clone(), |handle, data| {
+        ScrollContent::new(cx, content).bind(data, |handle, data| {
             let scale_factor = handle.scale_factor();
             let data = data.get(handle.cx);
             let left =
@@ -206,9 +206,8 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
         if scroll_y {
             Scrollbar::new(
                 cx,
-                data.clone().then(ScrollData::scroll_y),
-                data.clone()
-                    .then(RatioLens::new(ScrollData::container_height, ScrollData::inner_height)),
+                data.then(ScrollData::scroll_y),
+                data.then(RatioLens::new(ScrollData::container_height, ScrollData::inner_height)),
                 Orientation::Vertical,
                 |cx, value| {
                     cx.emit(ScrollEvent::SetY(value));
@@ -221,7 +220,7 @@ impl<L: Lens<Target = ScrollData>> ScrollView<L> {
         if scroll_x {
             Scrollbar::new(
                 cx,
-                data.clone().then(ScrollData::scroll_x),
+                data.then(ScrollData::scroll_x),
                 data.then(RatioLens::new(ScrollData::container_width, ScrollData::inner_width)),
                 Orientation::Horizontal,
                 |cx, value| {

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -102,9 +102,8 @@ where
     ///     });
     /// ```
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
-        let value_lens = lens.clone();
         Self {
-            lens: lens.clone(),
+            lens,
             is_dragging: false,
 
             internal: SliderDataInternal {
@@ -120,7 +119,6 @@ where
         }
         .build(cx, move |cx| {
             Binding::new(cx, Slider::<L>::internal, move |cx, slider_data| {
-                let lens = lens.clone();
                 ZStack::new(cx, move |cx| {
                     let slider_data = slider_data.get(cx);
                     let thumb_size = slider_data.thumb_size;
@@ -129,7 +127,7 @@ where
                     let range = slider_data.range;
 
                     // Active track
-                    Element::new(cx).class("active").bind(lens.clone(), move |handle, value| {
+                    Element::new(cx).class("active").bind(lens, move |handle, value| {
                         let val = value.get(handle.cx);
 
                         let normal_val = (val - range.start) / (range.end - range.start);
@@ -185,8 +183,8 @@ where
             });
         })
         .role(Role::Slider)
-        .numeric_value(value_lens.clone().map(|val| (*val as f64 * 100.0).round() / 100.0))
-        .text_value(value_lens.map(|val| {
+        .numeric_value(lens.map(|val| (*val as f64 * 100.0).round() / 100.0))
+        .text_value(lens.map(|val| {
             let v = (*val as f64 * 100.0).round() / 100.0;
             format!("{}", v)
         }))
@@ -533,14 +531,14 @@ impl NamedSlider {
         let name = name.get_val(cx).to_string();
         Self { on_changing: None }
             .build(cx, move |cx| {
-                Binding::new(cx, lens.clone(), move |cx, lens| {
+                Binding::new(cx, lens, move |cx, lens| {
                     Textbox::new(cx, lens.map(|v| format!("{:.2}", v))).on_submit(|cx, txt, _| {
                         if let Ok(val) = txt.parse() {
                             cx.emit(NamedSliderEvent::Change(val));
                         }
                     });
                 });
-                Slider::custom(cx, lens.clone(), move |cx| {
+                Slider::custom(cx, lens, move |cx| {
                     Binding::new(cx, Slider::<L>::internal, move |cx, slider_data| {
                         ZStack::new(cx, |cx| {
                             let slider_data = slider_data.get(cx);
@@ -549,23 +547,19 @@ impl NamedSlider {
                             let range = slider_data.range;
 
                             // Active track
-                            Element::new(cx).class("active").bind(
-                                lens.clone(),
-                                move |handle, value| {
-                                    let val = value.get(handle.cx);
-                                    let normal_val =
-                                        (val - range.start) / (range.end - range.start);
-                                    let min = thumb_size / size;
-                                    let max = 1.0;
-                                    let dx = min + normal_val * (max - min);
+                            Element::new(cx).class("active").bind(lens, move |handle, value| {
+                                let val = value.get(handle.cx);
+                                let normal_val = (val - range.start) / (range.end - range.start);
+                                let min = thumb_size / size;
+                                let max = 1.0;
+                                let dx = min + normal_val * (max - min);
 
-                                    handle
-                                        .height(Stretch(1.0))
-                                        .left(Pixels(0.0))
-                                        .right(Stretch(1.0))
-                                        .width(Percentage(dx * 100.0));
-                                },
-                            );
+                                handle
+                                    .height(Stretch(1.0))
+                                    .left(Pixels(0.0))
+                                    .right(Stretch(1.0))
+                                    .width(Percentage(dx * 100.0));
+                            });
 
                             Label::new(cx, &name);
                         });

--- a/crates/vizia_core/src/views/spinbox.rs
+++ b/crates/vizia_core/src/views/spinbox.rs
@@ -39,7 +39,7 @@ impl Spinbox {
     where
         <L as Lens>::Target: Data + ToStringLocalized,
     {
-        Self::custom(cx, move |cx| Label::new(cx, lens.clone()), kind, icons)
+        Self::custom(cx, move |cx| Label::new(cx, lens), kind, icons)
     }
 
     pub fn custom<F, V>(

--- a/crates/vizia_core/src/views/tab.rs
+++ b/crates/vizia_core/src/views/tab.rs
@@ -17,14 +17,13 @@ impl TabView {
         F: 'static + Clone + Fn(&mut Context, Then<L, Index<Vec<T>, T>>) -> TabPair,
     {
         Self { selected_index: 0 }.build(cx, move |cx| {
-            let lens2 = lens.clone();
             let content2 = content.clone();
             // Tab headers
             VStack::new(cx, move |cx| {
-                Binding::new(cx, lens.clone().map(|list| list.len()), move |cx, list_length| {
+                Binding::new(cx, lens.map(|list| list.len()), move |cx, list_length| {
                     let list_length = list_length.get_fallible(cx).map_or(0, |d| d);
                     for index in 0..list_length {
-                        let l = lens.clone().index(index);
+                        let l = lens.index(index);
                         let builder = (content2)(cx, l).header;
                         TabHeader::new(cx, index, builder).bind(
                             TabView::selected_index,
@@ -44,7 +43,7 @@ impl TabView {
             VStack::new(cx, |cx| {
                 Binding::new(cx, TabView::selected_index, move |cx, selected| {
                     let selected = selected.get(cx);
-                    let l = lens2.clone().index(selected);
+                    let l = lens.index(selected);
                     ((content)(cx, l).content)(cx);
                 });
             })

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -74,9 +74,8 @@ where
     }
 
     fn new_core(cx: &mut Context, lens: L, kind: TextboxKind) -> Handle<Self> {
-        let text_lens = lens.clone();
         Self {
-            lens: lens.clone(),
+            lens,
             kind,
             edit: false,
             transform: (0.0, 0.0),
@@ -108,7 +107,7 @@ where
             let parent = cx.current;
 
             Binding::new(cx, Self::placeholder, move |cx, placeholder| {
-                Binding::new(cx, lens.clone(), move |cx, text| {
+                Binding::new(cx, lens, move |cx, text| {
                     let mut ex = EventContext::new(cx);
                     ex.with_current(parent, |ex| {
                         if !ex.is_checked() {
@@ -136,7 +135,7 @@ where
         // .cursor(CursorIcon::Text)
         .navigable(true)
         .role(Role::TextField)
-        .text_value(text_lens)
+        .text_value(lens)
         // .cursor(CursorIcon::Text)
         .default_action_verb(DefaultActionVerb::Focus)
     }

--- a/crates/vizia_core/src/views/timepicker.rs
+++ b/crates/vizia_core/src/views/timepicker.rs
@@ -36,7 +36,7 @@ impl Timepicker {
     {
         Self { on_change: None }
             .build(cx, move |cx| {
-                DigitalTimepicker::new(cx, lens.clone())
+                DigitalTimepicker::new(cx, lens)
                     .on_change(|cx, time| cx.emit(TimepickerEvent::Change(time)));
                 AnalogTimepicker::new(cx, lens)
                     .on_change(|cx, time| cx.emit(TimepickerEvent::Change(time)))
@@ -103,24 +103,21 @@ where
     T: Timelike + Data,
 {
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
-        Self { lens: lens.clone(), p: PhantomData, on_change: None }
+        Self { lens, p: PhantomData, on_change: None }
             .build(cx, move |cx| {
                 Spinbox::custom(
                     cx,
                     |cx| {
-                        Textbox::new(
-                            cx,
-                            lens.clone().map(|time| format!("{:#02}", time.hour12().1)),
-                        )
-                        .on_submit(|cx, text, _| {
-                            if let Ok(parsed) = text.parse::<u32>() {
-                                if parsed < 24 {
-                                    cx.emit(DigitalTimepickerEvent::SetHour(parsed))
+                        Textbox::new(cx, lens.map(|time| format!("{:#02}", time.hour12().1)))
+                            .on_submit(|cx, text, _| {
+                                if let Ok(parsed) = text.parse::<u32>() {
+                                    if parsed < 24 {
+                                        cx.emit(DigitalTimepickerEvent::SetHour(parsed))
+                                    }
                                 }
-                            }
-                        })
-                        .width(Pixels(38.))
-                        .overflow(Overflow::Hidden)
+                            })
+                            .width(Pixels(38.))
+                            .overflow(Overflow::Hidden)
                     },
                     SpinboxKind::Vertical,
                     SpinboxIcons::PlusMinus,
@@ -138,7 +135,7 @@ where
                 Spinbox::custom(
                     cx,
                     |cx| {
-                        Textbox::new(cx, lens.clone().map(|time| format!("{:#02}", time.minute())))
+                        Textbox::new(cx, lens.map(|time| format!("{:#02}", time.minute())))
                             .on_submit(|cx, text, _| {
                                 if let Ok(parsed) = text.parse::<u32>() {
                                     if parsed < 60 {
@@ -375,7 +372,7 @@ where
 {
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
         Self {
-            lens: lens.clone(),
+            lens,
             p: PhantomData,
             page: AnalogTimepickerPage::Hours,
             on_change: None,
@@ -386,7 +383,7 @@ where
             HStack::new(cx, move |cx| {
                 Binding::new(cx, Self::page, move |cx, page| match page.get(cx) {
                     AnalogTimepickerPage::Hours => {
-                        Binding::new(cx, lens.clone().map(|time| time.hour()), |cx, hours| {
+                        Binding::new(cx, lens.map(|time| time.hour()), |cx, hours| {
                             let hours = hours.get(cx);
 
                             let angle = (hours) as f32 * 30.0;
@@ -421,14 +418,12 @@ where
                                 .position_type(PositionType::SelfDirected)
                                 .on_press(move |ex| ex.emit(AnalogTimepickerEvent::SetHours(i + 1)))
                                 .class("marker")
-                                .checked(
-                                    lens.clone().map(move |time| time.hour12().1 == (i + 1) as u32),
-                                );
+                                .checked(lens.map(move |time| time.hour12().1 == (i + 1) as u32));
                         }
                     }
 
                     AnalogTimepickerPage::Minutes => {
-                        Binding::new(cx, lens.clone().map(|time| time.minute()), |cx, minutes| {
+                        Binding::new(cx, lens.map(|time| time.minute()), |cx, minutes| {
                             let minutes = minutes.get(cx);
 
                             let angle = (minutes / 5) as f32 * 30.0;
@@ -456,14 +451,12 @@ where
                                     ex.emit(AnalogTimepickerEvent::SetMinutes(i * 5))
                                 })
                                 .class("marker")
-                                .checked(
-                                    lens.clone().map(move |time| time.minute() / 5 == i as u32),
-                                );
+                                .checked(lens.map(move |time| time.minute() / 5 == i as u32));
                         }
                     }
 
                     AnalogTimepickerPage::Seconds => {
-                        Binding::new(cx, lens.clone().map(|time| time.second()), |cx, seconds| {
+                        Binding::new(cx, lens.map(|time| time.second()), |cx, seconds| {
                             let seconds = seconds.get(cx);
 
                             let angle = (seconds / 5) as f32 * 30.0;
@@ -482,9 +475,7 @@ where
                                     ex.emit(AnalogTimepickerEvent::SetSeconds(i * 5))
                                 })
                                 .class("marker")
-                                .checked(
-                                    lens.clone().map(move |time| time.second() / 5 == i as u32),
-                                );
+                                .checked(lens.map(move |time| time.second() / 5 == i as u32));
                         }
                     }
                 });

--- a/crates/vizia_core/src/views/virtual_list.rs
+++ b/crates/vizia_core/src/views/virtual_list.rs
@@ -41,7 +41,7 @@ impl VirtualList {
                 VStack::new(cx, |cx| {
                     Binding::new(cx, VirtualList::visible_items, move |cx, visible_list| {
                         for i in visible_list.get(cx) {
-                            let ptr = list.clone().index(i);
+                            let ptr = list.index(i);
                             (item)(cx, i, ptr)
                                 .top(Pixels(i as f32 * height))
                                 .height(Pixels(height))

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -106,7 +106,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         quote! {
             #[doc = #struct_docs]
             #[allow(non_camel_case_types)]
-            #[derive(Copy, Clone, Hash, PartialEq, Eq)]
+            #[derive(Hash, PartialEq, Eq)]
             #struct_vis struct #field_name#lens_ty_generics(#(#phantom_decls),*);
 
             impl #lens_ty_generics #field_name#lens_ty_generics{
@@ -121,6 +121,16 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
                     write!(f,"{}:{}",stringify!(#struct_type), stringify!(#field_name))
                 }
             }
+
+            impl #lens_ty_generics Clone for #field_name#lens_ty_generics  {
+                fn clone(&self) -> #field_name#lens_ty_generics {
+                    Self(#(#phantom_inits),*)
+                }
+            }
+
+            impl #lens_ty_generics Copy for #field_name#lens_ty_generics {}
+
+
         }
     });
 
@@ -189,7 +199,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
         #[doc = #mod_docs]
         #module_vis mod #twizzled_name {
             #(#defs)*
-            #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+            #[derive(Debug, Hash, PartialEq, Eq)]
             #[doc = #root_docs]
             #[allow(non_camel_case_types)]
             #struct_vis struct root#lens_ty_generics(#(#phantom_decls),*);
@@ -199,6 +209,14 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
                     Self(#(#phantom_inits),*)
                 }
             }
+
+            impl #lens_ty_generics Clone for root#lens_ty_generics  {
+                fn clone(&self) -> root#lens_ty_generics {
+                    Self(#(#phantom_inits),*)
+                }
+            }
+
+            impl #lens_ty_generics Copy for root#lens_ty_generics {}
         }
 
         #(#impls)*

--- a/crates/vizia_derive/src/lens.rs
+++ b/crates/vizia_derive/src/lens.rs
@@ -124,7 +124,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
             impl #lens_ty_generics Clone for #field_name#lens_ty_generics  {
                 fn clone(&self) -> #field_name#lens_ty_generics {
-                    Self(#(#phantom_inits),*)
+                    *self
                 }
             }
 
@@ -212,7 +212,7 @@ fn derive_struct(input: &syn::DeriveInput) -> Result<proc_macro2::TokenStream, s
 
             impl #lens_ty_generics Clone for root#lens_ty_generics  {
                 fn clone(&self) -> root#lens_ty_generics {
-                    Self(#(#phantom_inits),*)
+                    *self
                 }
             }
 

--- a/examples/lens_map.rs
+++ b/examples/lens_map.rs
@@ -1,0 +1,18 @@
+use vizia::prelude::*;
+
+#[derive(Lens)]
+pub struct AppData {
+    value: f32,
+}
+
+impl Model for AppData {}
+
+fn main() {
+    Application::new(|cx| {
+        AppData { value: 3.14 }.build(cx);
+
+        Label::new(cx, AppData::value.map(|val| val.to_string()));
+    })
+    .title("Lens Map")
+    .run();
+}

--- a/examples/lens_map.rs
+++ b/examples/lens_map.rs
@@ -11,7 +11,7 @@ fn main() {
     Application::new(|cx| {
         AppData { value: 3.14 }.build(cx);
 
-        Label::new(cx, AppData::value.map(|val| val.to_string()));
+        Label::new(cx, AppData::value.map(|_val| String::from("Hello World")));
     })
     .title("Lens Map")
     .run();

--- a/examples/lists/selectable_list.rs
+++ b/examples/lists/selectable_list.rs
@@ -14,7 +14,6 @@ pub enum AppEvent {
 }
 
 impl Model for AppData {
-    // Intercept list events from the list view to modify the selected index in the model
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
             AppEvent::Select(index) => {
@@ -34,7 +33,7 @@ impl Model for AppData {
 
 fn main() {
     Application::new(|cx| {
-        cx.add_stylesheet(include_style!("../resources/themes/list_style.css"))
+        cx.add_stylesheet(include_style!("examples/resources/themes/list_style.css"))
             .expect("Failed to add stylesheet");
 
         let list: Vec<u32> = (0..4u32).collect();
@@ -42,9 +41,7 @@ fn main() {
 
         VStack::new(cx, move |cx| {
             List::new(cx, AppData::list, move |cx, index, item| {
-                let item_text = item.get(cx).to_string();
-                //let item_index = item.idx();
-                Label::new(cx, &item_text)
+                Label::new(cx, item)
                     // Set the checked state based on whether this item is selected
                     .checked(AppData::selected.map(move |selected| *selected == index))
                     // Set the selected item to this one if pressed


### PR DESCRIPTION
Adds a thread local store for lens mapping function, allowing the `Map` lens to be made `Copy`. This in turn allows `Lens` itself to be `Copy`.

In current vizia derived lenses are `Copy` but the `Lens` trait itself does not have a `Copy` bound because `Map` lenses are not `Copy`. This is because current `Map` lenses store a closure (for the mapping from lens output to desired output). This causes problems when passing lenses into closures and usually requires creating a clone of the lens to move into a closure.

This change solves this problem by moving the mapping closure out of the `Map` lens and into a thread local. Now the `Map` contains an id into a store of mapping functions. I'm not typically a fan of using global data like this but the ergonomic improvements are, I believe, worth it.