### PR TITLE
Avoid accidentally changing the logical size when changing user scale due to rounding errors

### DIFF
--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -149,7 +149,8 @@ impl<'a> BackendContext<'a> {
         self.0.text_config = text_config;
     }
 
-    /// Sets the scale factor used by the application.
+    /// Sets the scale factor used by the application. Includes both the user scaling and the system
+    /// DPI scaling.
     pub fn set_scale_factor(&mut self, scale: f64) {
         self.0.style.dpi_factor = scale;
     }


### PR DESCRIPTION
This happened due to rounding errors in the conversion to and from integers. We can detect this by doing the same computation, and treating the resize as a noop if it does happen. This prevents the logical size from slowly drifting when changing the user scale many times in a row.