### PR TITLE
Fixed the problem of capturing mouse even if user didn't used mouse

### DIFF
--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -96,8 +96,8 @@ impl View for Button {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::PressDown { .. } => {
-                cx.capture();
+            WindowEvent::PressDown { mouse } => {
+                if *mouse { cx.capture() }
                 cx.focus();
             }
 

--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -98,8 +98,8 @@ impl View for Button {
         event.map(|window_event, meta| match window_event {
             WindowEvent::PressDown { mouse } => {
                 if *mouse {
-					cx.capture()
-				}
+                    cx.capture()
+                }
                 cx.focus();
             }
 

--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -97,7 +97,9 @@ impl View for Button {
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
             WindowEvent::PressDown { mouse } => {
-                if *mouse { cx.capture() }
+                if *mouse {
+					cx.capture()
+				}
                 cx.focus();
             }
 


### PR DESCRIPTION
`WindowEvent::PressDown` event in button were previously capture mouse input even if user didn't used mouse to press the button, this would lead to a bug that mouse would get captured without ever get released.