### PR TITLE
Added `WindowEvent::ThemeChanged` event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,6 +345,10 @@ path = "examples/lens_map.rs"
 name = "timers"
 path = "examples/timers.rs"
 
+[[example]]
+name = "follow_system_theme"
+path = "examples/follow_system_theme.rs"
+
 [features]
 default = ["winit", "clipboard", "x11", "wayland", "embedded_fonts"]
 clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -35,7 +35,7 @@ pub use resource::*;
 
 use crate::binding::{BindingHandler, MapId};
 use crate::cache::CachedData;
-use crate::environment::{AppTheme, Environment, ThemeMode};
+use crate::environment::{Environment, ThemeMode};
 use crate::events::{TimedEvent, TimedEventHandle, Timer, TimerState, ViewHandler};
 #[cfg(feature = "embedded_fonts")]
 use crate::fonts;
@@ -551,12 +551,7 @@ impl Context {
         self.add_theme(DEFAULT_LAYOUT);
         if !self.ignore_default_theme {
             let environment = self.data::<Environment>().expect("Failed to get environment");
-            let theme_mode = match environment.app_theme {
-                AppTheme::System => environment.sys_theme.unwrap_or_default(),
-                AppTheme::BuiltIn(theme) => theme,
-            };
-
-            match theme_mode {
+            match environment.theme.get_current_theme() {
                 ThemeMode::LightMode => self.add_theme(LIGHT_THEME),
                 ThemeMode::DarkMode => self.add_theme(DARK_THEME),
             }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -35,7 +35,7 @@ pub use resource::*;
 
 use crate::binding::{BindingHandler, MapId};
 use crate::cache::CachedData;
-use crate::environment::{Environment, ThemeMode};
+use crate::environment::{AppTheme, Environment, ThemeMode};
 use crate::events::{TimedEvent, TimedEventHandle, Timer, TimerState, ViewHandler};
 #[cfg(feature = "embedded_fonts")]
 use crate::fonts;
@@ -551,7 +551,12 @@ impl Context {
         self.add_theme(DEFAULT_LAYOUT);
         if !self.ignore_default_theme {
             let environment = self.data::<Environment>().expect("Failed to get environment");
-            match environment.theme_mode {
+            let theme_mode = match environment.app_theme {
+                AppTheme::System => environment.sys_theme.unwrap_or_default(),
+                AppTheme::BuiltIn(theme) => theme,
+            };
+
+            match theme_mode {
                 ThemeMode::LightMode => self.add_theme(LIGHT_THEME),
                 ThemeMode::DarkMode => self.add_theme(DARK_THEME),
             }

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -14,7 +14,10 @@ use crate::{binding::Lens, context::EventContext, events::Event};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AppTheme {
+    /// System theme, if we choose this as our theme vizia
+    /// will follow system theme in supported platforms.
     System,
+    /// builtin vizia themes
     BuiltIn(ThemeMode),
     // Custom(String),
 }

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -1,23 +1,33 @@
 //! A model for system specific state which can be accessed by any model or view.
-use crate::{model::Model, prelude::Wrapper};
+use crate::{model::Model, prelude::Wrapper, window::WindowEvent};
 use unic_langid::LanguageIdentifier;
 use vizia_derive::Lens;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeMode {
+    #[default]
     DarkMode,
     LightMode,
 }
 
 use crate::{binding::Lens, context::EventContext, events::Event};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppTheme {
+    System,
+    BuiltIn(ThemeMode),
+    // Custom(String),
+}
+
 /// A model for system specific state which can be accessed by any model or view.
 #[derive(Lens)]
 pub struct Environment {
     // The locale used for localization.
     pub locale: LanguageIdentifier,
-    // The theme mode used when using the built-in theming.
-    pub theme_mode: ThemeMode,
+    // The current application theme
+    pub app_theme: AppTheme,
+    // The current system theme
+    pub sys_theme: Option<ThemeMode>,
 }
 
 impl Default for Environment {
@@ -30,7 +40,14 @@ impl Environment {
     pub fn new() -> Self {
         let locale = sys_locale::get_locale().and_then(|l| l.parse().ok()).unwrap_or_default();
 
-        Self { locale, theme_mode: ThemeMode::LightMode }
+        Self { locale, app_theme: AppTheme::BuiltIn(ThemeMode::LightMode), sys_theme: None }
+    }
+
+    pub fn get_current_theme(&self) -> ThemeMode {
+        match self.app_theme {
+            AppTheme::System => self.sys_theme.unwrap_or_default(),
+            AppTheme::BuiltIn(theme) => theme,
+        }
     }
 }
 
@@ -39,7 +56,8 @@ pub enum EnvironmentEvent {
     /// Set the locale used for the whole application.
     SetLocale(LanguageIdentifier),
     /// Set the default theme mode.
-    SetThemeMode(ThemeMode),
+    // TODO: add SetSysTheme event when the winit `set_theme` fixed.
+    SetThemeMode(AppTheme),
     /// Reset the locale to use the system provided locale.
     UseSystemLocale,
     /// Alternate between dark and light theme modes.
@@ -54,8 +72,9 @@ impl Model for Environment {
             }
 
             EnvironmentEvent::SetThemeMode(theme_mode) => {
-                self.theme_mode = *theme_mode;
-                cx.set_theme_mode(self.theme_mode);
+                self.app_theme = theme_mode.to_owned();
+
+                cx.set_theme_mode(self.get_current_theme());
                 cx.reload_styles().unwrap();
             }
 
@@ -65,15 +84,27 @@ impl Model for Environment {
             }
 
             EnvironmentEvent::ToggleThemeMode => {
-                let theme_mode = match self.theme_mode {
+                let theme_mode = match self.get_current_theme() {
                     ThemeMode::DarkMode => ThemeMode::LightMode,
                     ThemeMode::LightMode => ThemeMode::DarkMode,
                 };
 
-                self.theme_mode = theme_mode;
-                cx.set_theme_mode(self.theme_mode);
+                self.app_theme = AppTheme::BuiltIn(theme_mode);
+
+                cx.set_theme_mode(theme_mode);
                 cx.reload_styles().unwrap();
             }
         });
+
+        event.map(|event, _| match event {
+            WindowEvent::ThemeChanged(theme) => {
+                self.sys_theme = Some(*theme);
+                if self.app_theme == AppTheme::System {
+                    cx.set_theme_mode(*theme);
+                    cx.reload_styles().unwrap();
+                }
+            }
+            _ => (),
+        })
     }
 }

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -206,7 +206,7 @@ impl PartialEq<Self> for TimedEvent {
 impl Eq for TimedEvent {}
 impl PartialOrd for TimedEvent {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.time.partial_cmp(&other.time).map(|ord| ord.reverse())
+        Some(self.cmp(other))
     }
 }
 impl Ord for TimedEvent {

--- a/crates/vizia_core/src/events/timer.rs
+++ b/crates/vizia_core/src/events/timer.rs
@@ -62,7 +62,7 @@ impl Eq for TimerState {}
 
 impl PartialOrd for TimerState {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.time.partial_cmp(&other.time).map(|ord| ord.reverse())
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -73,7 +73,7 @@ pub mod prelude {
         EventContext, ProxyEmitError,
     };
     pub use super::entity::Entity;
-    pub use super::environment::{Environment, EnvironmentEvent, ThemeMode};
+    pub use super::environment::{AppTheme, Environment, EnvironmentEvent, ThemeMode};
     pub use super::events::{Event, Propagation, Timer, TimerAction};
     pub use super::include_style;
     pub use super::input::{Keymap, KeymapEntry, KeymapEvent};

--- a/crates/vizia_core/src/window/window_event.rs
+++ b/crates/vizia_core/src/window/window_event.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::{entity::Entity, layout::cache::GeoChanged};
+use crate::{entity::Entity, environment::ThemeMode, layout::cache::GeoChanged};
 use vizia_input::{Code, Key, MouseButton};
 use vizia_style::CursorIcon;
 use vizia_window::{Position, WindowSize};
@@ -69,6 +69,8 @@ pub enum WindowEvent {
     KeyDown(Code, Option<Key>),
     /// Emitted when a keyboard key is released.
     KeyUp(Code, Option<Key>),
+    /// Emited when the system window theme has changed.
+    ThemeChanged(ThemeMode),
     /// Sets the mouse cursor icon.
     SetCursor(CursorIcon),
     /// Grabs the mouse cursor, preventing it from leaving the window.

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -508,6 +508,14 @@ impl Application {
                             cx.needs_refresh();
                         }
 
+                        winit::event::WindowEvent::ThemeChanged(theme) => {
+                            let theme = match theme {
+                                winit::window::Theme::Light => ThemeMode::LightMode,
+                                winit::window::Theme::Dark => ThemeMode::DarkMode,
+                            };
+                            cx.emit_origin(WindowEvent::ThemeChanged(theme));
+                        }
+
                         winit::event::WindowEvent::ModifiersChanged(modifiers_state) => {
                             cx.modifiers().set(Modifiers::SHIFT, modifiers_state.shift());
                             cx.modifiers().set(Modifiers::ALT, modifiers_state.alt());

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -186,6 +186,15 @@ impl Application {
 
         let mut cx = BackendContext::new(&mut context);
 
+        // update the sys theme if any
+        if let Some(theme) = window.window().theme() {
+            let theme = match theme {
+                winit::window::Theme::Light => ThemeMode::LightMode,
+                winit::window::Theme::Dark => ThemeMode::DarkMode,
+            };
+            cx.emit_origin(WindowEvent::ThemeChanged(theme));
+        }
+
         #[cfg(not(target_arch = "wasm32"))]
         let root_node = NodeBuilder::new(Role::Window).build(cx.accesskit_node_classes());
         #[cfg(not(target_arch = "wasm32"))]

--- a/examples/follow_system_theme.rs
+++ b/examples/follow_system_theme.rs
@@ -1,0 +1,39 @@
+use vizia::prelude::*;
+
+#[derive(Debug, Lens)]
+pub struct AppData {
+    current_theme: String,
+}
+
+impl Model for AppData {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.map(|event, _| {
+            if let WindowEvent::ThemeChanged(theme) = event {
+                self.current_theme = match theme {
+                    ThemeMode::DarkMode => "Dark Mode",
+                    ThemeMode::LightMode => "Light Mode",
+                }
+                .to_owned();
+
+                cx.emit(EnvironmentEvent::SetThemeMode(*theme))
+            }
+        })
+    }
+}
+
+fn main() {
+    Application::new(|cx: &mut Context| {
+        AppData { current_theme: "Light mode".to_owned() }.build(cx);
+
+        VStack::new(cx, |cx| {
+            Label::new(cx, "This example follow system theme change");
+            Label::new(cx, "Change your theme to light or dark mode to see how it works\n");
+            Label::new(cx, AppData::current_theme.map(|v| format!("Current system theme: {v}")));
+        })
+        .child_space(Stretch(1.0))
+        .space(Stretch(1.0));
+    })
+    .title("Follow system theme")
+    .inner_size((470, 320))
+    .run();
+}

--- a/examples/follow_system_theme.rs
+++ b/examples/follow_system_theme.rs
@@ -6,7 +6,7 @@ pub struct AppData {
 }
 
 impl Model for AppData {
-    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
         event.map(|event, _| {
             if let WindowEvent::ThemeChanged(theme) = event {
                 self.current_theme = match theme {
@@ -14,8 +14,6 @@ impl Model for AppData {
                     ThemeMode::LightMode => "Light Mode",
                 }
                 .to_owned();
-
-                cx.emit(EnvironmentEvent::SetThemeMode(*theme))
             }
         })
     }
@@ -24,6 +22,8 @@ impl Model for AppData {
 fn main() {
     Application::new(|cx: &mut Context| {
         AppData { current_theme: "Light mode".to_owned() }.build(cx);
+
+        cx.emit(EnvironmentEvent::SetThemeMode(AppTheme::System));
 
         VStack::new(cx, |cx| {
             Label::new(cx, "This example follow system theme change");

--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,14 +1,5 @@
 #![allow(dead_code)]
-use vizia::{
-    icons::{ICON_MOON, ICON_SUN},
-    prelude::*,
-};
-
-use lazy_static::lazy_static;
-
-lazy_static! {
-    pub static ref THEME_MODES: Vec<&'static str> = vec!["Light", "Dark"];
-}
+use vizia::prelude::*;
 
 pub const CENTER_LAYOUT: &str = r#"
     .container {
@@ -23,30 +14,48 @@ pub const CENTER_LAYOUT: &str = r#"
 #[derive(Lens)]
 pub struct ControlsData {
     pub disabled: bool,
+    pub theme_options: Vec<&'static str>,
+    pub selected_theme: usize,
+}
+
+impl Default for ControlsData {
+    fn default() -> Self {
+        Self { disabled: false, theme_options: vec!["System", "Dark", "Light"], selected_theme: 0 }
+    }
 }
 
 pub enum ControlsEvent {
     ToggleDisabled,
+    SetThemeMode(usize),
 }
 
 impl Model for ControlsData {
-    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
             ControlsEvent::ToggleDisabled => {
                 self.disabled ^= true;
+            }
+            ControlsEvent::SetThemeMode(theme_mode) => {
+                self.selected_theme = *theme_mode;
+                cx.emit(EnvironmentEvent::SetThemeMode(match theme_mode {
+                    0 /* system */ => AppTheme::System,
+                    1 /* Dark */ => AppTheme::BuiltIn(ThemeMode::DarkMode),
+                    2 /* Light */ => AppTheme::BuiltIn(ThemeMode::LightMode),
+                    _ => unreachable!(),
+                }));
             }
         });
     }
 }
 
-pub struct ExamplePage {}
+pub struct ExamplePage;
 
 impl ExamplePage {
     pub fn vertical(cx: &mut Context, content: impl FnOnce(&mut Context)) -> Handle<Self> {
         cx.add_stylesheet(CENTER_LAYOUT).expect("Failed to add stylesheet");
 
-        Self {}.build(cx, |cx| {
-            ControlsData { disabled: false }.build(cx);
+        Self.build(cx, |cx| {
+            ControlsData::default().build(cx);
 
             HStack::new(cx, |cx| {
                 HStack::new(cx, |cx| {
@@ -61,24 +70,7 @@ impl ExamplePage {
                 .bottom(Stretch(1.0))
                 .size(Auto);
 
-                Button::new(
-                    cx,
-                    |ex| ex.emit(EnvironmentEvent::ToggleThemeMode),
-                    |cx| {
-                        Label::new(
-                            cx,
-                            Environment::theme.map(|theme| match theme.get_current_theme() {
-                                ThemeMode::DarkMode => ICON_SUN,
-                                ThemeMode::LightMode => ICON_MOON,
-                            }),
-                        )
-                        .class("icon")
-                    },
-                )
-                .class("icon")
-                .tooltip(|cx| {
-                    Label::new(cx, "Toggle Dark/Light Mode");
-                });
+                theme_selection_dropdown(cx);
             })
             .height(Auto)
             .width(Stretch(1.0))
@@ -98,13 +90,14 @@ impl ExamplePage {
             .class("container");
         })
     }
+
     pub fn new(cx: &mut Context, content: impl FnOnce(&mut Context)) -> Handle<Self> {
         // setup_logging().expect("Failed to setup logging");
 
         cx.add_stylesheet(CENTER_LAYOUT).expect("Failed to add stylesheet");
 
-        Self {}.build(cx, |cx| {
-            ControlsData { disabled: false }.build(cx);
+        Self.build(cx, |cx| {
+            ControlsData::default().build(cx);
 
             HStack::new(cx, |cx| {
                 HStack::new(cx, |cx| {
@@ -119,24 +112,7 @@ impl ExamplePage {
                 .bottom(Stretch(1.0))
                 .size(Auto);
 
-                Button::new(
-                    cx,
-                    |ex| ex.emit(EnvironmentEvent::ToggleThemeMode),
-                    |cx| {
-                        Label::new(
-                            cx,
-                            Environment::theme.map(|theme| match theme.get_current_theme() {
-                                ThemeMode::DarkMode => ICON_SUN,
-                                ThemeMode::LightMode => ICON_MOON,
-                            }),
-                        )
-                        .class("icon")
-                    },
-                )
-                .class("icon")
-                .tooltip(|cx| {
-                    Label::new(cx, "Toggle dark/light mode");
-                });
+                theme_selection_dropdown(cx);
             })
             .height(Auto)
             .width(Stretch(1.0))
@@ -159,3 +135,12 @@ impl ExamplePage {
 }
 
 impl View for ExamplePage {}
+
+fn theme_selection_dropdown(cx: &mut Context) {
+    PickList::new(cx, ControlsData::theme_options, ControlsData::selected_theme, true)
+        .on_select(|cx, index| cx.emit(ControlsEvent::SetThemeMode(index)))
+        .width(Pixels(85.0))
+        .tooltip(|cx| {
+            Label::new(cx, "Select Theme Mode");
+        });
+}

--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use vizia::{
-    icons::{ICON_MOON, ICON_SUN},
+    icons::{ICON_MOON, ICON_SETTINGS_AUTOMATION, ICON_SUN},
     prelude::*,
 };
 
@@ -67,12 +67,12 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::theme_mode.map(|mode| {
-                                if *mode == ThemeMode::DarkMode {
-                                    ICON_SUN
-                                } else {
-                                    ICON_MOON
-                                }
+                            Environment::app_theme.map(|mode| match mode {
+                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
+                                AppTheme::BuiltIn(theme) => match theme {
+                                    ThemeMode::DarkMode => ICON_SUN,
+                                    ThemeMode::LightMode => ICON_MOON,
+                                },
                             }),
                         )
                         .class("icon")
@@ -128,12 +128,12 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::theme_mode.map(|mode| {
-                                if *mode == ThemeMode::DarkMode {
-                                    ICON_SUN
-                                } else {
-                                    ICON_MOON
-                                }
+                            Environment::app_theme.map(|mode| match mode {
+                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
+                                AppTheme::BuiltIn(theme) => match theme {
+                                    ThemeMode::DarkMode => ICON_SUN,
+                                    ThemeMode::LightMode => ICON_MOON,
+                                },
                             }),
                         )
                         .class("icon")

--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use vizia::{
-    icons::{ICON_MOON, ICON_SETTINGS_AUTOMATION, ICON_SUN},
+    icons::{ICON_MOON, ICON_SUN},
     prelude::*,
 };
 
@@ -67,12 +67,9 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::app_theme.map(|mode| match mode {
-                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
-                                AppTheme::BuiltIn(theme) => match theme {
-                                    ThemeMode::DarkMode => ICON_SUN,
-                                    ThemeMode::LightMode => ICON_MOON,
-                                },
+                            Environment::theme.map(|theme| match theme.get_current_theme() {
+                                ThemeMode::DarkMode => ICON_SUN,
+                                ThemeMode::LightMode => ICON_MOON,
                             }),
                         )
                         .class("icon")
@@ -128,12 +125,9 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::app_theme.map(|mode| match mode {
-                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
-                                AppTheme::BuiltIn(theme) => match theme {
-                                    ThemeMode::DarkMode => ICON_SUN,
-                                    ThemeMode::LightMode => ICON_MOON,
-                                },
+                            Environment::theme.map(|theme| match theme.get_current_theme() {
+                                ThemeMode::DarkMode => ICON_SUN,
+                                ThemeMode::LightMode => ICON_MOON,
                             }),
                         )
                         .class("icon")

--- a/examples/views/helpers/mod.rs
+++ b/examples/views/helpers/mod.rs
@@ -1,17 +1,8 @@
 #![allow(dead_code)]
-use vizia::{
-    icons::{ICON_MOON, ICON_SUN},
-    prelude::*,
-};
+use vizia::prelude::*;
 
 use log::LevelFilter;
 use std::error::Error;
-
-use lazy_static::lazy_static;
-
-lazy_static! {
-    pub static ref THEME_MODES: Vec<&'static str> = vec!["Light", "Dark"];
-}
 
 pub const CENTER_LAYOUT: &str = r#"
     .container {
@@ -26,23 +17,41 @@ pub const CENTER_LAYOUT: &str = r#"
 #[derive(Lens)]
 pub struct ControlsData {
     pub disabled: bool,
+    pub theme_options: Vec<&'static str>,
+    pub selected_theme: usize,
+}
+
+impl Default for ControlsData {
+    fn default() -> Self {
+        Self { disabled: false, theme_options: vec!["System", "Dark", "Light"], selected_theme: 0 }
+    }
 }
 
 pub enum ControlsEvent {
     ToggleDisabled,
+    SetThemeMode(usize),
 }
 
 impl Model for ControlsData {
-    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
             ControlsEvent::ToggleDisabled => {
                 self.disabled ^= true;
+            }
+            ControlsEvent::SetThemeMode(theme_mode) => {
+                self.selected_theme = *theme_mode;
+                cx.emit(EnvironmentEvent::SetThemeMode(match theme_mode {
+                    0 /* system */ => AppTheme::System,
+                    1 /* Dark */ => AppTheme::BuiltIn(ThemeMode::DarkMode),
+                    2 /* Light */ => AppTheme::BuiltIn(ThemeMode::LightMode),
+                    _ => unreachable!(),
+                }));
             }
         });
     }
 }
 
-pub struct ExamplePage {}
+pub struct ExamplePage;
 
 impl ExamplePage {
     pub fn vertical(cx: &mut Context, content: impl FnOnce(&mut Context)) -> Handle<Self> {
@@ -50,8 +59,9 @@ impl ExamplePage {
 
         cx.add_stylesheet(CENTER_LAYOUT).expect("Failed to add stylesheet");
 
-        Self {}.build(cx, |cx| {
-            ControlsData { disabled: false }.build(cx);
+        Self.build(cx, |cx| {
+            ControlsData::default().build(cx);
+            cx.emit(EnvironmentEvent::SetThemeMode(AppTheme::System)); // set system theme
 
             HStack::new(cx, |cx| {
                 HStack::new(cx, |cx| {
@@ -66,24 +76,7 @@ impl ExamplePage {
                 .bottom(Stretch(1.0))
                 .size(Auto);
 
-                Button::new(
-                    cx,
-                    |ex| ex.emit(EnvironmentEvent::ToggleThemeMode),
-                    |cx| {
-                        Label::new(
-                            cx,
-                            Environment::theme.map(|theme| match theme.get_current_theme() {
-                                ThemeMode::DarkMode => ICON_SUN,
-                                ThemeMode::LightMode => ICON_MOON,
-                            }),
-                        )
-                        .class("icon")
-                    },
-                )
-                .class("icon")
-                .tooltip(|cx| {
-                    Label::new(cx, "Toggle Dark/Light Mode");
-                });
+                theme_selection_dropdown(cx);
             })
             .height(Auto)
             .width(Stretch(1.0))
@@ -103,13 +96,15 @@ impl ExamplePage {
             .class("container");
         })
     }
+
     pub fn new(cx: &mut Context, content: impl FnOnce(&mut Context)) -> Handle<Self> {
         setup_logging().expect("Failed to init logging");
 
         cx.add_stylesheet(CENTER_LAYOUT).expect("Failed to add stylesheet");
 
-        Self {}.build(cx, |cx| {
-            ControlsData { disabled: false }.build(cx);
+        Self.build(cx, |cx| {
+            ControlsData::default().build(cx);
+            cx.emit(EnvironmentEvent::SetThemeMode(AppTheme::System)); // set system theme
 
             HStack::new(cx, |cx| {
                 HStack::new(cx, |cx| {
@@ -124,24 +119,7 @@ impl ExamplePage {
                 .bottom(Stretch(1.0))
                 .size(Auto);
 
-                Button::new(
-                    cx,
-                    |ex| ex.emit(EnvironmentEvent::ToggleThemeMode),
-                    |cx| {
-                        Label::new(
-                            cx,
-                            Environment::theme.map(|theme| match theme.get_current_theme() {
-                                ThemeMode::DarkMode => ICON_SUN,
-                                ThemeMode::LightMode => ICON_MOON,
-                            }),
-                        )
-                        .class("icon")
-                    },
-                )
-                .class("icon")
-                .tooltip(|cx| {
-                    Label::new(cx, "Toggle dark/light mode");
-                });
+                theme_selection_dropdown(cx);
             })
             .height(Auto)
             .width(Stretch(1.0))
@@ -164,6 +142,15 @@ impl ExamplePage {
 }
 
 impl View for ExamplePage {}
+
+fn theme_selection_dropdown(cx: &mut Context) {
+    PickList::new(cx, ControlsData::theme_options, ControlsData::selected_theme, true)
+        .on_select(|cx, index| cx.emit(ControlsEvent::SetThemeMode(index)))
+        .width(Pixels(85.0))
+        .tooltip(|cx| {
+            Label::new(cx, "Select Theme Mode");
+        });
+}
 
 pub fn setup_logging() -> Result<(), Box<dyn Error>> {
     #[cfg(debug_assertions)]

--- a/examples/views/helpers/mod.rs
+++ b/examples/views/helpers/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use vizia::{
-    icons::{ICON_MOON, ICON_SUN},
+    icons::{ICON_MOON, ICON_SETTINGS_AUTOMATION, ICON_SUN},
     prelude::*,
 };
 
@@ -72,12 +72,12 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::theme_mode.map(|mode| {
-                                if *mode == ThemeMode::DarkMode {
-                                    ICON_SUN
-                                } else {
-                                    ICON_MOON
-                                }
+                            Environment::app_theme.map(|mode| match mode {
+                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
+                                AppTheme::BuiltIn(theme) => match theme {
+                                    ThemeMode::DarkMode => ICON_SUN,
+                                    ThemeMode::LightMode => ICON_MOON,
+                                },
                             }),
                         )
                         .class("icon")
@@ -133,12 +133,12 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::theme_mode.map(|mode| {
-                                if *mode == ThemeMode::DarkMode {
-                                    ICON_SUN
-                                } else {
-                                    ICON_MOON
-                                }
+                            Environment::app_theme.map(|mode| match mode {
+                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
+                                AppTheme::BuiltIn(theme) => match theme {
+                                    ThemeMode::DarkMode => ICON_SUN,
+                                    ThemeMode::LightMode => ICON_MOON,
+                                },
                             }),
                         )
                         .class("icon")

--- a/examples/views/helpers/mod.rs
+++ b/examples/views/helpers/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use vizia::{
-    icons::{ICON_MOON, ICON_SETTINGS_AUTOMATION, ICON_SUN},
+    icons::{ICON_MOON, ICON_SUN},
     prelude::*,
 };
 
@@ -72,12 +72,9 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::app_theme.map(|mode| match mode {
-                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
-                                AppTheme::BuiltIn(theme) => match theme {
-                                    ThemeMode::DarkMode => ICON_SUN,
-                                    ThemeMode::LightMode => ICON_MOON,
-                                },
+                            Environment::theme.map(|theme| match theme.get_current_theme() {
+                                ThemeMode::DarkMode => ICON_SUN,
+                                ThemeMode::LightMode => ICON_MOON,
                             }),
                         )
                         .class("icon")
@@ -133,12 +130,9 @@ impl ExamplePage {
                     |cx| {
                         Label::new(
                             cx,
-                            Environment::app_theme.map(|mode| match mode {
-                                AppTheme::System => ICON_SETTINGS_AUTOMATION,
-                                AppTheme::BuiltIn(theme) => match theme {
-                                    ThemeMode::DarkMode => ICON_SUN,
-                                    ThemeMode::LightMode => ICON_MOON,
-                                },
+                            Environment::theme.map(|theme| match theme.get_current_theme() {
+                                ThemeMode::DarkMode => ICON_SUN,
+                                ThemeMode::LightMode => ICON_MOON,
                             }),
                         )
                         .class("icon")


### PR DESCRIPTION
## Added a new event named `ThemeChanged` to `WindowEvent`
This event will get emitted when current system theme changed.
I also added a new example to showcase this new event.
currently this new event is only supported with winit backend (Im not sure if baseview support such a thing).

### todo
- [x] add a new method to vizia to receive current system theme.