### PR TITLE
Add deps.rs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
       alt="CI status" />
   </a>
   <!-- docs (TODO) -->
+  <!-- Dependency status -->
+  <a href="https://deps.rs/repo/github/vizia/vizia">
+    <img src="https://deps.rs/repo/github/vizia/vizia/status.svg"
+      alt="Dependency status" />
+  </a>
   <!-- Audit -->
   <a href="https://github.com/vizia/vizia/actions/workflows/audit.yml">
     <img src="https://github.com/vizia/vizia/actions/workflows/audit.yml/badge.svg"


### PR DESCRIPTION
I have noticed that many dependencies are outdated. Upgrading them requires migrating existing code. Relying on unmaintained versions is not an option.

This PR adds a [deps.rs](https://deps.rs/repo/github/vizia/vizia) badge to the README to show the current status.