### PR TITLE
Removed the `MouseEnter` and `MouseLeave` temporary fix and fixed all clippy warnings

### DIFF
--- a/crates/vizia_core/src/storage/animatable_set.rs
+++ b/crates/vizia_core/src/storage/animatable_set.rs
@@ -738,9 +738,9 @@ mod tests {
     #[test]
     fn is_inline() {
         let data_index1 = DataIndex::inline(5);
-        assert_eq!(data_index1.is_inline(), true);
+        assert!(data_index1.is_inline());
         let data_index2 = DataIndex::shared(5);
-        assert_eq!(data_index2.is_inline(), false);
+        assert!(!data_index2.is_inline());
     }
 
     /// Test that a null data index is the correct value #7FFFFFFF (i.e. all bits = 1 except the first bit).
@@ -756,10 +756,10 @@ mod tests {
     #[test]
     fn new() {
         let animatable_storage = AnimatableSet::<f32>::default();
-        assert_eq!(animatable_storage.inline_data.is_empty(), true);
-        assert_eq!(animatable_storage.shared_data.is_empty(), true);
-        assert_eq!(animatable_storage.animations.is_empty(), true);
-        assert_eq!(animatable_storage.active_animations.is_empty(), true);
+        assert!(animatable_storage.inline_data.is_empty());
+        assert!(animatable_storage.shared_data.is_empty());
+        assert!(animatable_storage.animations.is_empty());
+        assert!(animatable_storage.active_animations.is_empty());
     }
 
     /// Test inserting inline data into the storage.

--- a/crates/vizia_core/src/storage/style_set.rs
+++ b/crates/vizia_core/src/storage/style_set.rs
@@ -400,9 +400,9 @@ mod tests {
     #[test]
     fn is_inline() {
         let data_index1 = DataIndex::inline(5);
-        assert_eq!(data_index1.is_inline(), true);
+        assert!(data_index1.is_inline());
         let data_index2 = DataIndex::shared(5);
-        assert_eq!(data_index2.is_inline(), false);
+        assert!(!data_index2.is_inline());
     }
 
     /// Test that a null data index is the correct value #7FFFFFFF (i.e. all bits = 1 except the first bit).
@@ -418,8 +418,8 @@ mod tests {
     #[test]
     fn new() {
         let animatable_storage = StyleSet::<f32>::new();
-        assert_eq!(animatable_storage.inline_data.is_empty(), true);
-        assert_eq!(animatable_storage.shared_data.is_empty(), true);
+        assert!(animatable_storage.inline_data.is_empty());
+        assert!(animatable_storage.shared_data.is_empty());
     }
 
     /// Test inserting inline data into the storage.

--- a/crates/vizia_id/src/id_manager.rs
+++ b/crates/vizia_id/src/id_manager.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn new() {
         let id_manager = IdManager::<Entity>::new();
-        assert_eq!(id_manager.generation.is_empty(), true);
-        assert_eq!(id_manager.free_list.is_empty(), true);
+        assert!(id_manager.generation.is_empty());
+        assert!(id_manager.free_list.is_empty());
     }
 
     /// Test for creating a new id.
@@ -133,7 +133,7 @@ mod tests {
         let mut id_manager = IdManager::<Entity>::new();
         let id = id_manager.create();
         let success = id_manager.destroy(id);
-        assert_eq!(success, true);
+        assert!(success);
         assert_eq!(id_manager.generation[id.index()], 1);
         assert_eq!(*id_manager.free_list.front().unwrap(), id.index() as u64);
     }
@@ -154,7 +154,7 @@ mod tests {
         id_manager.destroy(id);
 
         let success = id_manager.destroy(id);
-        assert_eq!(success, false);
+        assert!(!success);
     }
 
     /// Test for reusing an id.
@@ -180,9 +180,9 @@ mod tests {
         let mut id_manager = IdManager::<Entity>::new();
         let id = id_manager.create();
         let alive1 = id_manager.is_alive(id);
-        assert_eq!(alive1, true);
+        assert!(alive1);
         id_manager.destroy(id);
         let alive2 = id_manager.is_alive(id);
-        assert_eq!(alive2, false);
+        assert!(!alive2);
     }
 }

--- a/crates/vizia_storage/src/tree/iter/layout_child_iter.rs
+++ b/crates/vizia_storage/src/tree/iter/layout_child_iter.rs
@@ -102,12 +102,12 @@ mod test {
         tree.set_ignored(b, true);
         tree.set_ignored(ba, true);
 
-        let iter = LayoutChildIterator::new(&mut tree, Entity::root());
+        let iter = LayoutChildIterator::new(&tree, Entity::root());
         let mut ground = vec![a, baa, bb, c];
         let vec: Vec<Entity> = iter.collect();
         assert_eq!(vec, ground);
 
-        let iter = LayoutChildIterator::new(&mut tree, Entity::root()).rev();
+        let iter = LayoutChildIterator::new(&tree, Entity::root()).rev();
         ground.reverse();
         let vec: Vec<Entity> = iter.collect();
         assert_eq!(vec, ground);

--- a/crates/vizia_style/selectors/bloom.rs
+++ b/crates/vizia_style/selectors/bloom.rs
@@ -274,7 +274,7 @@ fn hash2(hash: u32) -> u32 {
 fn create_and_insert_some_stuff() {
     use fxhash::FxHasher;
     use std::hash::{Hash, Hasher};
-    use std::mem::transmute;
+    use std::mem::size_of;
 
     fn hash_as_str(i: usize) -> u32 {
         let mut hasher = FxHasher::default();
@@ -286,11 +286,9 @@ fn create_and_insert_some_stuff() {
 
     let mut bf = BloomFilter::new();
 
-    // Statically assert that ARRAY_SIZE is a multiple of 8, which
+    // Assert that ARRAY_SIZE is a multiple of 8, which
     // BloomStorageBool relies on.
-    unsafe {
-        transmute::<[u8; ARRAY_SIZE % 8], [u8; 0]>([]);
-    }
+    assert_eq!(size_of::<[u8; ARRAY_SIZE % 8]>(), size_of::<[u8; 0]>());
 
     for i in 0_usize..1000 {
         bf.insert_hash(hash_as_str(i));

--- a/crates/vizia_style/selectors/parser.rs
+++ b/crates/vizia_style/selectors/parser.rs
@@ -2620,15 +2620,13 @@ pub mod tests {
         }
     }
 
-    fn parse<'i>(
-        input: &'i str,
-    ) -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i>> {
+    fn parse(input: &str) -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'_>> {
         parse_ns(input, &DummyParser::default())
     }
 
-    fn parse_expected<'i, 'a>(
+    fn parse_expected<'i>(
         input: &'i str,
-        expected: Option<&'a str>,
+        expected: Option<&str>,
     ) -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i>> {
         parse_ns_expected(input, &DummyParser::default(), expected)
     }
@@ -2640,10 +2638,10 @@ pub mod tests {
         parse_ns_expected(input, parser, None)
     }
 
-    fn parse_ns_expected<'i, 'a>(
+    fn parse_ns_expected<'i>(
         input: &'i str,
         parser: &DummyParser,
-        expected: Option<&'a str>,
+        expected: Option<&str>,
     ) -> Result<SelectorList<DummySelectorImpl>, SelectorParseError<'i>> {
         let mut parser_input = ParserInput::new(input);
         let result = SelectorList::parse(parser, &mut CssParser::new(&mut parser_input));
@@ -3065,7 +3063,7 @@ pub mod tests {
                     Component::Combinator(Combinator::Child),
                     Component::Class(DummyAtom::from("ok")),
                 ],
-                (1 << 20) + (1 << 10) + (0 << 0),
+                specificity(1, 1, 0),
                 Default::default(),
             )]))
         );

--- a/crates/vizia_style/src/matching.rs
+++ b/crates/vizia_style/src/matching.rs
@@ -23,9 +23,7 @@ mod test {
 
     use crate::{CustomParseError, SelectorIdent, SelectorParser, Selectors};
 
-    fn parse<'i>(
-        input: &'i str,
-    ) -> Result<SelectorList<Selectors>, ParseError<'i, CustomParseError<'i>>> {
+    fn parse(input: &str) -> Result<SelectorList<Selectors>, ParseError<'_, CustomParseError<'_>>> {
         let mut parser_input = ParserInput::new(input);
         let mut parser = Parser::new(&mut parser_input);
         SelectorList::parse(
@@ -284,12 +282,12 @@ mod test {
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
 
             println!("Result: {}", result);
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
 
             println!("Result: {}", result);
-            assert_eq!(result, false);
+            assert!(!result);
         }
     }
 
@@ -326,10 +324,10 @@ mod test {
                 MatchingContext::new(MatchingMode::Normal, None, None, QuirksMode::NoQuirks);
 
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
-            assert_eq!(result, false);
+            assert!(!result);
         }
 
         if let Ok(selector_list) = parse(".bar") {
@@ -337,10 +335,10 @@ mod test {
                 MatchingContext::new(MatchingMode::Normal, None, None, QuirksMode::NoQuirks);
 
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
         }
 
         if let Ok(selector_list) = parse(".foo.bar") {
@@ -348,10 +346,10 @@ mod test {
                 MatchingContext::new(MatchingMode::Normal, None, None, QuirksMode::NoQuirks);
 
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
-            assert_eq!(result, false);
+            assert!(!result);
         }
 
         if let Ok(selector_list) = parse(".foo, .bar") {
@@ -359,10 +357,10 @@ mod test {
                 MatchingContext::new(MatchingMode::Normal, None, None, QuirksMode::NoQuirks);
 
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
         }
     }
 
@@ -395,10 +393,10 @@ mod test {
                 MatchingContext::new(MatchingMode::Normal, None, None, QuirksMode::NoQuirks);
 
             let result = matches_selector_list(&selector_list, &root_node, &mut context).0;
-            assert_eq!(result, true);
+            assert!(result);
 
             let result = matches_selector_list(&selector_list, &child_node, &mut context).0;
-            assert_eq!(result, false);
+            assert!(!result);
         }
     }
 }

--- a/crates/vizia_style/src/selector.rs
+++ b/crates/vizia_style/src/selector.rs
@@ -166,9 +166,7 @@ mod tests {
 
     use super::*;
 
-    fn parse<'i>(
-        input: &'i str,
-    ) -> Result<SelectorList<Selectors>, ParseError<'i, CustomParseError<'i>>> {
+    fn parse(input: &str) -> Result<SelectorList<Selectors>, ParseError<'_, CustomParseError<'_>>> {
         let mut parser_input = ParserInput::new(input);
         let mut parser = Parser::new(&mut parser_input);
         SelectorList::parse(

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -281,8 +281,6 @@ impl Application {
 
         let mut cursor_moved = false;
         let mut cursor = (0.0f32, 0.0f32);
-        #[cfg(target_os = "windows")]
-        let mut inside_window = false;
 
         // cx.process_events();
 
@@ -461,32 +459,6 @@ impl Application {
                                     cursor.0 = position.x as f32;
                                     cursor.1 = position.y as f32;
                                 }
-
-                                // Temporary fix for windows platform until winit merge #3154
-                                #[cfg(target_os = "windows")]
-                                {
-                                    let (width, height) = {
-                                        let scale_factor = cx.scale_factor();
-                                        let size = cx.window_size();
-                                        (
-                                            (size.width as f32 * scale_factor).round() as u32,
-                                            (size.height as f32 * scale_factor).round() as u32,
-                                        )
-                                    };
-
-                                    let x = position.x.is_positive()
-                                        && (0..width).contains(&(position.x as u32));
-                                    let y = position.y.is_positive()
-                                        && (0..height).contains(&(position.y as u32));
-
-                                    if !inside_window && x && y {
-                                        inside_window = true;
-                                        cx.emit_origin(WindowEvent::MouseEnter);
-                                    } else if inside_window && !(x && y) {
-                                        inside_window = false;
-                                        cx.emit_origin(WindowEvent::MouseLeave);
-                                    }
-                                }
                             }
 
                             #[allow(deprecated)]
@@ -649,18 +621,10 @@ impl Application {
                             }
 
                             winit::event::WindowEvent::CursorEntered { device_id: _ } => {
-                                #[cfg(target_os = "windows")]
-                                {
-                                    inside_window = true;
-                                }
                                 cx.emit_origin(WindowEvent::MouseEnter);
                             }
 
                             winit::event::WindowEvent::CursorLeft { device_id: _ } => {
-                                #[cfg(target_os = "windows")]
-                                {
-                                    inside_window = false;
-                                }
                                 cx.emit_origin(WindowEvent::MouseLeave);
                             }
 

--- a/examples/7GUIs/flight_booker.rs
+++ b/examples/7GUIs/flight_booker.rs
@@ -34,8 +34,8 @@ impl Model for AppData {
     fn event(&mut self, _: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
             AppEvent::SetChoice(choice) => self.selected_option = *choice,
-            AppEvent::SetStartDate(date) => self.start_date = date.clone(),
-            AppEvent::SetEndDate(date) => self.end_date = date.clone(),
+            AppEvent::SetStartDate(date) => self.start_date = *date,
+            AppEvent::SetEndDate(date) => self.end_date = *date,
         });
     }
 }
@@ -46,7 +46,7 @@ fn input_box<L: Lens<Target = NaiveDate>>(
     message: impl Fn(NaiveDate) -> AppEvent + Send + Sync + 'static,
 ) {
     Textbox::new(cx, date_lens.map(|date| format!("{}", date.format("%Y:%m:%d"))))
-        .validate(|text| NaiveDate::parse_from_str(&text, "%Y:%m:%d").is_ok())
+        .validate(|text| NaiveDate::parse_from_str(text, "%Y:%m:%d").is_ok())
         .on_submit(move |ex, text, _| {
             if let Ok(val) = NaiveDate::parse_from_str(&text, "%Y:%m:%d") {
                 ex.emit(message(val));
@@ -62,8 +62,8 @@ fn main() -> Result<(), ApplicationError> {
         AppData {
             options: vec!["one-way flight", "return flight"],
             selected_option: 0,
-            start_date: NaiveDate::from_ymd_opt(2022, 02, 12).unwrap(),
-            end_date: NaiveDate::from_ymd_opt(2022, 02, 26).unwrap(),
+            start_date: NaiveDate::from_ymd_opt(2022, 2, 12).unwrap(),
+            end_date: NaiveDate::from_ymd_opt(2022, 2, 26).unwrap(),
         }
         .build(cx);
 

--- a/examples/lens_map.rs
+++ b/examples/lens_map.rs
@@ -9,7 +9,7 @@ impl Model for AppData {}
 
 fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
-        AppData { value: 3.14 }.build(cx);
+        AppData { value: std::f32::consts::PI }.build(cx);
 
         Label::new(cx, AppData::value.map(|_val| String::from("Hello World")));
     })

--- a/examples/save_dialog.rs
+++ b/examples/save_dialog.rs
@@ -43,15 +43,14 @@ pub struct AppData {
 
 impl Model for AppData {
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
-        event.map(|window_event, meta| match window_event {
+        event.map(|window_event, meta| {
             // Intercept WindowClose event to show a dialog if not 'saved'.
-            WindowEvent::WindowClose => {
+            if let WindowEvent::WindowClose = window_event {
                 if !self.is_saved {
                     self.show_dialog = true;
                     meta.consume();
                 }
             }
-            _ => {}
         });
 
         event.map(|app_event, _| match app_event {

--- a/examples/style/filter.rs
+++ b/examples/style/filter.rs
@@ -93,13 +93,11 @@ impl FilterElement {
 
 impl View for FilterElement {
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
-        event.map(|window_event, _| match window_event {
-            WindowEvent::MouseMove(x, y) => {
+        event.map(|window_event, _| {
+            if let WindowEvent::MouseMove(x, y) = window_event {
                 self.left = Pixels(*x / cx.scale_factor());
                 self.top = Pixels(*y / cx.scale_factor());
             }
-
-            _ => {}
         })
     }
 }

--- a/examples/views/hstack.rs
+++ b/examples/views/hstack.rs
@@ -8,8 +8,8 @@ fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         ExamplePage::new(cx, |cx| {
             HStack::new(cx, |cx| {
-                for i in 0..3 {
-                    Element::new(cx).size(Pixels(100.0)).background_color(COLORS[i]);
+                for color in COLORS {
+                    Element::new(cx).size(Pixels(100.0)).background_color(color);
                 }
             })
             .child_space(Stretch(1.0));

--- a/examples/views/label.rs
+++ b/examples/views/label.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         AppData {
             text: String::from("As well as model data which implements ToString:"),
-            value: 3.141592,
+            value: std::f32::consts::PI,
             checked: false,
         }
         .build(cx);

--- a/examples/views/menu.rs
+++ b/examples/views/menu.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), ApplicationError> {
                         |cx| {
                             HStack::new(cx, |cx| {
                                 Label::new(cx, "New");
-                                Label::new(cx, &"Ctrl + N".to_string()).class("shortcut");
+                                Label::new(cx, "Ctrl + N").class("shortcut");
                             })
                         },
                     );
@@ -25,7 +25,7 @@ fn main() -> Result<(), ApplicationError> {
                         |cx| {
                             HStack::new(cx, |cx| {
                                 Label::new(cx, "Open");
-                                Label::new(cx, &"Ctrl + O".to_string()).class("shortcut");
+                                Label::new(cx, "Ctrl + O").class("shortcut");
                             })
                         },
                     );

--- a/examples/views/menu.rs
+++ b/examples/views/menu.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), ApplicationError> {
                         |cx| {
                             HStack::new(cx, |cx| {
                                 Label::new(cx, "New");
-                                Label::new(cx, &format!("Ctrl + N")).class("shortcut");
+                                Label::new(cx, &"Ctrl + N".to_string()).class("shortcut");
                             })
                         },
                     );
@@ -25,7 +25,7 @@ fn main() -> Result<(), ApplicationError> {
                         |cx| {
                             HStack::new(cx, |cx| {
                                 Label::new(cx, "Open");
-                                Label::new(cx, &format!("Ctrl + O")).class("shortcut");
+                                Label::new(cx, &"Ctrl + O".to_string()).class("shortcut");
                             })
                         },
                     );

--- a/examples/views/menubar.rs
+++ b/examples/views/menubar.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), ApplicationError> {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "New");
-                                    Label::new(cx, &"Ctrl + N".to_string()).class("shortcut");
+                                    Label::new(cx, "Ctrl + N").class("shortcut");
                                 })
                             },
                         );
@@ -27,7 +27,7 @@ fn main() -> Result<(), ApplicationError> {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "Open");
-                                    Label::new(cx, &"Ctrl + O".to_string()).class("shortcut");
+                                    Label::new(cx, "Ctrl + O").class("shortcut");
                                 })
                             },
                         );

--- a/examples/views/menubar.rs
+++ b/examples/views/menubar.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), ApplicationError> {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "New");
-                                    Label::new(cx, &format!("Ctrl + N")).class("shortcut");
+                                    Label::new(cx, &"Ctrl + N".to_string()).class("shortcut");
                                 })
                             },
                         );
@@ -27,7 +27,7 @@ fn main() -> Result<(), ApplicationError> {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "Open");
-                                    Label::new(cx, &format!("Ctrl + O")).class("shortcut");
+                                    Label::new(cx, &"Ctrl + O".to_string()).class("shortcut");
                                 })
                             },
                         );

--- a/examples/views/spinbox.rs
+++ b/examples/views/spinbox.rs
@@ -124,7 +124,7 @@ impl Model for AppState {
             }
 
             AppEvent::Decrement3 => {
-                let mut index = self.spinbox_value_3 as usize;
+                let mut index = self.spinbox_value_3;
                 if index == 0 {
                     index = 3
                 }

--- a/examples/views/vstack.rs
+++ b/examples/views/vstack.rs
@@ -5,8 +5,8 @@ const COLORS: [Color; 3] = [Color::red(), Color::green(), Color::blue()];
 fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         VStack::new(cx, |cx| {
-            for i in 0..3 {
-                Element::new(cx).size(Pixels(100.0)).background_color(COLORS[i]);
+            for color in COLORS {
+                Element::new(cx).size(Pixels(100.0)).background_color(color);
             }
         })
         .child_space(Stretch(1.0));

--- a/examples/views/zstack.rs
+++ b/examples/views/zstack.rs
@@ -5,11 +5,11 @@ const COLORS: [Color; 3] = [Color::red(), Color::green(), Color::blue()];
 fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         ZStack::new(cx, |cx| {
-            for i in 0..3 {
+            for (i, color) in COLORS.into_iter().enumerate() {
                 Element::new(cx)
                     .size(Pixels(100.0))
                     .translate(Pixels(10.0 * i as f32))
-                    .background_color(COLORS[i]);
+                    .background_color(color);
             }
         })
         .child_space(Stretch(1.0));

--- a/examples/widget_gallery/src/views/menu.rs
+++ b/examples/widget_gallery/src/views/menu.rs
@@ -23,7 +23,7 @@ pub fn menu(cx: &mut Context) {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "New");
-                                    Label::new(cx, &format!("Ctrl + N")).class("shortcut");
+                                    Label::new(cx, "Ctrl + N").class("shortcut");
                                 })
                             },
                         );
@@ -33,7 +33,7 @@ pub fn menu(cx: &mut Context) {
                             |cx| {
                                 HStack::new(cx, |cx| {
                                     Label::new(cx, "Open");
-                                    Label::new(cx, &format!("Ctrl + O")).class("shortcut");
+                                    Label::new(cx, "Ctrl + O").class("shortcut");
                                 })
                             },
                         );

--- a/examples/widget_gallery/src/views/menu_bar.rs
+++ b/examples/widget_gallery/src/views/menu_bar.rs
@@ -26,7 +26,7 @@ pub fn menu_bar(cx: &mut Context) {
                                 |cx| {
                                     HStack::new(cx, |cx| {
                                         Label::new(cx, "New");
-                                        Label::new(cx, &format!("Ctrl + N")).class("shortcut");
+                                        Label::new(cx, "Ctrl + N").class("shortcut");
                                     })
                                 },
                             );
@@ -36,7 +36,7 @@ pub fn menu_bar(cx: &mut Context) {
                                 |cx| {
                                     HStack::new(cx, |cx| {
                                         Label::new(cx, "Open");
-                                        Label::new(cx, &format!("Ctrl + O")).class("shortcut");
+                                        Label::new(cx, "Ctrl + O").class("shortcut");
                                     })
                                 },
                             );

--- a/examples/widget_gallery/src/views/toggle_button.rs
+++ b/examples/widget_gallery/src/views/toggle_button.rs
@@ -12,23 +12,23 @@ pub struct ToggleData {
 }
 
 pub enum ToggleEvent {
-    ToggleBold,
-    ToggleItalic,
-    ToggleUnderline,
+    Bold,
+    Italic,
+    Underline,
 }
 
 impl Model for ToggleData {
     fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
         event.map(|app_event, _| match app_event {
-            ToggleEvent::ToggleBold => {
+            ToggleEvent::Bold => {
                 self.bold ^= true;
             }
 
-            ToggleEvent::ToggleItalic => {
+            ToggleEvent::Italic => {
                 self.italic ^= true;
             }
 
-            ToggleEvent::ToggleUnderline => {
+            ToggleEvent::Underline => {
                 self.underline ^= true;
             }
         })
@@ -49,7 +49,7 @@ pub fn toggle_button(cx: &mut Context) {
             cx,
             |cx| {
                 ToggleButton::new(cx, ToggleData::bold, |cx| Label::new(cx, "Bold"))
-                    .on_toggle(|cx| cx.emit(ToggleEvent::ToggleBold));
+                    .on_toggle(|cx| cx.emit(ToggleEvent::Bold));
             },
             r#"ToggleButton::new(cx, ToggleData::bold, |cx| Label::new(cx, "Bold"))
     .on_toggle(|cx| cx.emit(ToggleEvent::ToggleBold));"#,
@@ -61,15 +61,15 @@ pub fn toggle_button(cx: &mut Context) {
             |cx| {
                 ButtonGroup::new(cx, |cx| {
                     ToggleButton::new(cx, ToggleData::bold, |cx| Icon::new(cx, ICON_BOLD))
-                        .on_toggle(|cx| cx.emit(ToggleEvent::ToggleBold));
+                        .on_toggle(|cx| cx.emit(ToggleEvent::Bold));
 
                     ToggleButton::new(cx, ToggleData::italic, |cx| Icon::new(cx, ICON_ITALIC))
-                        .on_toggle(|cx| cx.emit(ToggleEvent::ToggleItalic));
+                        .on_toggle(|cx| cx.emit(ToggleEvent::Italic));
 
                     ToggleButton::new(cx, ToggleData::underline, |cx| {
                         Icon::new(cx, ICON_UNDERLINE)
                     })
-                    .on_toggle(|cx| cx.emit(ToggleEvent::ToggleUnderline));
+                    .on_toggle(|cx| cx.emit(ToggleEvent::Underline));
                 });
             },
             r#"ButtonGroup::new(cx, |cx| {


### PR DESCRIPTION
Removed temporary fix in windows because its already fixed in winit and also fixed all clippy warnings