### PR TITLE
Set input focus on alt-click

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -292,6 +292,13 @@ impl ApplicationRunner {
                 baseview::MouseEvent::ButtonPressed { button, modifiers } => {
                     update_modifiers(modifiers);
 
+                    // give input focus to the view on alt-click
+                    if modifiers == vizia_input::KeyboardModifiers::ALT {
+                        if !window.has_input_focus() {
+                            window.set_input_focus();
+                        };
+                    };
+
                     let b = translate_mouse_button(button);
                     cx.emit_origin(WindowEvent::MouseDown(b));
                 }

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -175,10 +175,10 @@ impl WindowHandler for ViziaWindow {
         unsafe { context.make_not_current() };
     }
 
-    fn on_event(&mut self, _window: &mut Window<'_>, event: Event) -> EventStatus {
+    fn on_event(&mut self, window: &mut Window<'_>, event: Event) -> EventStatus {
         let mut should_quit = false;
-        self.application.handle_event(event, &mut should_quit);
 
+        self.application.handle_event(event, &mut should_quit, window);
         self.application.handle_idle(&self.on_idle);
 
         if should_quit {


### PR DESCRIPTION
I have submitted a PR for the input focus issue (https://github.com/RustAudio/baseview/pull/170). Assuming it is accepted and merged in `baseview` these are the changes required on `vizia_baseview`.

I have opted for the least intrusive call on alt-click but I wonder if there are other views that would need it. Let me know what you think.

I have tested this as mentioned in the PR comments.