### PR TITLE
Trigger update on parent access node when children are removed

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -458,6 +458,10 @@ impl Context {
                 }
             });
 
+            if let Some(parent) = self.tree.get_layout_parent(*entity) {
+                self.style.needs_access_update(parent);
+            }
+
             self.tree.remove(*entity).expect("");
             self.cache.remove(*entity);
             self.style.remove(*entity);


### PR DESCRIPTION
Fixes an issue where the accessibility tree wasn't being updated correctly when the children of a node were removed. This is because the child nodes are updated by triggering an accessibility update (`TreeUpdate`) on the parent, passing in the updated list of children. This PR fixes the issue by flagging the parent for an accessibility update when children are removed.