### PR TITLE
accesskit: Disable default features

### DIFF
--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -21,7 +21,7 @@ vizia_id = { path = "../vizia_id" }
 vizia_input = { path = "../vizia_input" }
 vizia_window = { path = "../vizia_window" }
 vizia_style = { path = "../vizia_style"}
-accesskit = "0.11.0"
+accesskit = { version = "0.11.0", default-features = false }
 
 femtovg = "0.7.0"
 image = { version = "0.24.6", default-features = false, features = ["png"] } # inherited from femtovg

--- a/crates/vizia_window/Cargo.toml
+++ b/crates/vizia_window/Cargo.toml
@@ -13,5 +13,5 @@ vizia_input = { path = "../vizia_input" }
 vizia_style = { path = "../vizia_style" }
 # morphorm = {path = "../../../morphorm" }
 morphorm = "0.6.4"
-accesskit = "0.11.0"
+accesskit = { version = "0.11.0", default-features = false }
 #morphorm = { path = "../../../morphorm", features = ["rounding"] }

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -19,14 +19,14 @@ vizia_core = { path = "../vizia_core" }
 vizia_id = { path = "../vizia_id" }
 vizia_window = { path = "../vizia_window" }
 
-accesskit = "0.11.0"
+accesskit = { version = "0.11.0", default-features = false }
 winit = { version = "0.28.6", default-features = false }
 femtovg = "0.7.0"
 glutin = { version = "0.30.8", default-features = false, optional = true }
 copypasta = {version = "0.8.2", optional = true, default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-accesskit_winit = "0.14.0"
+accesskit_winit = { version = "0.14.0", default-features = false }
 glutin = { version = "0.30.8", default-features = false }
 femtovg = "0.7.0"
 glutin-winit = { version = "0.3.0", default-features = false, features = ["egl", "glx", "wgl"] }


### PR DESCRIPTION
The default feature "async-io" conflicts with applications that use the Tokio runtime.

Example: Adding `rfd` as a dependency with features "tokio" and "xdg-portal" causes a panic on startup.