### PR TITLE
Replace `std::collections::HashSet` with `hashbrown::HashSet`

### DIFF
--- a/crates/vizia_core/src/animation/animation_state.rs
+++ b/crates/vizia_core/src/animation/animation_state.rs
@@ -1,6 +1,6 @@
 use crate::animation::Interpolator;
+use hashbrown::HashSet;
 use instant::{Duration, Instant};
-use std::collections::HashSet;
 use vizia_id::GenerationalId;
 
 use crate::prelude::*;

--- a/crates/vizia_core/src/binding/binding_view.rs
+++ b/crates/vizia_core/src/binding/binding_view.rs
@@ -1,6 +1,5 @@
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use std::any::TypeId;
-use std::collections::HashSet;
 
 use crate::binding::{get_storeid, BasicStore, Store, StoreId};
 use crate::context::{CURRENT, MAPS, MAP_MANAGER};

--- a/crates/vizia_core/src/binding/store.rs
+++ b/crates/vizia_core/src/binding/store.rs
@@ -1,6 +1,6 @@
+use hashbrown::{hash_map::DefaultHashBuilder, HashSet};
 use std::any::TypeId;
-use std::collections::{hash_map::DefaultHasher, HashSet};
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 use crate::{model::ModelOrView, prelude::*};
 
@@ -8,7 +8,7 @@ use crate::{model::ModelOrView, prelude::*};
 pub struct StoreId(pub u64);
 
 pub(crate) fn get_storeid<T: 'static + Hash>(t: &T) -> StoreId {
-    let mut s = DefaultHasher::new();
+    let mut s = DefaultHashBuilder::default().build_hasher();
     TypeId::of::<T>().hash(&mut s);
     t.hash(&mut s);
     StoreId(s.finish())

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1,11 +1,11 @@
 use std::any::{Any, TypeId};
-use std::collections::{BinaryHeap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, VecDeque};
 #[cfg(feature = "clipboard")]
 use std::error::Error;
 use std::rc::Rc;
 
 use femtovg::Transform2D;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use instant::{Duration, Instant};
 use vizia_storage::{LayoutTreeIterator, TreeIterator};
 use vizia_style::{ClipPath, Filter, Scale, Translate};

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -12,8 +12,7 @@ use instant::{Duration, Instant};
 use log::debug;
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
-use std::collections::{BinaryHeap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, VecDeque};
 use std::rc::Rc;
 use std::sync::Mutex;
 use vizia_id::IdManager;
@@ -23,7 +22,7 @@ use copypasta::ClipboardContext;
 #[cfg(feature = "clipboard")]
 use copypasta::{nop_clipboard::NopClipboardContext, ClipboardProvider};
 use cosmic_text::{fontdb::Database, FamilyOwned};
-use hashbrown::HashMap;
+use hashbrown::{hash_map::Entry, HashMap, HashSet};
 
 use unic_langid::LanguageIdentifier;
 

--- a/crates/vizia_core/src/context/resource.rs
+++ b/crates/vizia_core/src/context/resource.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, HashSet};
+use hashbrown::{hash_map::Entry, HashSet};
 
 use vizia_storage::Tree;
 

--- a/crates/vizia_core/src/resource.rs
+++ b/crates/vizia_core/src/resource.rs
@@ -5,9 +5,9 @@ use crate::entity::Entity;
 use crate::prelude::IntoCssStr;
 use crate::view::Canvas;
 use fluent_bundle::{FluentBundle, FluentResource};
+use hashbrown::{HashMap, HashSet};
 use image::GenericImageView;
 use std::borrow::Borrow;
-use std::collections::{HashMap, HashSet};
 use unic_langid::LanguageIdentifier;
 
 pub(crate) struct StoredImage {

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -60,12 +60,11 @@
 //! Element::new(cx).class("foo");
 //! ```
 
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
 use instant::{Duration, Instant};
 use log::warn;
 use morphorm::{LayoutType, PositionType, Units};
-use std::collections::HashSet;
 use std::fmt::Debug;
 use vizia_id::GenerationalId;
 

--- a/crates/vizia_core/src/systems/binding.rs
+++ b/crates/vizia_core/src/systems/binding.rs
@@ -1,8 +1,6 @@
 use crate::{binding::StoreId, model::ModelOrView, prelude::*};
-use std::{
-    any::TypeId,
-    collections::{HashMap, HashSet},
-};
+use hashbrown::{HashMap, HashSet};
+use std::any::TypeId;
 
 pub(crate) fn binding_system(cx: &mut Context) {
     let mut observers: HashMap<Entity, (Entity, Option<TypeId>, StoreId)> = HashMap::new();

--- a/crates/vizia_core/src/systems/image.rs
+++ b/crates/vizia_core/src/systems/image.rs
@@ -2,7 +2,7 @@ use crate::context::{Context, ResourceContext};
 use crate::resource::{ImageRetentionPolicy, StoredImage};
 use crate::style::ImageOrGradient;
 use crate::{prelude::*, resource::ImageOrId};
-use std::collections::HashSet;
+use hashbrown::HashSet;
 use vizia_id::GenerationalId;
 
 // Iterate the tree and load any images used by entities which aren't already loaded. Remove any images no longer being used.


### PR DESCRIPTION
Previously (208ec91dee8f51bca76fde6e335ccbf9cc1d4f33) replaced `HashMap` occurrences, this commit extends that to cover `HashSet` as well.