### PR TITLE
Update Baseview

### DIFF
--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -12,7 +12,7 @@ vizia_core = { path = "../vizia_core" }
 vizia_input = { path = "../vizia_input" }
 vizia_id = { path = "../vizia_id" }
 
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "f0639b787bbda506434d3f6b5c91e94ca59904c6", features = ["opengl"] }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4", features = ["opengl"] }
 raw-window-handle = "0.5.2"
 femtovg = "0.7.0"
 lazy_static = "1.4.0"

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -123,23 +123,6 @@ where
         )
     }
 
-    /// Open a new window as if it had a parent window.
-    ///
-    /// This function does **not** block the current thread. This is only to be
-    /// used in the context of audio plugins.
-    ///
-    /// * `app` - The Vizia application builder.
-    pub fn open_as_if_parented(self) -> WindowHandle {
-        ViziaWindow::open_as_if_parented(
-            self.window_description,
-            self.window_scale_policy,
-            self.app,
-            self.on_idle,
-            self.ignore_default_theme,
-            self.text_config,
-        )
-    }
-
     /// Takes a closure which will be called at the end of every loop of the application.
     ///
     /// The callback provides a place to run 'idle' processing and happens at the end of each loop but before drawing.

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -113,55 +113,6 @@ impl ViziaWindow {
         )
     }
 
-    /// Open a new window as if it had a parent window.
-    ///
-    /// * `app` - The Vizia application builder.
-    pub fn open_as_if_parented<F>(
-        win_desc: WindowDescription,
-        scale_policy: WindowScalePolicy,
-        app: F,
-        on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
-        ignore_default_theme: bool,
-        text_config: TextConfig,
-    ) -> WindowHandle
-    where
-        F: Fn(&mut Context),
-        F: 'static + Send,
-    {
-        let window_settings = WindowOpenOptions {
-            title: win_desc.title.clone(),
-            size: baseview::Size::new(
-                win_desc.inner_size.width as f64 * win_desc.user_scale_factor,
-                win_desc.inner_size.height as f64 * win_desc.user_scale_factor,
-            ),
-            scale: scale_policy,
-            gl_config: Some(GlConfig { vsync: false, ..GlConfig::default() }),
-        };
-
-        Window::open_as_if_parented(
-            window_settings,
-            move |window: &mut baseview::Window<'_>| -> ViziaWindow {
-                let mut context = Context::new(win_desc.inner_size, win_desc.user_scale_factor);
-
-                context.ignore_default_theme = ignore_default_theme;
-                context.remove_user_themes();
-
-                let mut cx = BackendContext::new(&mut context);
-                cx.set_text_config(text_config);
-
-                cx.set_event_proxy(Box::new(BaseviewProxy()));
-                ViziaWindow::new(
-                    context,
-                    win_desc,
-                    scale_policy,
-                    window,
-                    Some(Box::new(app)),
-                    on_idle,
-                )
-            },
-        )
-    }
-
     /// Open a new window that blocks the current thread until the window is destroyed.
     ///
     /// * `app` - The Vizia application builder.


### PR DESCRIPTION
Update to the latest version of Baseview. Includes some important fixes for window lifetime management on macOS and removes the `Window::open_as_if_parented` API.