### PR TITLE
Change `from_str` to `from_string` to fix stylesheet loading

### DIFF
--- a/crates/vizia_core/src/util/mod.rs
+++ b/crates/vizia_core/src/util/mod.rs
@@ -71,7 +71,7 @@ macro_rules! include_style {
 #[macro_export]
 macro_rules! include_style {
     ($filename:tt) => {
-        $crate::prelude::CSS::from_str(include_str!(concat!(
+        $crate::prelude::CSS::from_string(include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/",
             $filename


### PR DESCRIPTION
seems like at some point the `from_str` function renamed to `from_string` but the method name didn't changed in the `include_style` macro, this will fix it