### PR TITLE
Fix for combobox opening on init

### DIFF
--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -1038,8 +1038,10 @@ where
 
                 self.placeholder_shown = text.is_empty();
 
-                if let Some(callback) = &self.on_edit {
-                    (callback)(cx, text);
+                if self.edit {
+                    if let Some(callback) = &self.on_edit {
+                        (callback)(cx, text);
+                    }
                 }
             }
 


### PR DESCRIPTION
The `TextEvent::InsertText` is called when the textbox is updated externally (via binding), which was triggering the `on_edit` callback. This was then calling the `ComboBoxEvent::SetFilterText` event, which opens the popup if closed. This PR adds a check to see if the textbox is editable before calling `on_edit`.