### PR TITLE
Improve `Application::icon` method argument order.

### DIFF
--- a/crates/vizia_core/src/window/window_modifiers.rs
+++ b/crates/vizia_core/src/window/window_modifiers.rs
@@ -184,13 +184,17 @@ pub trait WindowModifiers {
     /// ```no_run
     /// # use vizia_core::prelude::*;
     /// # use vizia_winit::application::Application;
+    ///
+    /// let icon = vizia::image::load_from_memory(include_bytes!("../icon.png"))
+    ///     .expect("Failed to load icon");
+    ///
     /// Application::new(|cx|{
     ///     // Content here
     /// })
-    /// // .icon() TODO
+    /// .icon(icon.width(), icon.height(), icon.into_bytes())
     /// .run();
     /// ```
-    fn icon(self, image: Vec<u8>, width: u32, height: u32) -> Self;
+    fn icon(self, width: u32, height: u32, image: Vec<u8>) -> Self;
     #[cfg(target_arch = "wasm32")]
     fn canvas(self, canvas: &str) -> Self;
 }

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -619,7 +619,7 @@ impl WindowModifiers for Application {
         self
     }
 
-    fn icon(mut self, image: Vec<u8>, width: u32, height: u32) -> Self {
+    fn icon(mut self, width: u32, height: u32, image: Vec<u8>) -> Self {
         self.window_description.icon = Some(image);
         self.window_description.icon_width = width;
         self.window_description.icon_height = height;


### PR DESCRIPTION
I encountered this minor annoyance when trying to give my application an icon. As far as I can tell the "canonical" way to apply application icons in vizia is to use `load_from_memory` and pass the data into `Application::icon`. Unfortunately the argument order for `Application::icon` takes the bytes first, which requires consuming the icon via `.into_bytes()`, after which you can longer access `.weight()` and `.height()` which are needed for the second and third arguments. 

This PR simply changes the argument order so you can pass all arguments in the same line without binding temporary variables. I also went ahead and filled in the example in the method documentation.

```rs
let icon = vizia::image::load_from_memory(include_bytes!("../icon.png"))
    .expect("Failed to load icon");

Application::new(|cx| {
    // ...
})
.icon(icon.width(), icon.height(), icon.into_bytes())
```