### PR TITLE
Textbox improvements

### DIFF
--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -774,7 +774,7 @@ tabview .tabview-divider {
 textbox {
     border-width: 1px;
     border-radius: 4px;
-    border-color: #323232;
+    border-color: #32323200;
     background-color: #323232;
     transition: border-color 100ms;
     transition: background-color 100ms;
@@ -784,8 +784,13 @@ textbox:checked {
     border-color: #51afef;
     background-color: #323232;
     transition: border-color 100ms;
-    caret-color: red;
+    caret-color: #c4c4c4;
     selection-color: #6464c888;
+}
+
+textbox > label.placeholder {
+    caret-color: transparent;
+    color: gray;
 }
 
 textbox:read-only {

--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -784,8 +784,6 @@ textbox:checked {
     border-color: #51afef;
     background-color: #323232;
     transition: border-color 100ms;
-    caret-color: transparent;
-    selection-color: #6464c888;
 }
 
 textbox:checked.caret {
@@ -800,8 +798,6 @@ textbox > label.placeholder {
 textbox:read-only {
     background-color: transparent;
     border-width: 0px;
-    caret-color: transparent;
-    selection-color: #6464c888;
 }
 
 textbox:disabled {

--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -784,8 +784,12 @@ textbox:checked {
     border-color: #51afef;
     background-color: #323232;
     transition: border-color 100ms;
-    caret-color: #c4c4c4;
+    caret-color: transparent;
     selection-color: #6464c888;
+}
+
+textbox:checked.caret {
+    caret-color: #c4c4c4;
 }
 
 textbox > label.placeholder {

--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -710,6 +710,20 @@ textbox {
     cursor: text;
 }
 
+textbox > label.placeholder {
+    child-left: 10px;
+    child-top: 1s;
+    child-bottom: 1s;
+}
+
+textbox.icon-before {
+    child-left: 30px;
+}
+
+textbox.icon-before > label.placeholder {
+    child-left: 30px;
+}
+
 textbox.multiline {
     height: auto;
     child-top: 4px;

--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -708,6 +708,20 @@ textbox {
     child-top: 1s;
     child-bottom: 1s;
     cursor: text;
+    caret-color: transparent;
+    selection-color: #6464c888;
+}
+
+textbox:checked.caret {
+    caret-color: #181818;
+}
+
+textbox:read-only {
+    caret-color: transparent;
+}
+
+textbox:checked:read-only.caret {
+    caret-color: transparent;
 }
 
 textbox > label.placeholder {

--- a/crates/vizia_core/resources/themes/light_theme.css
+++ b/crates/vizia_core/resources/themes/light_theme.css
@@ -746,8 +746,6 @@ textbox {
 textbox:checked {
     border-color: #51afef;
     transition: border-color 100ms;
-    caret-color: transparent;
-    selection-color: #6464c888;
 }
 
 textbox:checked.caret {
@@ -762,8 +760,6 @@ textbox > label.placeholder {
 textbox:read-only {
     background-color: transparent;
     border-width: 0px;
-    caret-color: transparent;
-    selection-color: #6464c888;
 }
 
 textbox:disabled {

--- a/crates/vizia_core/resources/themes/light_theme.css
+++ b/crates/vizia_core/resources/themes/light_theme.css
@@ -746,8 +746,13 @@ textbox {
 textbox:checked {
     border-color: #51afef;
     transition: border-color 100ms;
-    caret-color: red;
+    caret-color: #181818;
     selection-color: #6464c888;
+}
+
+textbox > label.placeholder {
+    caret-color: transparent;
+    color: gray;
 }
 
 textbox:read-only {

--- a/crates/vizia_core/resources/themes/light_theme.css
+++ b/crates/vizia_core/resources/themes/light_theme.css
@@ -746,8 +746,12 @@ textbox {
 textbox:checked {
     border-color: #51afef;
     transition: border-color 100ms;
-    caret-color: #181818;
+    caret-color: transparent;
     selection-color: #6464c888;
+}
+
+textbox:checked.caret {
+    caret-color: #181818;
 }
 
 textbox > label.placeholder {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1159,14 +1159,18 @@ impl<'a> EventContext<'a> {
     ///
     /// Any events emitted in response to the timer stopping, as determined by the callback provided in `add_timer()`, will target the view which called `start_timer()`.
     pub fn stop_timer(&mut self, timer: Timer) {
-        while let Some(next_timer_state) = self.running_timers.peek() {
-            if next_timer_state.id == timer {
-                let timer_state = self.running_timers.pop().unwrap();
+        let mut running_timers = self.running_timers.clone();
+
+        for timer_state in running_timers.iter() {
+            if timer_state.id == timer {
                 self.with_current(timer_state.entity, |cx| {
                     (timer_state.callback)(cx, TimerAction::Stop);
                 });
             }
         }
+
+        *self.running_timers =
+            running_timers.drain().filter(|timer_state| timer_state.id != timer).collect();
     }
 }
 

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -838,12 +838,29 @@ impl<'a> EventContext<'a> {
         self.style.needs_restyle();
     }
 
+    pub fn set_placeholder_shown(&mut self, flag: bool) {
+        let current = self.current();
+        if let Some(pseudo_classes) = self.style.pseudo_classes.get_mut(current) {
+            pseudo_classes.set(PseudoClassFlags::PLACEHOLDER_SHOWN, flag);
+        }
+
+        self.style.needs_restyle();
+    }
+
     // TODO: Move me
     pub fn is_valid(&self) -> bool {
         self.style
             .pseudo_classes
             .get(self.current)
             .map(|pseudo_classes| pseudo_classes.contains(PseudoClassFlags::VALID))
+            .unwrap_or_default()
+    }
+
+    pub fn is_placeholder_shown(&self) -> bool {
+        self.style
+            .pseudo_classes
+            .get(self.current)
+            .map(|pseudo_classes| pseudo_classes.contains(PseudoClassFlags::PLACEHOLDER_SHOWN))
             .unwrap_or_default()
     }
 

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -679,15 +679,19 @@ impl Context {
     ///
     /// Any events emitted in response to the timer stopping, as determined by the callback provided in `add_timer()`, will target the view which called `start_timer()`.
     pub fn stop_timer(&mut self, timer: Timer) {
-        while let Some(next_timer_state) = self.running_timers.peek() {
-            if next_timer_state.id == timer {
-                let timer_state = self.running_timers.pop().unwrap();
+        let mut running_timers = self.running_timers.clone();
+
+        for timer_state in running_timers.iter() {
+            if timer_state.id == timer {
                 (timer_state.callback)(
                     &mut EventContext::new_with_current(self, timer_state.entity),
                     TimerAction::Stop,
                 );
             }
         }
+
+        self.running_timers =
+            running_timers.drain().filter(|timer_state| timer_state.id != timer).collect();
     }
 
     // Tick all timers.
@@ -704,11 +708,12 @@ impl Context {
                             TimerAction::Start,
                         );
                         timer_state.ticking = true;
+                    } else {
+                        (timer_state.callback)(
+                            &mut EventContext::new_with_current(self, timer_state.entity),
+                            TimerAction::Tick(now - timer_state.time),
+                        );
                     }
-                    (timer_state.callback)(
-                        &mut EventContext::new_with_current(self, timer_state.entity),
-                        TimerAction::Tick(now - timer_state.time),
-                    );
                     timer_state.time = now + timer_state.interval - (now - timer_state.time);
                     self.running_timers.push(timer_state);
                 } else {

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -190,8 +190,12 @@ fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, met
             context.mouse.cursorx = *x;
             context.mouse.cursory = *y;
 
-            hover_system(context);
-            mutate_direct_or_up(meta, context.captured, context.hovered, false);
+            if context.mouse.cursorx != context.mouse.previous_cursorx
+                || context.mouse.cursory != context.mouse.previous_cursory
+            {
+                hover_system(context);
+                mutate_direct_or_up(meta, context.captured, context.hovered, false);
+            }
 
             // if let Some(dropped_file) = context.dropped_file.take() {
             //     emit_direct_or_up(

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -2,9 +2,12 @@ use crate::context::{InternalEvent, ResourceContext};
 use crate::events::EventMeta;
 use crate::prelude::*;
 use crate::style::{Abilities, PseudoClassFlags};
-use crate::systems::{compute_matched_rules, hover_system};
+#[cfg(debug_assertions)]
+use crate::systems::compute_matched_rules;
+use crate::systems::hover_system;
 use crate::tree::{focus_backward, focus_forward, is_navigatable};
 use instant::{Duration, Instant};
+#[cfg(debug_assertions)]
 use log::debug;
 use std::any::Any;
 use vizia_id::GenerationalId;

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -52,7 +52,7 @@ impl<'s, 't, 'v> Element for Node<'s, 't, 'v> {
     }
 
     fn parent_element(&self) -> Option<Self> {
-        self.tree.get_parent(self.entity).map(|parent| Node {
+        self.tree.get_layout_parent(self.entity).map(|parent| Node {
             entity: parent,
             store: self.store,
             tree: self.tree,

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -731,9 +731,6 @@ where
             WindowEvent::MouseUp(MouseButton::Left) => {
                 cx.unlock_cursor_icon();
                 cx.release();
-                // if cx.mouse.left.pressed == cx.current() {
-                //     cx.emit(TextEvent::StartEdit);
-                // }
             }
 
             WindowEvent::MouseMove(_, _) => {
@@ -766,9 +763,6 @@ where
                 Code::Enter => {
                     if matches!(self.kind, TextboxKind::SingleLine) {
                         cx.emit(TextEvent::Submit(true));
-
-                        cx.set_checked(false);
-                        cx.release();
                     } else if !cx.is_read_only() {
                         cx.emit(TextEvent::InsertText("\n".to_owned()));
                     }
@@ -1032,7 +1026,7 @@ where
                 if !cx.is_disabled() && !self.edit {
                     self.edit = true;
                     cx.focus_with_visibility(false);
-                    // cx.capture();
+                    cx.capture();
                     cx.set_checked(true);
 
                     if let Some(source) = cx.data::<L::Source>() {
@@ -1102,6 +1096,7 @@ where
                     (callback)(cx);
                 } else {
                     cx.emit(TextEvent::Submit(false));
+                    cx.emit(TextEvent::EndEdit);
                 }
             }
 
@@ -1114,7 +1109,6 @@ where
                         }
                     }
                 }
-                cx.emit(TextEvent::EndEdit);
             }
 
             TextEvent::SelectAll => {
@@ -1191,11 +1185,8 @@ where
                                 cx.set_valid(false);
                             }
 
-                            if let Some(callback) = self.on_edit.take() {
-                                let text = self.clone_text(cx);
+                            if let Some(callback) = &self.on_edit {
                                 (callback)(cx, text);
-
-                                self.on_edit = Some(callback);
                             }
                         }
                     }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -474,8 +474,10 @@ where
 
     fn reset_caret_timer(&mut self, cx: &mut EventContext) {
         cx.stop_timer(self.caret_timer);
-        self.show_caret = true;
-        cx.start_timer(self.caret_timer);
+        if !cx.is_read_only() {
+            self.show_caret = true;
+            cx.start_timer(self.caret_timer);
+        }
     }
 }
 
@@ -761,9 +763,7 @@ where
                     && cx.mouse.left.pressed == cx.current
                 {
                     if self.edit {
-                        cx.stop_timer(self.caret_timer);
-                        self.show_caret = true;
-                        cx.start_timer(self.caret_timer);
+                        self.reset_caret_timer(cx);
                     }
                     cx.emit(TextEvent::Drag(cx.mouse.cursorx, cx.mouse.cursory));
                 }
@@ -1067,7 +1067,7 @@ where
                     cx.focus_with_visibility(false);
                     cx.capture();
                     cx.set_checked(true);
-                    cx.start_timer(self.caret_timer);
+                    self.reset_caret_timer(cx);
 
                     if let Some(source) = cx.data::<L::Source>() {
                         let text = self.lens.view(source, |t| {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -780,6 +780,7 @@ where
                     *c != '\u{7f}' && // Delete
                     *c != '\u{0d}' && // Carriage return
                     !cx.modifiers.contains(Modifiers::CTRL) &&
+                    !cx.modifiers.contains(Modifiers::LOGO) &&
                     self.edit &&
                     !cx.is_read_only()
                 {
@@ -912,21 +913,45 @@ where
                 }
 
                 Code::KeyA => {
-                    if cx.modifiers.contains(Modifiers::CTRL) {
+                    #[cfg(target_os = "macos")]
+                    let modifier = Modifiers::LOGO;
+                    #[cfg(not(target_os = "macos"))]
+                    let modifier = Modifiers::CTRL;
+
+                    if cx.modifiers == &modifier {
                         cx.emit(TextEvent::SelectAll);
                     }
                 }
 
-                Code::KeyC if cx.modifiers == &Modifiers::CTRL => {
-                    cx.emit(TextEvent::Copy);
+                Code::KeyC => {
+                    #[cfg(target_os = "macos")]
+                    let modifier = Modifiers::LOGO;
+                    #[cfg(not(target_os = "macos"))]
+                    let modifier = Modifiers::CTRL;
+
+                    if cx.modifiers == &modifier {
+                        cx.emit(TextEvent::Copy);
+                    }
                 }
 
-                Code::KeyV if cx.modifiers == &Modifiers::CTRL => {
-                    cx.emit(TextEvent::Paste);
+                Code::KeyV => {
+                    #[cfg(target_os = "macos")]
+                    let modifier = Modifiers::LOGO;
+                    #[cfg(not(target_os = "macos"))]
+                    let modifier = Modifiers::CTRL;
+
+                    if cx.modifiers == &modifier {
+                        cx.emit(TextEvent::Paste);
+                    }
                 }
 
-                Code::KeyX if cx.modifiers == &Modifiers::CTRL => {
-                    if !cx.is_read_only() {
+                Code::KeyX => {
+                    #[cfg(target_os = "macos")]
+                    let modifier = Modifiers::LOGO;
+                    #[cfg(not(target_os = "macos"))]
+                    let modifier = Modifiers::CTRL;
+
+                    if cx.modifiers == &modifier && !cx.is_read_only() {
                         cx.emit(TextEvent::Cut);
                     }
                 }

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -123,7 +123,7 @@ where
     /// #
     /// # AppData { text: String::from("Hello World") }.build(cx);
     /// #
-    /// Textbox::new_multiline(cx, AppData::text);
+    /// Textbox::new_multiline(cx, AppData::text, true);
     /// ```
     pub fn new_multiline(cx: &mut Context, lens: L, wrap: bool) -> Handle<Self> {
         Self::new_core(

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -434,17 +434,18 @@ where
         let child_right = child_right.to_px(logical_parent_width, 0.0) * cx.scale_factor();
         let child_bottom = child_bottom.to_px(logical_parent_height, 0.0) * cx.scale_factor();
 
-        let mut text_bounds = cx.text_context.get_bounds(entity).unwrap();
-        text_bounds.x = bounds.x;
-        text_bounds.y = bounds.y;
-        bounds.h -= child_top + child_bottom;
-        bounds.w -= child_left + child_right;
-        let (mut tx, mut ty) = self.transform;
-        tx += x * SCROLL_SENSITIVITY;
-        ty += y * SCROLL_SENSITIVITY;
-        (tx, ty) = enforce_text_bounds(&text_bounds, &bounds, (tx, ty));
-        self.transform = (tx, ty);
-        cx.needs_redraw();
+        if let Some(mut text_bounds) = cx.text_context.get_bounds(entity) {
+            text_bounds.x = bounds.x;
+            text_bounds.y = bounds.y;
+            bounds.h -= child_top + child_bottom;
+            bounds.w -= child_left + child_right;
+            let (mut tx, mut ty) = self.transform;
+            tx += x * SCROLL_SENSITIVITY;
+            ty += y * SCROLL_SENSITIVITY;
+            (tx, ty) = enforce_text_bounds(&text_bounds, &bounds, (tx, ty));
+            self.transform = (tx, ty);
+            cx.needs_redraw();
+        }
     }
 
     #[allow(dead_code)]

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -45,6 +45,7 @@ pub struct Textbox<L: Lens> {
     on_edit: Option<Box<dyn Fn(&mut EventContext, String) + Send + Sync>>,
     on_submit: Option<Box<dyn Fn(&mut EventContext, String, bool) + Send + Sync>>,
     on_blur: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
+    on_cancel: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
     validate: Option<Box<dyn Fn(&String) -> bool>>,
     placeholder: String,
 }
@@ -82,6 +83,7 @@ where
             on_edit: None,
             on_submit: None,
             on_blur: None,
+            on_cancel: None,
             validate: None,
             placeholder: String::from(""),
         }
@@ -789,6 +791,9 @@ where
                 Code::Escape => {
                     cx.emit(TextEvent::EndEdit);
                     cx.set_checked(false);
+                    if let Some(callback) = &self.on_cancel {
+                        (callback)(cx);
+                    }
                 }
 
                 Code::Home => {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -51,6 +51,12 @@ pub enum TextEvent {
     Blur,
 }
 
+/// The `Textbox` view provides an input control for editing a value as a string.
+///
+/// The textbox takes a lens to some value, which must be a type which can convert to and from a `String`,
+/// as determined by the `ToString` and `FromStr` traits. The value type is used for validation and returned by
+/// the `on_submit` callback, which is triggered when the textbox is submitted with the enter key or when the textbox
+/// loses keyboard focus.
 #[derive(Lens)]
 pub struct Textbox<L: Lens> {
     lens: L,
@@ -241,7 +247,7 @@ where
         self.transform = (tx.round(), ty.round());
     }
 
-    pub fn insert_text(&mut self, cx: &mut EventContext, text: &str) {
+    fn insert_text(&mut self, cx: &mut EventContext, text: &str) {
         cx.text_context.with_editor(cx.current, |_: &mut FontSystem, buf| {
             buf.insert_string(text, None);
         });
@@ -249,7 +255,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn delete_text(&mut self, cx: &mut EventContext, movement: Movement) {
+    fn delete_text(&mut self, cx: &mut EventContext, movement: Movement) {
         let x = |_: &mut FontSystem, buf: &mut Editor| {
             let no_selection = match (buf.cursor(), buf.select_opt()) {
                 (cursor, Some(selection)) => cursor == selection,
@@ -269,7 +275,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn reset_text(&mut self, cx: &mut EventContext) {
+    fn reset_text(&mut self, cx: &mut EventContext) {
         self.select_all(cx);
         cx.text_context.with_editor(cx.current, |_, buf| {
             buf.delete_selection();
@@ -278,7 +284,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn move_cursor(&mut self, cx: &mut EventContext, movement: Movement, selection: bool) {
+    fn move_cursor(&mut self, cx: &mut EventContext, movement: Movement, selection: bool) {
         cx.text_context.with_editor(cx.current, |fs, buf| {
             if selection {
                 if buf.select_opt().is_none() {
@@ -319,7 +325,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn select_all(&mut self, cx: &mut EventContext) {
+    fn select_all(&mut self, cx: &mut EventContext) {
         cx.text_context.with_editor(cx.current, |fs, buf| {
             buf.action(fs, Action::BufferStart);
             buf.set_select_opt(Some(buf.cursor()));
@@ -328,7 +334,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn select_word(&mut self, cx: &mut EventContext) {
+    fn select_word(&mut self, cx: &mut EventContext) {
         cx.text_context.with_editor(cx.current, |fs, buf| {
             buf.action(fs, Action::PreviousWord);
             buf.set_select_opt(Some(buf.cursor()));
@@ -337,7 +343,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn select_paragraph(&mut self, cx: &mut EventContext) {
+    fn select_paragraph(&mut self, cx: &mut EventContext) {
         cx.text_context.with_editor(cx.current, |fs, buf| {
             buf.action(fs, Action::ParagraphStart);
             buf.set_select_opt(Some(buf.cursor()));
@@ -346,7 +352,7 @@ where
         cx.needs_redraw();
     }
 
-    pub fn deselect(&mut self, cx: &mut EventContext) {
+    fn deselect(&mut self, cx: &mut EventContext) {
         cx.text_context.with_editor(cx.current, |_, buf| {
             buf.set_select_opt(None);
         });
@@ -356,7 +362,7 @@ where
     /// These input coordinates should be physical coordinates, i.e. what the mouse events provide.
     /// The output text coordinates will also be physical, but relative to the top of the text
     /// glyphs, appropriate for passage to cosmic.
-    pub fn coordinates_global_to_text(&self, cx: &mut EventContext, x: f32, y: f32) -> (f32, f32) {
+    fn coordinates_global_to_text(&self, cx: &mut EventContext, x: f32, y: f32) -> (f32, f32) {
         let bounds = cx.bounds();
 
         let child_left = cx.style.child_left.get(cx.current).copied().unwrap_or_default();
@@ -393,7 +399,7 @@ where
     }
 
     /// This function takes window-global physical coordinates.
-    pub fn hit(&mut self, cx: &mut EventContext, x: f32, y: f32) {
+    fn hit(&mut self, cx: &mut EventContext, x: f32, y: f32) {
         let (x, y) = self.coordinates_global_to_text(cx, x, y);
         cx.text_context.with_editor(cx.current, |fs, buf| {
             buf.action(fs, Action::Click { x: x as i32, y: y as i32 });
@@ -402,7 +408,7 @@ where
     }
 
     /// This function takes window-global physical coordinates.
-    pub fn drag(&mut self, cx: &mut EventContext, x: f32, y: f32) {
+    fn drag(&mut self, cx: &mut EventContext, x: f32, y: f32) {
         let (x, y) = self.coordinates_global_to_text(cx, x, y);
         cx.text_context.with_editor(cx.current, |fs, buf| {
             buf.action(fs, Action::Drag { x: x as i32, y: y as i32 });
@@ -411,7 +417,7 @@ where
     }
 
     /// This function takes window-global physical dimensions.
-    pub fn scroll(&mut self, cx: &mut EventContext, x: f32, y: f32) {
+    fn scroll(&mut self, cx: &mut EventContext, x: f32, y: f32) {
         let entity = cx.current;
         let mut bounds = cx.cache.get_bounds(entity);
 

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -161,8 +161,8 @@ impl Window {
         let raw_window_handle = window.raw_window_handle();
         let attrs = SurfaceAttributesBuilder::<WindowSurface>::new().build(
             raw_window_handle,
-            NonZeroU32::new(width).unwrap(),
-            NonZeroU32::new(height).unwrap(),
+            NonZeroU32::new(width.max(1)).unwrap(),
+            NonZeroU32::new(height.max(1)).unwrap(),
         );
 
         let surface =

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -50,24 +50,27 @@ fn main() {
 
         HStack::new(cx, |cx| {
             Textbox::new(cx, AppData::number)
-                .validate(|text| text.parse::<f32>().is_ok())
-                .on_submit(|cx, text, _| {
-                    if let Ok(valid_number) = text.parse::<i32>() {
-                        cx.emit(AppEvent::SetNumber(valid_number));
-                    }
+                .validate(|val| *val < 50)
+                .on_submit(|cx, val, _| {
+                    cx.emit(AppEvent::SetNumber(val));
                 })
                 .width(Pixels(200.0))
                 .child_left(Pixels(5.0));
 
-            // Label::new(cx, "Please enter a number")
+            // Label::new(cx, "Please enter a number less than 50")
             //     .class("validation_error_label")
             //     .toggle_class("validation_error", AppData::invalid);
 
             Label::new(cx, AppData::number)
                 .width(Pixels(200.0))
-                .height(Pixels(30.0))
+                .height(Pixels(32.0))
+                .child_top(Stretch(1.0))
+                .child_bottom(Stretch(1.0))
                 .child_left(Pixels(5.0));
         })
+        .child_top(Stretch(1.0))
+        .child_bottom(Stretch(1.0))
+        .height(Auto)
         .space(Stretch(1.0))
         .col_between(Pixels(10.0));
     })

--- a/examples/user_scale.rs
+++ b/examples/user_scale.rs
@@ -28,11 +28,9 @@ fn app_main(cx: &mut Context) {
                 .bottom(Pixels(5.0))
                 .top(Pixels(-5.0));
             Textbox::new(cx, AppData::user_scale_factor).width(Percentage(100.0)).on_submit(
-                |cx, value, success| {
-                    if success {
-                        if let Ok(factor) = value.parse() {
-                            cx.set_user_scale_factor(factor);
-                        }
+                |cx, value, blur| {
+                    if blur {
+                        cx.set_user_scale_factor(value);
                     }
                 },
             );

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -1,32 +1,55 @@
 mod helpers;
 use helpers::*;
 use vizia::prelude::*;
+use vizia_core::ICON_SEARCH;
 
 #[derive(Lens, Setter, Model)]
 pub struct AppData {
     editable_text: String,
     multiline_text: String,
     non_editable_text: String,
+    non_editable_multiline_text: String,
 }
 
 fn main() {
     Application::new(|cx| {
         AppData {
-            editable_text: "This is some editable text".to_string(),
+            editable_text: "".to_string(),
             multiline_text: "This is some text which is editable and spans multiple lines"
                 .to_string(),
             non_editable_text: "This text can be selected but not edited".to_string(),
+            non_editable_multiline_text:
+                "This text can be selected but not edited and spans multiple lines".to_string(),
         }
         .build(cx);
 
         ExamplePage::vertical(cx, |cx| {
             Textbox::new(cx, AppData::editable_text)
                 .width(Pixels(300.0))
+                .placeholder("Type something...")
                 .on_edit(|cx, text| cx.emit(AppDataSetter::EditableText(text)));
+
+            HStack::new(cx, |cx| {
+                Textbox::new(cx, AppData::editable_text)
+                    .class("icon-before")
+                    .width(Stretch(1.0))
+                    .placeholder("Search")
+                    .on_edit(|cx, text| cx.emit(AppDataSetter::EditableText(text)));
+                Icon::new(cx, ICON_SEARCH)
+                    .color(Color::gray())
+                    .position_type(PositionType::SelfDirected);
+            })
+            .height(Auto)
+            .width(Pixels(300.0));
+
             Textbox::new_multiline(cx, AppData::multiline_text, true)
                 .width(Pixels(300.0))
                 .on_edit(|cx, text| cx.emit(AppDataSetter::MultilineText(text)));
-            Textbox::new(cx, AppData::non_editable_text).width(Pixels(300.0)).read_only(true);
+
+            Textbox::new(cx, AppData::non_editable_text).width(Auto).read_only(true);
+            Textbox::new_multiline(cx, AppData::non_editable_multiline_text, true)
+                .width(Pixels(300.0))
+                .read_only(true);
         });
     })
     .title("Textbox")


### PR DESCRIPTION
- [x] Allow placeholder text to be styled
- [x] Show placeholder text when textbox is being edited but is empty
- [x] Add example for preceding icon
- [x] Use lens target as validation type to remove the need for the user to manually parse
- [x] Add `on_cancel` callback which is triggered when the escape key is pressed
- [x] Update textbox theming
- [x] Cleanup textbox code
- [x] Use command key for cut/copy/paste/select all on macOS 