### PR TITLE
Split Res trait into ResGet

### DIFF
--- a/crates/vizia_core/src/animation/animation_state.rs
+++ b/crates/vizia_core/src/animation/animation_state.rs
@@ -118,8 +118,8 @@ where
             t: 0.0,
             active: false,
             entities: HashSet::new(),
-            from_rule: std::usize::MAX,
-            to_rule: std::usize::MAX,
+            from_rule: usize::MAX,
+            to_rule: usize::MAX,
         }
     }
 }

--- a/crates/vizia_core/src/layout/bounds.rs
+++ b/crates/vizia_core/src/layout/bounds.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for BoundingBox {
 
 impl Default for BoundingBox {
     fn default() -> Self {
-        Self { x: 0.0, y: 0.0, w: std::f32::MAX, h: std::f32::MAX }
+        Self { x: 0.0, y: 0.0, w: f32::MAX, h: f32::MAX }
     }
 }
 

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod backend {
 #[doc(hidden)]
 pub mod prelude {
     pub use super::binding::{
-        Binding, Data, Index, Lens, LensExt, LensValue, Map, MapRef, Res, StaticLens, Then,
+        Binding, Data, Index, Lens, LensExt, LensValue, Map, MapRef, Res, ResGet, StaticLens, Then,
         UnwrapLens, Wrapper,
     };
 

--- a/crates/vizia_core/src/localization/mod.rs
+++ b/crates/vizia_core/src/localization/mod.rs
@@ -240,7 +240,7 @@ impl Localized {
     }
 }
 
-impl Res<String> for Localized {
+impl ResGet<String> for Localized {
     fn get_ref<'a>(&'a self, cx: &'a impl DataContext) -> Option<LensValue<'a, String>> {
         Some(LensValue::Owned(self.get(cx)))
     }
@@ -271,7 +271,9 @@ impl Res<String> for Localized {
             format!("{} {{ERROR: {:?}}}", res, err)
         }
     }
+}
 
+impl Res<String> for Localized {
     fn set_or_bind<F>(self, cx: &mut Context, entity: Entity, closure: F)
     where
         F: 'static + Clone + Fn(&mut Context, Localized),

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -617,17 +617,9 @@ pub(crate) fn compute_matched_rules(
 }
 
 fn has_same_selector(cx: &Context, entity1: Entity, entity2: Entity) -> bool {
-    let element1 = if let Some(element1) = cx.views.get(&entity1).and_then(|view| view.element()) {
-        element1
-    } else {
-        ""
-    };
+    let element1 = cx.views.get(&entity1).and_then(|view| view.element()).unwrap_or_default();
 
-    let element2 = if let Some(element2) = cx.views.get(&entity2).and_then(|view| view.element()) {
-        element2
-    } else {
-        ""
-    };
+    let element2 = cx.views.get(&entity2).and_then(|view| view.element()).unwrap_or_default();
 
     if element1 != element2 {
         return false;

--- a/crates/vizia_core/src/views/combobox.rs
+++ b/crates/vizia_core/src/views/combobox.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::usize;
 
 use crate::prelude::*;
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -557,7 +557,7 @@ where
             let mut selection_anchor_cursor = 0;
 
             let mut current_cursor = 0;
-            let mut prev_line_index = std::usize::MAX;
+            let mut prev_line_index = usize::MAX;
 
             for (index, line) in editor.buffer().layout_runs().enumerate() {
                 let text = line.text;
@@ -960,7 +960,7 @@ where
                     let mut selection_index = 0;
 
                     let mut current_cursor = 0;
-                    let mut prev_line_index = std::usize::MAX;
+                    let mut prev_line_index = usize::MAX;
 
                     for (index, line) in editor.buffer().layout_runs().enumerate() {
                         let line_node = AccessNode::new_from_parent(node_id, index);

--- a/crates/vizia_id/src/id_manager.rs
+++ b/crates/vizia_id/src/id_manager.rs
@@ -2,7 +2,7 @@ use crate::GenerationalId;
 use std::{collections::VecDeque, marker::PhantomData};
 
 const MINIMUM_FREE_INDICES: usize = 4096;
-const IDX_MAX: u64 = std::u64::MAX >> 16;
+const IDX_MAX: u64 = u64::MAX >> 16;
 
 /// The IdManager is responsible for allocating and destroying generational IDs.
 ///

--- a/crates/vizia_style/src/values/color.rs
+++ b/crates/vizia_style/src/values/color.rs
@@ -745,15 +745,15 @@ impl RGBA {
             h += 1.0;
         }
 
-        let s = s.max(0.0).min(1.0);
-        let l = l.max(0.0).min(1.0);
+        let s = s.clamp(0.0, 1.0);
+        let l = l.clamp(0.0, 1.0);
 
         let m2 = if l <= 0.5 { l * (1.0 + s) } else { l + s - l * s };
         let m1 = 2.0 * l - m2;
 
-        let r = (hue(h + 1.0 / 3.0, m1, m2).max(0.0).min(1.0) * 255.255) as u8;
-        let g = (hue(h, m1, m2).max(0.0).min(1.0) * 255.0) as u8;
-        let b = (hue(h - 1.0 / 3.0, m1, m2).max(0.0).min(1.0) * 255.0) as u8;
+        let r = (hue(h + 1.0 / 3.0, m1, m2).clamp(0.0, 1.0) * 255.255) as u8;
+        let g = (hue(h, m1, m2).clamp(0.0, 1.0) * 255.0) as u8;
+        let b = (hue(h - 1.0 / 3.0, m1, m2).clamp(0.0, 1.0) * 255.0) as u8;
 
         Self::rgba(r, g, b, a)
     }

--- a/crates/vizia_winit/src/lib.rs
+++ b/crates/vizia_winit/src/lib.rs
@@ -30,7 +30,6 @@ impl<'a> GetRawWindowHandle for EventContext<'a> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl GetRawWindowHandle for Context {
     fn raw_window_handle(&mut self) -> rwh::RawWindowHandle {
         let mut cx = EventContext::new(self);

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -18,12 +18,11 @@ use glutin::{
 
 use vizia_core::backend::*;
 use vizia_core::prelude::*;
+use winit::dpi::*;
 use winit::event_loop::EventLoop;
 use winit::window::{CursorGrabMode, WindowBuilder, WindowLevel};
-use winit::{dpi::*, window::WindowId};
 
 pub struct Window {
-    pub id: WindowId,
     context: glutin::context::PossiblyCurrentContext,
     surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
     window: winit::window::Window,
@@ -150,8 +149,7 @@ impl Window {
         canvas.clear_rect(0, 0, size.width, size.height, Color::rgb(255, 80, 80));
 
         // Build our window
-        let win =
-            Window { id: window.id(), context: gl_context, surface, window, should_close: false };
+        let win = Window { context: gl_context, surface, window, should_close: false };
 
         (win, canvas)
     }


### PR DESCRIPTION
Fixes an issue where some lenses which couldn't be bound to also couldn't implement `Res` for just getting the value. 