### PR TITLE
Skip non-displayed views when iterating focus

### DIFF
--- a/crates/vizia_storage/src/tree/iter/focus_iter.rs
+++ b/crates/vizia_storage/src/tree/iter/focus_iter.rs
@@ -1,0 +1,75 @@
+use crate::{DoubleEndedTreeTour, TourDirection, TourStep, Tree};
+use vizia_id::GenerationalId;
+
+/// Iterator for iterating through the tree in depth first preorder.
+pub struct FocusTreeIterator<'a, I>
+where
+    I: GenerationalId,
+{
+    tree: &'a Tree<I>,
+    tours: DoubleEndedTreeTour<I>,
+    is_hidden: Box<dyn Fn(I) -> bool + 'a>,
+}
+
+impl<'a, I> FocusTreeIterator<'a, I>
+where
+    I: GenerationalId,
+{
+    pub fn new(
+        tree: &'a Tree<I>,
+        tours: DoubleEndedTreeTour<I>,
+        is_hidden: impl Fn(I) -> bool + 'a,
+    ) -> Self {
+        Self { tree, tours, is_hidden: Box::new(is_hidden) }
+    }
+
+    pub fn full(tree: &'a Tree<I>, is_hidden: impl Fn(I) -> bool + 'a) -> Self {
+        Self::subtree(tree, I::root(), is_hidden)
+    }
+
+    pub fn subtree(tree: &'a Tree<I>, root: I, is_hidden: impl Fn(I) -> bool + 'a) -> Self {
+        Self {
+            tree,
+            tours: DoubleEndedTreeTour::new_same(Some(root)),
+            is_hidden: Box::new(is_hidden),
+        }
+    }
+}
+
+impl<'a, I> Iterator for FocusTreeIterator<'a, I>
+where
+    I: GenerationalId,
+{
+    type Item = I;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.tours.next_with(self.tree, |node, direction| match direction {
+            TourDirection::Entering => {
+                if (self.is_hidden)(node) {
+                    (None, TourStep::LeaveCurrent)
+                } else {
+                    (Some(node), TourStep::EnterFirstChild)
+                }
+            }
+            TourDirection::Leaving => (None, TourStep::EnterNextSibling),
+        })
+    }
+}
+
+impl<'a, I> DoubleEndedIterator for FocusTreeIterator<'a, I>
+where
+    I: GenerationalId,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.tours.next_back_with(self.tree, |node, direction| match direction {
+            TourDirection::Entering => (None, TourStep::EnterLastChild),
+            TourDirection::Leaving => {
+                if (self.is_hidden)(node) {
+                    (None, TourStep::EnterPrevSibling)
+                } else {
+                    (Some(node), TourStep::EnterPrevSibling)
+                }
+            }
+        })
+    }
+}

--- a/crates/vizia_storage/src/tree/iter/mod.rs
+++ b/crates/vizia_storage/src/tree/iter/mod.rs
@@ -1,5 +1,6 @@
 mod child_iter;
 mod draw_iter;
+mod focus_iter;
 mod layout_child_iter;
 mod layout_tree_iter;
 mod parent_iter;
@@ -11,6 +12,7 @@ pub use self::{
     child_iter::ChildIterator,
     child_iter::MorphormChildIter,
     draw_iter::DrawIterator,
+    focus_iter::FocusTreeIterator,
     layout_child_iter::LayoutChildIterator,
     layout_tree_iter::LayoutTreeIterator,
     parent_iter::{LayoutParentIterator, ParentIterator},


### PR DESCRIPTION
Fixes a bug where the descendants  of non-displayed views could still be navigated to with tab/shift-tab.