### PR TITLE
Minor improvements to the `Dropdown` view.

### DIFF
--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -171,6 +171,8 @@ dropdown .title {
 dropdown popup {
     width: 100%;
     height: auto;
+    top: 100%;
+    translate: 0px 4px;
 }
 
 dropdown popup list {

--- a/crates/vizia_core/src/views/dropdown.rs
+++ b/crates/vizia_core/src/views/dropdown.rs
@@ -153,16 +153,14 @@ impl Dropdown {
                     .role(Role::PopupButton)
                     .width(Stretch(1.0))
                     .cursor(CursorIcon::Hand)
+                    .checked(PopupData::is_open)
                     .navigable(true)
                     .on_press(|cx| cx.emit(PopupEvent::Switch));
 
                 Popup::new(cx, PopupData::is_open, false, move |cx| {
                     (content)(cx);
                 })
-                .on_blur(|cx| cx.emit(PopupEvent::Close))
-                .top(Percentage(100.0))
-                .translate((Pixels(0.0), Pixels(4.0)))
-                .height(Auto);
+                .on_blur(|cx| cx.emit(PopupEvent::Close));
             })
             .cursor(CursorIcon::Hand)
     }


### PR DESCRIPTION
1. Move styling to `default_layout.css` rather than hard-coding it in rust. This is needed to enable user customization.

2. Add `checked` modifier to the dropdown title. This allows it to be styled differently when opened versus closed.

It was suggested on discord that refactoring the `Dropdown` itself to hold the `is_open` state may be a better solution to `2`, but that is a larger change and I'm not familiar enough with the internals yet to implement it.