### PR TITLE
Bump image to 0.25.0

### DIFF
--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -23,7 +23,7 @@ vizia_window = { path = "../vizia_window" }
 vizia_style = { path = "../vizia_style"}
 accesskit = "0.12.0"
 femtovg = "0.9"
-image = { version = "0.24.8", default-features = false, features = ["png"] } # inherited from femtovg
+image = { version = "0.25.0", default-features = false, features = ["png"] } # inherited from femtovg
 # morphorm = {path = "../../../morphorm" }
 morphorm = {git = "https://github.com/vizia/morphorm.git", branch = "auto-min-size2"}
 # morphorm = "0.6.4"


### PR DESCRIPTION
Femtovg uses image 0.25.0, yielding the following error when building our vizia application: 

``error[E0277]: the trait bound `ImageSource<'_>: std::convert::From<&image::DynamicImage>` is not satisfied
  --> ~/.cargo/git/checkouts/vizia-a7ac1d316660c1f9/5b548c3/crates/vizia_core/src/resource.rs:32:35
   |
32 |                     .create_image(femtovg::ImageSource::try_from(image_ref).unwrap(), *flags)
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&image::DynamicImage>` is not implemented for `ImageSource<'_>`
   |
   = help: the following other types implement trait `std::convert::From<T>`:
             <ImageSource<'a> as std::convert::From<Img<&'a [RGB<u8>]>>>
             <ImageSource<'a> as std::convert::From<Img<&'a [femtovg::rgb::RGBA<u8>]>>>
             <ImageSource<'a> as std::convert::From<Img<&'a [femtovg::rgb::alt::Gray<u8>]>>>
   = note: required for `&image::DynamicImage` to implement `Into<ImageSource<'_>>`
   = note: required for `ImageSource<'_>` to implement `TryFrom<&image::DynamicImage>`
   ``

This addresses the issue by bumping the vizia image dependency accordingly.