### PR TITLE
More VirtualList performance improvements and fixes.

### DIFF
--- a/crates/vizia_core/src/views/virtual_list.rs
+++ b/crates/vizia_core/src/views/virtual_list.rs
@@ -5,10 +5,9 @@ use crate::prelude::*;
 #[derive(Lens)]
 pub struct VirtualList {
     num_items: usize,
-    item_offset: usize,
     item_height: f32,
-    visible_items: Vec<usize>,
-    scrolly: f32,
+    visible_range: Range<usize>,
+    scroll_y: f32,
     scroll_to_cursor: bool,
     on_change: Option<Box<dyn Fn(&mut EventContext, Range<usize>)>>,
 }
@@ -28,12 +27,12 @@ impl VirtualList {
     where
         <L as Lens>::Target: Deref<Target = [T]>,
     {
+        let num_items = list.map(|list| list.len());
         Self {
-            num_items: 0,
-            item_offset: 0,
+            num_items: num_items.get(cx),
             item_height,
-            visible_items: Vec::new(),
-            scrolly: 0.0,
+            visible_range: 0..0,
+            scroll_y: 0.0,
             scroll_to_cursor: true,
             on_change: None,
         }
@@ -44,13 +43,13 @@ impl VirtualList {
                 VStack::new(cx, |cx| {
                     // Within the VStack we create a view for each visible item.
                     // This binding ensures the amount of views stay up to date.
-                    let num_visible_items = Self::visible_items.map(Vec::len);
+                    let num_visible_items = Self::visible_range.map(Range::len);
                     Binding::new(cx, num_visible_items, move |cx, lens| {
                         for i in 0..lens.get(cx) {
-                            // Each visible item is an index into the backing list.
-                            // As we scroll the index my change, representing an item going in/out of visibility.
-                            // Wrap `item_content`` in a binding to the index so it only rebuilds when necessary.
-                            let item_index = Self::visible_items.index(i);
+                            // Each item of the range maps to an index into the backing list.
+                            // As we scroll the index may change, representing an item going in/out of visibility.
+                            // Wrap `item_content` in a binding to said index, so it rebuilds only when necessary.
+                            let item_index = Self::visible_item_index(i);
                             HStack::new(cx, move |cx| {
                                 Binding::new(cx, item_index, move |cx, lens| {
                                     let index = lens.get(cx);
@@ -61,13 +60,13 @@ impl VirtualList {
                             .height(Pixels(item_height))
                             .position_type(PositionType::SelfDirected)
                             .bind(item_index, move |handle, lens| {
-                                let item_index = lens.get(&handle);
-                                handle.top(Pixels(item_index as f32 * item_height));
+                                let index = lens.get(&handle);
+                                handle.top(Pixels(index as f32 * item_height));
                             });
                         }
                     });
                 })
-                .bind(list.map(|list| list.len()), move |handle, lens| {
+                .bind(num_items, move |handle, lens| {
                     let num_items = lens.get(&handle);
                     handle
                         .height(Pixels(num_items as f32 * item_height))
@@ -75,64 +74,55 @@ impl VirtualList {
                         .emit(VirtualListEvent::SetNumItems(num_items));
                 });
             })
+            .scroll_to_cursor(true)
             .on_scroll(|cx, _, y| {
                 cx.emit(VirtualListEvent::SetScrollY(y));
             });
         })
     }
 
-    fn visible_range(&self) -> Range<usize> {
-        let mut min = self.num_items;
-        let mut max = 0;
-        for item in &self.visible_items {
-            min = min.min(*item);
-            max = max.max(*item);
+    fn evaluate_index(index: usize, start: usize, end: usize) -> usize {
+        match end - start {
+            0 => 0,
+            len => start + (len - (start % len) + index) % len,
         }
-        min..max
+    }
+
+    fn visible_item_index(index: usize) -> impl Lens<Target = usize> {
+        Self::visible_range.map(move |range| Self::evaluate_index(index, range.start, range.end))
     }
 
     fn recalc(&mut self, cx: &mut EventContext) {
-        let current = cx.current();
-        let dpi = cx.scale_factor();
-        let visible_height = cx.cache.get_height(current) / dpi;
-
-        let item_height = self.item_height;
-        let total_height = item_height * self.num_items as f32;
-
-        let mut num_visible_items = (visible_height / item_height).ceil() as usize;
-        num_visible_items += 1; // Plus one to support partially visible end-items.
-
-        let offsety = ((total_height - visible_height) * self.scrolly).round() * dpi;
-        self.item_offset = (offsety / item_height / dpi).ceil() as usize;
-        self.item_offset = self.item_offset.saturating_sub(1);
-
-        let mut min = self.item_offset;
-        let mut max = (self.item_offset + num_visible_items).clamp(0, self.num_items);
-
-        if self.visible_items.len() != num_visible_items {
-            self.visible_items.clear();
-            self.visible_items.extend(min..max);
+        if self.num_items == 0 {
+            self.visible_range = 0..0;
             return;
         }
 
-        for item in &mut self.visible_items {
-            match *item {
-                // If the front item has fallen off, swap in a new item from the back.
-                i if (i < min) && (i < max) => {
-                    max -= 1;
-                    *item = max;
-                }
-                // If the back item has fallen off, swap in a new item from the front.
-                i if (i >= min) && (i >= max) => {
-                    *item = min;
-                    min += 1;
-                }
-                _ => {}
-            }
-        }
+        let current = cx.current();
+        let scale_factor = cx.scale_factor();
+        let visible_height = cx.cache.get_height(current) / scale_factor;
+
+        let item_height = self.item_height;
+        let total_height = item_height * (self.num_items as f32);
+
+        let mut num_visible_items = (visible_height / item_height).ceil();
+        num_visible_items += 1.0; // To account for partially-visible items.
+
+        let visible_items_height = item_height * num_visible_items;
+        let empty_height = (total_height - visible_items_height).max(0.0);
+
+        // The pixel offsets within the container to the visible area.
+        let visible_start = empty_height * (self.scroll_y / scale_factor);
+        let visible_end = visible_start + visible_items_height;
+
+        // The indices of the first and last item of the visible area.
+        let start_index = (visible_start / item_height).trunc() as usize;
+        let end_index = 1 + (visible_end / item_height).trunc() as usize;
+
+        self.visible_range = start_index..end_index.min(self.num_items);
 
         if let Some(callback) = &self.on_change {
-            (callback)(cx, self.visible_range())
+            (callback)(cx, self.visible_range.clone())
         }
     }
 }
@@ -158,21 +148,19 @@ impl View for VirtualList {
                 }
             }
 
-            VirtualListEvent::SetScrollY(scrolly) => {
-                self.scrolly = *scrolly;
+            VirtualListEvent::SetScrollY(scroll_y) => {
+                self.scroll_y = *scroll_y;
                 self.recalc(cx);
 
                 if let Some(callback) = &self.on_change {
-                    (callback)(cx, self.visible_range())
+                    (callback)(cx, self.visible_range.clone())
                 }
             }
         });
 
         event.map(|window_event, _| match window_event {
             WindowEvent::GeometryChanged(geo) => {
-                if geo.contains(GeoChanged::WIDTH_CHANGED)
-                    || geo.contains(GeoChanged::HEIGHT_CHANGED)
-                {
+                if geo.intersects(GeoChanged::WIDTH_CHANGED | GeoChanged::HEIGHT_CHANGED) {
                     self.recalc(cx);
                 }
             }
@@ -191,5 +179,40 @@ impl<'a> Handle<'a, VirtualList> {
 
     pub fn on_change(self, callback: impl Fn(&mut EventContext, Range<usize>) + 'static) -> Self {
         self.modify(|virtual_list| virtual_list.on_change = Some(Box::new(callback)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn evaluate_indices(range: Range<usize>) -> Vec<usize> {
+        (0..range.len())
+            .map(|index| VirtualList::evaluate_index(index, range.start, range.end))
+            .collect()
+    }
+
+    #[test]
+    fn test_evaluate_index() {
+        // Move forward by 0
+        assert_eq!(evaluate_indices(0..4), [0, 1, 2, 3]);
+        // Move forward by 1
+        assert_eq!(evaluate_indices(1..5), [4, 1, 2, 3]);
+        // Move forward by 2
+        assert_eq!(evaluate_indices(2..6), [4, 5, 2, 3]);
+        // Move forward by 3
+        assert_eq!(evaluate_indices(3..7), [4, 5, 6, 3]);
+        // Move forward by 4
+        assert_eq!(evaluate_indices(4..8), [4, 5, 6, 7]);
+        // Move forward by 5
+        assert_eq!(evaluate_indices(5..9), [8, 5, 6, 7]);
+        // Move forward by 6
+        assert_eq!(evaluate_indices(6..10), [8, 9, 6, 7]);
+        // Move forward by 7
+        assert_eq!(evaluate_indices(7..11), [8, 9, 10, 7]);
+        // Move forward by 8
+        assert_eq!(evaluate_indices(8..12), [8, 9, 10, 11]);
+        // Move forward by 9
+        assert_eq!(evaluate_indices(9..13), [12, 9, 10, 11]);
     }
 }


### PR DESCRIPTION
Follow up and fixes to #451

1. Fixes a panic that was caused by the `num_items` field not being initialized in the `new` method.

2. Restores `.scroll_to_cursor(true)` that accidentally got left out. Hopefully this changes to shift+click instead when the "standardized" scroll behavior is implemented.

3. Implements the additional performance improvements theorized in the previous PR comments. Now the `VirtualList` does not store any additional list of items all, and only holds a `visible_range: Range<usize>`. In addition to the memory savings, all related methods are now constant-time and non-allocating. The `on_change` callback is now free as well, though maybe it's less necessary as we can bind to `VirtualList::visible_range` directly.

4. Added tests so further tweaks are less likely to break the stable indexing logic.

5. Renamed a few variables to be consistent with `ScrollView` naming conventions.
