### PR TITLE
Cleanup and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,6 @@ path = "examples/keyframes.rs"
 [features]
 default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]
 clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
-serde = ["vizia_core/serde"]
 winit = ["vizia_winit"]
 baseview = ["vizia_baseview"]
 x11 = ["vizia_winit?/x11", "vizia_core/x11"]
@@ -342,9 +341,6 @@ vizia_winit = { version = "0.1.0", path = "crates/vizia_winit", optional = true 
 vizia_baseview = { version = "0.1.0", path = "crates/vizia_baseview", optional = true }
 
 [dev-dependencies]
-english-numbers = "0.3.3"
 lazy_static = "1.4.0"
 chrono = "0.4.19"
-image = { version = "0.24.0", default-features = false, features = ["png"] }
-reqwest = { version = "0.11.9", features = ["blocking"] }
-instant = "0.1.12"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,4 +343,4 @@ vizia_baseview = { version = "0.1.0", path = "crates/vizia_baseview", optional =
 [dev-dependencies]
 lazy_static = "1.4.0"
 chrono = "0.4.19"
-
+reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -24,7 +24,7 @@ vizia_style = { path = "../vizia_style"}
 accesskit = "0.11.0"
 
 femtovg = "0.7.0"
-image = { version = "0.24.0", default-features = false, features = ["png"] } # inherited from femtovg
+image = { version = "0.24.6", default-features = false, features = ["png"] } # inherited from femtovg
 # morphorm = {path = "../../../morphorm" }
 morphorm = {git = "https://github.com/vizia/morphorm", rev = "8bae565241845d0d36a491d072cbd0ad797e7d54" }
 #morphorm = { path = "../../../morphorm", features = ["rounding"] }
@@ -32,19 +32,16 @@ bitflags = "2.1.0"
 fnv = "1.0.7"
 fluent-bundle = "0.15.2"
 fluent-langneg = "0.13"
-fluent-syntax = "0.11.0"
 unic-langid = {version = "0.9", features = ["macros"]}
 sys-locale = "0.3.0"
 unicode-segmentation = "1.8.0"
-unicode-bidi = "0.3.7"
 copypasta = {version = "0.8.1", optional = true, default-features = false }
 instant = "0.1.12"
-serde = { version = "1.0", optional = true, features = ["derive"] }
 chrono = "0.4.22"
 # cosmic-text = "0.8.0"
 cosmic-text = { git="https://github.com/pop-os/cosmic-text", rev="79275d15e857428e9b8874f28413197e878f3788" }
-swash = "^0.1"
-reqwest = { version = "0.11.9", features = ["blocking"] }
+swash = "0.1.8"
+# reqwest = { version = "0.11.9", features = ["blocking"] }
 
 # Required so that doc tests will compile
 [dev-dependencies]

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -3,9 +3,6 @@
 #![allow(clippy::single_match)]
 // To allow enum names with the same prefix
 #![allow(clippy::enum_variant_names)]
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
 
 #[doc(hidden)]
 mod accessibility;
@@ -102,6 +99,7 @@ pub mod prelude {
     pub use super::style::*;
 
     pub use cosmic_text::FamilyOwned;
+    pub use instant::{Duration, Instant};
     pub use morphorm::Units::*;
     pub use morphorm::{LayoutType, PositionType, Units};
     pub use unic_langid::{langid, LanguageIdentifier};

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -62,29 +62,29 @@ pub struct ResourceManager {
 impl ResourceManager {
     pub fn new() -> Self {
         let locale = sys_locale::get_locale().and_then(|l| l.parse().ok()).unwrap_or_default();
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> =
-            Some(Box::new(|cx: &mut ResourceContext, path: &str| {
-                if path.starts_with("https://") {
-                    let path = path.to_string();
-                    cx.spawn(move |cx| {
-                        let data = reqwest::blocking::get(&path).unwrap().bytes().unwrap();
-                        cx.load_image(
-                            path,
-                            image::load_from_memory_with_format(
-                                &data,
-                                image::guess_format(&data).unwrap(),
-                            )
-                            .unwrap(),
-                            ImageRetentionPolicy::DropWhenUnusedForOneFrame,
-                        )
-                        .unwrap();
-                    });
-                } else {
-                    // TODO: Try to load path from file
-                }
-            }));
+        let default_image_loader = None;
+        // #[cfg(not(target_arch = "wasm32"))]
+        // let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> =
+        //     Some(Box::new(|cx: &mut ResourceContext, path: &str| {
+        //         if path.starts_with("https://") {
+        //             let path = path.to_string();
+        //             cx.spawn(move |cx| {
+        //                 let data = reqwest::blocking::get(&path).unwrap().bytes().unwrap();
+        //                 cx.load_image(
+        //                     path,
+        //                     image::load_from_memory_with_format(
+        //                         &data,
+        //                         image::guess_format(&data).unwrap(),
+        //                     )
+        //                     .unwrap(),
+        //                     ImageRetentionPolicy::DropWhenUnusedForOneFrame,
+        //                 )
+        //                 .unwrap();
+        //             });
+        //         } else {
+        //             // TODO: Try to load path from file
+        //         }
+        //     }));
 
         #[cfg(target_arch = "wasm32")]
         let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> = None;

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -62,6 +62,8 @@ pub struct ResourceManager {
 impl ResourceManager {
     pub fn new() -> Self {
         let locale = sys_locale::get_locale().and_then(|l| l.parse().ok()).unwrap_or_default();
+
+        #[cfg(not(target_arch = "wasm32"))]
         let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> = None;
 
         // Disable this for now because reqwest pulls in too many dependencies.

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -62,7 +62,9 @@ pub struct ResourceManager {
 impl ResourceManager {
     pub fn new() -> Self {
         let locale = sys_locale::get_locale().and_then(|l| l.parse().ok()).unwrap_or_default();
-        let default_image_loader = None;
+        let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> = None;
+
+        // Disable this for now because reqwest pulls in too many dependencies.
         // #[cfg(not(target_arch = "wasm32"))]
         // let default_image_loader: Option<Box<dyn Fn(&mut ResourceContext, &str)>> =
         //     Some(Box::new(|cx: &mut ResourceContext, path: &str| {

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -20,17 +20,17 @@ vizia_id = { path = "../vizia_id" }
 vizia_window = { path = "../vizia_window" }
 
 accesskit = "0.11.0"
-winit = { version = "0.28.1", default-features = false }
+winit = { version = "0.28.6", default-features = false }
 femtovg = "0.7.0"
-glutin = { version = "0.30.3", default-features = false, optional = true }
-copypasta = {version = "0.8.1", optional = true, default-features = false }
+glutin = { version = "0.30.8", default-features = false, optional = true }
+copypasta = {version = "0.8.2", optional = true, default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 accesskit_winit = "0.14.0"
-glutin = { version = "0.30.3", default-features = false }
+glutin = { version = "0.30.8", default-features = false }
 femtovg = "0.7.0"
 glutin-winit = "0.3.0"
-raw-window-handle = "0.5.0"
+raw-window-handle = "0.5.2"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,4 +1,3 @@
-use instant::Duration;
 use vizia::prelude::*;
 
 fn main() {

--- a/examples/keyframes.rs
+++ b/examples/keyframes.rs
@@ -1,4 +1,3 @@
-use instant::Duration;
 use vizia::prelude::*;
 
 const STYLE: &str = r#"

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -15,7 +15,7 @@ fn main() {
 fn main() {
     let app = Application::new(|_| {})
         .on_idle(|_| {
-            println!("On Idle: {:?}", instant::Instant::now());
+            println!("On Idle: {:?}", Instant::now());
         })
         .title("Proxy");
 

--- a/examples/style/background_image.rs
+++ b/examples/style/background_image.rs
@@ -1,8 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use vizia::image;
 #[allow(unused)]
 use vizia::prelude::*;
-#[cfg(not(target_arch = "wasm32"))]
-use vizia_core::resource::ImageRetentionPolicy;
 
 #[allow(unused)]
 const STYLE: &str = r#"

--- a/examples/style/background_image.rs
+++ b/examples/style/background_image.rs
@@ -1,3 +1,4 @@
+use vizia::image;
 #[allow(unused)]
 use vizia::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/style/background_size.rs
+++ b/examples/style/background_size.rs
@@ -1,8 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
 use vizia::image;
 #[allow(unused)]
 use vizia::prelude::*;
-#[cfg(not(target_arch = "wasm32"))]
-use vizia_core::resource::ImageRetentionPolicy;
 
 #[allow(unused)]
 const STYLE: &str = r#"

--- a/examples/style/background_size.rs
+++ b/examples/style/background_size.rs
@@ -1,3 +1,4 @@
+use vizia::image;
 #[allow(unused)]
 use vizia::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/style/filter.rs
+++ b/examples/style/filter.rs
@@ -1,3 +1,4 @@
+use vizia::image;
 use vizia::prelude::*;
 
 const STYLE: &str = r#"


### PR DESCRIPTION
Removed the `reqwest` dependency for now because it pulls in nearly 80 other crates. It's still a dev dependency to demo loading images from the web but I'd like to move that to a dedicated example package so that simpler examples don't need to pull in all these crates.