### PR TITLE
Feat: Adds xypad and an example for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,10 @@ name = "tabview"
 path = "examples/views/tabview.rs"
 
 [[example]]
+name = "xypad"
+path = "examples/views/xypad.rs"
+
+[[example]]
 name = "circle_drawer"
 path = "examples/7GUIs/circle_drawer.rs"
 

--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -937,3 +937,13 @@ tooltip arrow {
 virtual-list label.dark {
     background-color: #00000015;
 }
+
+/* XY PAD */
+
+xypad {
+    background-color: #5c5c5c;
+}
+
+xypad:disabled {
+    background-color: #323232;
+}

--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -941,7 +941,11 @@ virtual-list label.dark {
 /* XY PAD */
 
 xypad {
-    background-color: #5c5c5c;
+    border-color: #ffffff;
+}
+
+xypad .thumb {
+    border-color: #ffffff;
 }
 
 xypad:disabled {

--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -944,3 +944,16 @@ virtual-list label {
     child-left: 5px;
     width: 1s;
 }
+
+/* XY PAD */
+
+xypad {
+    height: 50px;
+    width: 50px;
+}
+
+xypad .thumb {
+    width: 10px;
+    height: 10px;
+    child-space: 1s;
+}

--- a/crates/vizia_core/resources/themes/light_theme.css
+++ b/crates/vizia_core/resources/themes/light_theme.css
@@ -994,3 +994,13 @@ tooltip arrow {
 virtual-list label.dark {
     background-color: #00000015;
 }
+
+/* XY PAD */
+
+xypad {
+    border-color: #000000ff;
+}
+
+xypad .thumb {
+    border-color: #000000ff;
+}

--- a/crates/vizia_core/src/views/mod.rs
+++ b/crates/vizia_core/src/views/mod.rs
@@ -35,6 +35,7 @@ mod textbox;
 mod toggle_button;
 mod tooltip;
 mod virtual_list;
+mod xypad;
 
 pub use self::image::Image;
 pub use crate::binding::Binding;
@@ -72,6 +73,7 @@ pub use textbox::{TextEvent, Textbox};
 pub use toggle_button::{ToggleButton, ToggleButtonModifiers};
 pub use tooltip::Tooltip;
 pub use virtual_list::*;
+pub use xypad::XYPad;
 
 use crate::prelude::Data;
 

--- a/crates/vizia_core/src/views/xypad.rs
+++ b/crates/vizia_core/src/views/xypad.rs
@@ -22,15 +22,12 @@ impl XYPad {
                     .size(Pixels(10.0))
                     .border_radius(Percentage(50.0))
                     .border_width(Pixels(2.0))
-                    .border_color(Color::black())
                     .hoverable(false)
                     .class("thumb");
             })
             .overflow(Overflow::Hidden)
             .border_width(Pixels(1.0))
-            .border_color(Color::black())
             .size(Pixels(200.0))
-            .class("xypad")
     }
 }
 

--- a/crates/vizia_core/src/views/xypad.rs
+++ b/crates/vizia_core/src/views/xypad.rs
@@ -1,0 +1,104 @@
+use crate::prelude::*;
+
+pub struct XYPad {
+    is_dragging: bool,
+
+    on_change: Option<Box<dyn Fn(&mut EventContext, f32, f32)>>,
+}
+
+impl XYPad {
+    pub fn new<L: Lens<Target = (f32, f32)>>(cx: &mut Context, lens: L) -> Handle<Self> {
+        Self { is_dragging: false, on_change: None }
+            .build(cx, |cx| {
+                // Thumb
+                Element::new(cx)
+                    .position_type(PositionType::SelfDirected)
+                    .left(lens.clone().map(|(x, _)| Percentage(*x * 100.0)))
+                    .top(lens.clone().map(|(_, y)| Percentage((1.0 - *y) * 100.0)))
+                    .translate(Translate::new(
+                        Length::Value(LengthValue::Px(-6.0)),
+                        Length::Value(LengthValue::Px(-6.0)),
+                    ))
+                    .size(Pixels(10.0))
+                    .border_radius(Percentage(50.0))
+                    .border_width(Pixels(2.0))
+                    .border_color(Color::black())
+                    .hoverable(false)
+                    .class("thumb");
+            })
+            .overflow(Overflow::Hidden)
+            .border_width(Pixels(1.0))
+            .border_color(Color::black())
+            .size(Pixels(200.0))
+            .class("xypad")
+    }
+}
+
+impl View for XYPad {
+    fn element(&self) -> Option<&'static str> {
+        Some("xypad")
+    }
+
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
+                if cx.is_disabled() {
+                    return;
+                }
+                let current = cx.current();
+                cx.capture();
+                let mouse = cx.mouse();
+                if meta.target == current {
+                    // let width = cx.cache.get_width(current);
+                    // let height = cx.cache.get_height(current);
+
+                    let mut dx = (mouse.left.pos_down.0 - cx.cache.get_posx(current))
+                        / cx.cache.get_width(current);
+                    let mut dy = (mouse.left.pos_down.1 - cx.cache.get_posy(current))
+                        / cx.cache.get_height(current);
+
+                    dx = dx.clamp(0.0, 1.0);
+                    dy = dy.clamp(0.0, 1.0);
+
+                    self.is_dragging = true;
+
+                    if let Some(callback) = &self.on_change {
+                        (callback)(cx, dx, 1.0 - dy);
+                    }
+                }
+            }
+
+            WindowEvent::MouseUp(button) if *button == MouseButton::Left => {
+                cx.set_active(false);
+                cx.release();
+                self.is_dragging = false;
+                if meta.target == cx.current() {
+                    cx.release();
+                }
+            }
+
+            WindowEvent::MouseMove(x, y) => {
+                if self.is_dragging {
+                    let current = cx.current();
+                    let mut dx = (*x - cx.cache.get_posx(current)) / cx.cache.get_width(current);
+                    let mut dy = (*y - cx.cache.get_posy(current)) / cx.cache.get_height(current);
+
+                    dx = dx.clamp(0.0, 1.0);
+                    dy = dy.clamp(0.0, 1.0);
+
+                    if let Some(callback) = &self.on_change {
+                        (callback)(cx, dx, 1.0 - dy);
+                    }
+                }
+            }
+
+            _ => {}
+        });
+    }
+}
+
+impl Handle<'_, XYPad> {
+    pub fn on_change<F: Fn(&mut EventContext, f32, f32) + 'static>(self, callback: F) -> Self {
+        self.modify(|xypad| xypad.on_change = Some(Box::new(callback)))
+    }
+}

--- a/crates/vizia_core/src/views/xypad.rs
+++ b/crates/vizia_core/src/views/xypad.rs
@@ -13,8 +13,8 @@ impl XYPad {
                 // Thumb
                 Element::new(cx)
                     .position_type(PositionType::SelfDirected)
-                    .left(lens.clone().map(|(x, _)| Percentage(*x * 100.0)))
-                    .top(lens.clone().map(|(_, y)| Percentage((1.0 - *y) * 100.0)))
+                    .left(lens.map(|(x, _)| Percentage(*x * 100.0)))
+                    .top(lens.map(|(_, y)| Percentage((1.0 - *y) * 100.0)))
                     .translate(Translate::new(
                         Length::Value(LengthValue::Px(-6.0)),
                         Length::Value(LengthValue::Px(-6.0)),

--- a/examples/views/xypad.rs
+++ b/examples/views/xypad.rs
@@ -1,0 +1,67 @@
+mod helpers;
+use helpers::*;
+use vizia::prelude::*;
+
+#[derive(Debug, Lens)]
+pub struct AppData {
+    pub xy_data: (f32, f32),
+}
+
+#[derive(Debug)]
+pub enum AppEvent {
+    XYPadChange(f32, f32),
+    XSliderChange(f32),
+    YSliderChange(f32),
+}
+
+impl Model for AppData {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
+        event.map(|app_event, _| match app_event {
+            AppEvent::XYPadChange(value_x, value_y) => {
+                self.xy_data = (*value_x, *value_y);
+            }
+            AppEvent::XSliderChange(value_x) => {
+                self.xy_data.0 = *value_x;
+            }
+            AppEvent::YSliderChange(value_y) => {
+                self.xy_data.1 = *value_y;
+            }
+        });
+    }
+}
+
+fn main() -> Result<(), ApplicationError> {
+    Application::new(|cx| {
+        AppData { xy_data: (0.25, 0.25) }.build(cx);
+
+        ExamplePage::vertical(cx, |cx| {
+            Label::new(cx, "2-dimensional XY Pad");
+            VStack::new(cx, |cx| {
+                HStack::new(cx, |cx| {
+                    Slider::new(cx, AppData::xy_data.map(|data| data.1))
+                        .width(Pixels(10.0))
+                        .height(Pixels(100.0))
+                        .range(0.0..1.0)
+                        .on_changing(move |cx, val| cx.emit(AppEvent::YSliderChange(val)));
+                    // XY pad
+                    XYPad::new(cx, AppData::xy_data.map(|data| (data.0, data.1))).on_change(
+                        |ex, value_x, value_y| ex.emit(AppEvent::XYPadChange(value_x, value_y)),
+                    );
+                })
+                .size(Auto)
+                .col_between(Pixels(5.0))
+                .child_top(Stretch(1.0))
+                .child_bottom(Stretch(1.0));
+                Slider::new(cx, AppData::xy_data.map(|data| data.0))
+                    .width(Pixels(100.0))
+                    .height(Pixels(10.0))
+                    .range(0.0..1.0)
+                    .on_changing(move |cx, val| cx.emit(AppEvent::XSliderChange(val)));
+            })
+            .child_left(Stretch(1.0))
+            .child_right(Stretch(1.0));
+        });
+    })
+    .title("XY Pad")
+    .run()
+}


### PR DESCRIPTION
* Adds XY pad view
    * Supports disabling
    * Supports light/dark themes
* Adds an example for the new view
<img width="269" alt="Screenshot 2024-04-07 at 1 41 44 PM" src="https://github.com/vizia/vizia/assets/13266420/8cd76a11-0320-419a-a87a-6042b9da333d">
<img width="269" alt="Screenshot 2024-04-07 at 11 41 26 AM" src="https://github.com/vizia/vizia/assets/13266420/4ced213b-998f-4386-aff7-506b2143e1c8">
