### PR TITLE
Baseview mouse event fix

### DIFF
--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -12,7 +12,7 @@ vizia_core = { path = "../vizia_core" }
 vizia_input = { path = "../vizia_input" }
 vizia_id = { path = "../vizia_id" }
 
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "c129b12ead4f5ac02126f559ceb8ce43cc982200", features = ["opengl"] }
-raw-window-handle = "0.4.2"
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "f0639b787bbda506434d3f6b5c91e94ca59904c6", features = ["opengl"] }
+raw-window-handle = "0.5.2"
 femtovg = "0.7.0"
 lazy_static = "1.4.0"

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -213,7 +213,6 @@ impl ApplicationRunner {
         while let Some(event) = queue_get() {
             cx.send_event(event);
         }
-
         // Events
         cx.process_events();
 

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -247,7 +247,7 @@ impl ApplicationRunner {
         }
 
         // Force restyle on every frame for baseview backend to avoid style inheritance issues
-        cx.style().needs_restyle();
+        // cx.style().needs_restyle();
         cx.process_data_updates();
 
         let context = window.gl_context().expect("Window was created without OpenGL support");
@@ -343,6 +343,15 @@ impl ApplicationRunner {
 
                     cx.emit_origin(WindowEvent::MouseScroll(lines_x, lines_y));
                 }
+
+                baseview::MouseEvent::CursorEntered => {
+                    cx.emit_origin(WindowEvent::MouseEnter);
+                }
+
+                baseview::MouseEvent::CursorLeft => {
+                    cx.emit_origin(WindowEvent::MouseLeave);
+                }
+
                 _ => {}
             },
             baseview::Event::Keyboard(event) => {

--- a/crates/vizia_baseview/src/parent_window.rs
+++ b/crates/vizia_baseview/src/parent_window.rs
@@ -17,9 +17,9 @@ unsafe impl HasRawWindowHandle for ParentWindow {
 #[cfg(target_os = "windows")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::Win32Handle;
+        use raw_window_handle::Win32WindowHandle;
 
-        let mut handle = Win32Handle::empty();
+        let mut handle = Win32WindowHandle::empty();
         handle.hwnd = self.0;
 
         RawWindowHandle::Win32(handle)
@@ -29,9 +29,9 @@ unsafe impl HasRawWindowHandle for ParentWindow {
 #[cfg(target_os = "linux")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::XcbHandle;
+        use raw_window_handle::XcbWindowHandle;
 
-        let mut handle = XcbHandle::empty();
+        let mut handle = XcbWindowHandle::empty();
         handle.window = self.0 as u32;
 
         RawWindowHandle::Xcb(handle)

--- a/crates/vizia_baseview/src/parent_window.rs
+++ b/crates/vizia_baseview/src/parent_window.rs
@@ -5,9 +5,9 @@ pub struct ParentWindow(pub *mut ::std::ffi::c_void);
 #[cfg(target_os = "macos")]
 unsafe impl HasRawWindowHandle for ParentWindow {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        use raw_window_handle::AppKitHandle;
+        use raw_window_handle::AppKitWindowHandle;
 
-        let mut handle = AppKitHandle::empty();
+        let mut handle = AppKitWindowHandle::empty();
         handle.ns_view = self.0;
 
         RawWindowHandle::AppKit(handle)

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -949,7 +949,7 @@ impl<'a> EventContext<'a> {
         self.style.live.insert(self.current, live);
     }
 
-    /// Sets the view, by id name, which labels the current view for accessibility.  
+    /// Sets the view, by id name, which labels the current view for accessibility.
     pub fn labelled_by(&mut self, id: &str) {
         if let Some(entity) = self.resolve_entity_identifier(id) {
             self.style.labelled_by.insert(self.current, entity);
@@ -1119,7 +1119,7 @@ impl<'a> EventContext<'a> {
     /// `duration` - An optional duration for the timer. Pass `None` for a continuos timer.
     /// `callback` - A callback which is called on when the timer is started, ticks, and stops. Disambiguated by the `TimerAction` parameter of the callback.
     ///
-    /// Returns a `Timer` id which can be used to start and stop the timer.  
+    /// Returns a `Timer` id which can be used to start and stop the timer.
     ///
     /// # Example
     /// Creates a timer which calls the provided callback every second for 5 seconds:
@@ -1132,7 +1132,7 @@ impl<'a> EventContext<'a> {
     ///         TimerAction::Start => {
     ///             println!("Start timer");
     ///         }
-    ///     
+    ///
     ///         TimerAction::Tick(delta) => {
     ///             println!("Tick timer: {:?}", delta);
     ///         }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -576,7 +576,7 @@ impl Context {
     /// `duration` - An optional duration for the timer. Pass `None` for a continuos timer.
     /// `callback` - A callback which is called on when the timer is started, ticks, and stops. Disambiguated by the `TimerAction` parameter of the callback.
     ///
-    /// Returns a `Timer` id which can be used to start and stop the timer.  
+    /// Returns a `Timer` id which can be used to start and stop the timer.
     ///
     /// # Example
     /// Creates a timer which calls the provided callback every second for 5 seconds:
@@ -589,7 +589,7 @@ impl Context {
     ///         TimerAction::Start => {
     ///             println!("Start timer");
     ///         }
-    ///     
+    ///
     ///         TimerAction::Tick(delta) => {
     ///             println!("Tick timer: {:?}", delta);
     ///         }
@@ -889,7 +889,7 @@ pub trait EmitContext {
     /// # use instant::{Instant, Duration};
     /// # let cx = &mut Context::default();
     /// # enum AppEvent {Increment}
-    /// cx.schedule_emit_custom(    
+    /// cx.schedule_emit_custom(
     ///     Event::new(AppEvent::Increment)
     ///         .target(Entity::root())
     ///         .origin(cx.current())

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -206,7 +206,7 @@ impl PartialEq<Self> for TimedEvent {
 impl Eq for TimedEvent {}
 impl PartialOrd for TimedEvent {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.time.partial_cmp(&other.time).map(|ord| ord.reverse())
+        Some(self.cmp(other))
     }
 }
 impl Ord for TimedEvent {

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -187,6 +187,11 @@ fn internal_state_updates(context: &mut Context, window_event: &WindowEvent, met
             context.drop_data = Some(drop_data.clone());
         }
 
+        WindowEvent::InterfaceMoved => {
+            hover_system(context);
+            mutate_direct_or_up(meta, context.captured, context.hovered, false);
+        }
+
         WindowEvent::MouseMove(x, y) => {
             context.mouse.previous_cursorx = context.mouse.cursorx;
             context.mouse.previous_cursory = context.mouse.cursory;

--- a/crates/vizia_core/src/events/timer.rs
+++ b/crates/vizia_core/src/events/timer.rs
@@ -62,7 +62,7 @@ impl Eq for TimerState {}
 
 impl PartialOrd for TimerState {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.time.partial_cmp(&other.time).map(|ord| ord.reverse())
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -137,10 +137,10 @@ pub(crate) fn layout_system(cx: &mut Context) {
             }
         }
 
-        // A relayout, retransform, or reclip, can cause the element under the cursor to change. So we push a mouse move event here to force
+        // A relayout, retransform, or reclip, can cause the element under the cursor to change. So we push an event here to force
         // a new event cycle and the hover system to trigger.
         if let Some(proxy) = &cx.event_proxy {
-            let event = Event::new(WindowEvent::MouseMove(cx.mouse.cursorx, cx.mouse.cursory))
+            let event = Event::new(WindowEvent::InterfaceMoved)
                 .target(Entity::root())
                 .origin(Entity::root())
                 .propagate(Propagation::Up);

--- a/crates/vizia_core/src/window/window_event.rs
+++ b/crates/vizia_core/src/window/window_event.rs
@@ -49,6 +49,8 @@ pub enum WindowEvent {
     },
     /// Emitted when the mouse cursor is moved
     MouseMove(f32, f32),
+    /// Emitted when relayout has been performed & interface elements under the cursor may have moved.
+    InterfaceMoved,
     /// Emitted when the mouse scroll wheel is scrolled.
     MouseScroll(f32, f32),
     /// Emitted when the mouse cursor enters the bounding box of an entity.


### PR DESCRIPTION
Possible fix for #422 

Prevents this sequence of events:

1. Frame update calls layout system
2. Baseview sends mousemove & layout system sends a mousemove
3. Frame update processes baseview mousemove, & then processes layout mousemove overwriting the real cursor position
4. Frame update then calls layout which re-sends the stale cursor value for the next frame update
5. Repeat from 3 for the duration of the gesture triggering relayout, or until relayout is not performed on a frame

An alternative fix may be to prevent such frequent layout, or to investigate what is different in winit feature that prevents this, but I think the mousemoved event that was being sent here was sort of a band-aid in the first place?