### PR TITLE
Fix the "blank window flash" problem on windows.

### DIFF
--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -36,3 +36,6 @@ raw-window-handle = "0.5.2"
 wasm-bindgen = { version = "0.2" }
 web_sys = { version = "0.3", package = "web-sys", features = ["console", "WebGlContextAttributes"] }
 console_error_panic_hook = "0.1.5"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3.9", default-features = false, features = ["minwindef", "dwmapi"] }


### PR DESCRIPTION
See: https://github.com/rust-windowing/winit/issues/1290

Fix explained here: https://stackoverflow.com/a/74019785

Cloak attribute documentation: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute

TL;DR: Set the `Cloak` window attribute on creation, hiding the window, then unset it once the first draw is complete. `Cloak` differs from `Visible` in that the window will still be composited, allowing said draw to actually work.