### PR TITLE
Allow `Datepicker` to be localized

### DIFF
--- a/crates/vizia_core/src/binding/data.rs
+++ b/crates/vizia_core/src/binding/data.rs
@@ -68,6 +68,7 @@ impl_data_simple!(NaiveTime);
 impl_data_simple!(Angle);
 impl_data_simple!(String);
 impl_data_simple!(Entity);
+impl_data_simple!(Localized);
 
 impl Data for &'static str {
     fn same(&self, other: &Self) -> bool {

--- a/crates/vizia_core/src/binding/res.rs
+++ b/crates/vizia_core/src/binding/res.rs
@@ -93,22 +93,22 @@ impl_res_clone!(Translate);
 impl_res_clone!(Scale);
 impl_res_clone!(Position);
 
-impl<T, L> Res<T> for L
+impl<L> Res<L::Target> for L
 where
-    L: Lens<Target = T> + LensExt,
-    T: Clone + Data,
+    L: Lens + LensExt,
+    L::Target: Clone + Data,
 {
-    fn get_val(&self, cx: &Context) -> T {
+    fn get_val(&self, cx: &Context) -> L::Target {
         self.get(cx)
     }
 
-    fn get_val_fallible(&self, cx: &Context) -> Option<T> {
+    fn get_val_fallible(&self, cx: &Context) -> Option<L::Target> {
         self.get_fallible(cx)
     }
 
     fn set_or_bind<F>(&self, cx: &mut Context, entity: Entity, closure: F)
     where
-        F: 'static + Fn(&mut Context, Entity, T),
+        F: 'static + Fn(&mut Context, Entity, L::Target),
     {
         cx.with_current(entity, |cx| {
             Binding::new(cx, self.clone(), move |cx, val| {

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -197,6 +197,10 @@ impl<'a> BackendContext<'a> {
         !self.0.event_queue.is_empty()
     }
 
+    pub fn renegotiate_language(&mut self) {
+        self.0.resource_manager.renegotiate_language();
+    }
+
     /// Returns a mutable reference to the accesskit node classes.
     pub fn accesskit_node_classes(&mut self) -> &mut accesskit::NodeClassSet {
         &mut self.style().accesskit_node_classes

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -339,6 +339,17 @@ impl<'a> EventContext<'a> {
         );
     }
 
+    /// Sets the language used by the application for localization.
+    pub fn set_language(&mut self, lang: LanguageIdentifier) {
+        if let Some(mut model_data_store) = self.data.remove(Entity::root()) {
+            if let Some(model) = model_data_store.models.get_mut(&TypeId::of::<Environment>()) {
+                model.event(self, &mut Event::new(EnvironmentEvent::SetLocale(lang)));
+            }
+
+            self.data.insert(Entity::root(), model_data_store);
+        }
+    }
+
     /// Capture mouse input for the current view.
     pub fn capture(&mut self) {
         *self.captured = self.current;

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -494,6 +494,18 @@ impl Context {
         });
     }
 
+    /// Sets the language used by the application for localization.
+    pub fn set_language(&mut self, lang: LanguageIdentifier) {
+        let cx = &mut EventContext::new(self);
+        if let Some(mut model_data_store) = cx.data.remove(Entity::root()) {
+            if let Some(model) = model_data_store.models.get_mut(&TypeId::of::<Environment>()) {
+                model.event(cx, &mut Event::new(EnvironmentEvent::SetLocale(lang)));
+            }
+
+            self.data.insert(Entity::root(), model_data_store);
+        }
+    }
+
     /// Sets the global default font for the application.
     pub fn set_default_font(&mut self, names: &[&str]) {
         self.style.default_font = names
@@ -542,7 +554,6 @@ impl Context {
 
     pub fn add_translation(&mut self, lang: LanguageIdentifier, ftl: impl ToString) {
         self.resource_manager.add_translation(lang, ftl.to_string());
-        self.emit(EnvironmentEvent::SetLocale(self.resource_manager.language.clone()));
     }
 
     pub fn load_image(

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
     pub use super::include_style;
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};
     pub use super::layout::{BoundingBox, GeoChanged};
-    pub use super::localization::Localized;
+    pub use super::localization::{Localized, ToStringLocalized};
     pub use super::modifiers::{
         AbilityModifiers, AccessibilityModifiers, ActionModifiers, BoxShadowBuilder,
         LayoutModifiers, LinearGradientBuilder, StyleModifiers, TextModifiers,

--- a/crates/vizia_core/src/localization/mod.rs
+++ b/crates/vizia_core/src/localization/mod.rs
@@ -73,6 +73,7 @@ use crate::prelude::*;
 use fluent_bundle::FluentArgs;
 use fluent_bundle::FluentValue;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 pub(crate) trait FluentStore {
     fn get_val(&self, cx: &Context) -> FluentValue<'static>;
@@ -135,6 +136,13 @@ where
 pub struct Localized {
     key: String,
     args: HashMap<String, Box<dyn FluentStore>>,
+    map: Rc<dyn Fn(&str) -> String + 'static>,
+}
+
+impl PartialEq for Localized {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
 }
 
 impl Clone for Localized {
@@ -142,6 +150,7 @@ impl Clone for Localized {
         Self {
             key: self.key.clone(),
             args: self.args.iter().map(|(k, v)| (k.clone(), v.make_clone())).collect(),
+            map: self.map.clone(),
         }
     }
 }
@@ -169,7 +178,14 @@ impl Localized {
     /// })
     /// .run();
     pub fn new(key: &str) -> Self {
-        Self { key: key.to_owned(), args: HashMap::new() }
+        Self { key: key.to_owned(), args: HashMap::new(), map: Rc::new(|s| s.to_string()) }
+    }
+
+    /// Sets a mapping function to apply to the translated text.
+    pub fn map(mut self, mapping: impl Fn(&str) -> String + 'static) -> Self {
+        self.map = Rc::new(mapping);
+
+        self
     }
 
     /// Add a variable argument binding to the Localized type.
@@ -230,13 +246,13 @@ impl Res<String> for Localized {
         let message = if let Some(msg) = bundle.get_message(&self.key) {
             msg
         } else {
-            return format!("{{MISSING: {}}}", self.key);
+            return (self.map)(&self.key);
         };
 
         let value = if let Some(value) = message.value() {
             value
         } else {
-            return format!("{{MISSING: {}}}", self.key);
+            return (self.map)(&self.key);
         };
 
         let mut err = vec![];
@@ -244,7 +260,7 @@ impl Res<String> for Localized {
         let res = bundle.format_pattern(value, Some(&args), &mut err);
 
         if err.is_empty() {
-            res.to_string()
+            return (self.map)(&res);
         } else {
             format!("{} {{ERROR: {:?}}}", res, err)
         }
@@ -282,5 +298,45 @@ where
         );
     } else {
         closure(cx);
+    }
+}
+
+impl<T: ToString> ToStringLocalized for T {
+    fn to_string_local(&self, _cx: &Context) -> String {
+        self.to_string()
+    }
+}
+
+pub trait ToStringLocalized {
+    fn to_string_local(&self, cx: &Context) -> String;
+}
+
+impl ToStringLocalized for Localized {
+    fn to_string_local(&self, cx: &Context) -> String {
+        let locale = &cx.environment().locale;
+        let bundle = cx.resource_manager.current_translation(locale);
+        let message = if let Some(msg) = bundle.get_message(&self.key) {
+            msg
+        } else {
+            // Warn here of missing key
+            return (self.map)(&self.key);
+        };
+
+        let value = if let Some(value) = message.value() {
+            value
+        } else {
+            // Warn here of missing value
+            return (self.map)(&self.key);
+        };
+
+        let mut err = vec![];
+        let args = self.get_args(cx);
+        let res = bundle.format_pattern(value, Some(&args), &mut err);
+
+        if err.is_empty() {
+            return (self.map)(&res);
+        } else {
+            format!("{} {{ERROR: {:?}}}", res, err)
+        }
     }
 }

--- a/crates/vizia_core/src/modifiers/accessibility.rs
+++ b/crates/vizia_core/src/modifiers/accessibility.rs
@@ -15,10 +15,10 @@ pub trait AccessibilityModifiers: internal::Modifiable {
     }
 
     /// Sets the accessibility name of the view.
-    fn name<U: ToString>(mut self, name: impl Res<U>) -> Self {
+    fn name<U: ToStringLocalized>(mut self, name: impl Res<U>) -> Self {
         let entity = self.entity();
         name.set_or_bind(self.context(), entity, |cx, id, name| {
-            cx.style.name.insert(id, name.to_string());
+            cx.style.name.insert(id, name.to_string_local(cx));
             cx.style.needs_access_update(id);
         });
 

--- a/crates/vizia_core/src/modifiers/text.rs
+++ b/crates/vizia_core/src/modifiers/text.rs
@@ -6,10 +6,10 @@ use vizia_style::{FontSize, FontStretch, FontStyle, FontWeight};
 /// Modifiers for changing the text properties of a view.
 pub trait TextModifiers: internal::Modifiable {
     /// Sets the text content of the view.
-    fn text<U: ToString>(mut self, value: impl Res<U>) -> Self {
+    fn text<T: ToStringLocalized>(mut self, value: impl Res<T>) -> Self {
         let entity = self.entity();
         value.set_or_bind(self.context(), entity, |cx, entity, val| {
-            let text_data = val.to_string();
+            let text_data = val.to_string_local(cx);
             cx.text_context.set_text(entity, &text_data);
 
             cx.style.needs_text_layout.insert(entity, true);

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -104,7 +104,7 @@ impl ResourceManager {
         }
     }
 
-    fn renegotiate_language(&mut self) {
+    pub fn renegotiate_language(&mut self) {
         let available = self
             .translations
             .keys()

--- a/crates/vizia_core/src/views/chip.rs
+++ b/crates/vizia_core/src/views/chip.rs
@@ -10,7 +10,7 @@ pub struct Chip {
 impl Chip {
     pub fn new<T>(cx: &mut Context, text: impl Res<T> + Clone) -> Handle<Self>
     where
-        T: ToString,
+        T: ToStringLocalized,
     {
         Self { on_close: None }
             .build(cx, move |cx| {

--- a/crates/vizia_core/src/views/datepicker.rs
+++ b/crates/vizia_core/src/views/datepicker.rs
@@ -8,7 +8,7 @@ use super::spinbox::SpinboxIcons;
 #[derive(Lens)]
 pub struct Datepicker {
     view_date: NaiveDate,
-    months: Vec<String>,
+    months: Vec<Localized>,
     selected_month: usize,
 
     #[lens(ignore)]
@@ -30,7 +30,8 @@ const MONTHS: [&str; 12] = [
     "December",
 ];
 
-const DAYS_HEADER: [&str; 7] = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+const DAYS_HEADER: [&str; 7] =
+    ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
 pub enum DatepickerEvent {
     IncrementMonth,
@@ -117,7 +118,7 @@ impl Datepicker {
         let view_date = lens.get(cx);
 
         Self {
-            months: MONTHS.to_vec().iter_mut().map(|v| v.to_string()).collect(),
+            months: MONTHS.iter().map(|m| Localized::new(m)).collect::<Vec<_>>(),
             selected_month: view_date.month() as usize - 1,
             view_date: NaiveDate::from_ymd_opt(view_date.year(), view_date.month(), 1).unwrap(),
             on_select: None,
@@ -158,7 +159,8 @@ impl Datepicker {
                 // Days of the week
                 HStack::new(cx, |cx| {
                     for h in DAYS_HEADER {
-                        Label::new(cx, h).class("datepicker-calendar-header");
+                        Label::new(cx, Localized::new(h).map(|day| day[0..2].to_string()))
+                            .class("datepicker-calendar-header");
                     }
                 })
                 .class("datepicker-calendar-headers");

--- a/crates/vizia_core/src/views/label.rs
+++ b/crates/vizia_core/src/views/label.rs
@@ -101,7 +101,7 @@ impl Label {
     /// ```
     pub fn new<T>(cx: &mut Context, text: impl Res<T> + Clone) -> Handle<Self>
     where
-        T: ToString,
+        T: ToStringLocalized,
     {
         Self { describing: None }
             .build(cx, |_| {})
@@ -194,7 +194,7 @@ impl Icon {
     /// ```
     pub fn new<T>(cx: &mut Context, icon_code: impl Res<T> + Clone) -> Handle<Self>
     where
-        T: ToString,
+        T: ToStringLocalized,
     {
         Self {}.build(cx, |_| {}).text(icon_code).role(Role::StaticText)
     }

--- a/crates/vizia_core/src/views/picklist.rs
+++ b/crates/vizia_core/src/views/picklist.rs
@@ -18,7 +18,7 @@ impl PickList {
     ) -> Handle<Self>
     where
         L1: Lens<Target = Vec<T>>,
-        T: 'static + Data + ToString,
+        T: 'static + Data + ToStringLocalized,
         L2: Lens<Target = usize>,
     {
         Self { on_select: None }.build(cx, |cx| {

--- a/crates/vizia_core/src/views/spinbox.rs
+++ b/crates/vizia_core/src/views/spinbox.rs
@@ -37,7 +37,7 @@ impl Spinbox {
         icons: SpinboxIcons,
     ) -> Handle<Spinbox>
     where
-        <L as Lens>::Target: Data + ToString,
+        <L as Lens>::Target: Data + ToStringLocalized,
     {
         Self::custom(cx, move |cx| Label::new(cx, lens.clone()), kind, icons)
     }

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -234,6 +234,7 @@ impl Application {
         cx.add_window(window);
 
         cx.0.remove_user_themes();
+        cx.renegotiate_language();
         if let Some(builder) = self.builder.take() {
             (builder)(cx.0);
         }

--- a/examples/resources/translations/fr/hello.ftl
+++ b/examples/resources/translations/fr/hello.ftl
@@ -7,3 +7,24 @@ emails =
        *[other] Vous avez { $unread_emails } e-mails non lus.
     }
 refresh = Actualiser la page
+
+January = Janvier
+February = Février
+March = Mars
+April = Avril
+May = Mai
+June = Juin
+July = Juillet
+August = Aout
+September = Septembre
+October = Octobre
+November = Novembre
+December = Décembre
+
+Monday = Lundi
+Tuesday = Mardi
+Wednesday = Mercredi
+Thursday = Jeudi
+Friday = Vendredi
+Saturday = Samedi
+Sunday = Dimanche


### PR DESCRIPTION
Adds `ToStringLocalized`, which allows lenses which target `Localized`. This allows the months and days used by the datepicker to be localized.

To localize the datepicker, simply add the appropriate key/values to an ftl file. See `examples/resources/translations/fr/hello.ftl` for example.