### PR TITLE
Update `accesskit` and `accesskit-winit` dependencies to latest version

### DIFF
--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -20,7 +20,7 @@ vizia_id = { path = "../vizia_id" }
 vizia_input = { path = "../vizia_input" }
 vizia_window = { path = "../vizia_window" }
 vizia_style = { path = "../vizia_style"}
-accesskit = "0.12.0"
+accesskit = "0.16"
 
 skia-safe = { version = "0.75", features = ["textlayout", "svg"] }
 # morphorm = {path = "../../../morphorm" }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -201,11 +201,6 @@ impl BackendContext {
         self.0.resource_manager.renegotiate_language();
     }
 
-    /// Returns a mutable reference to the accesskit node classes.
-    pub fn accesskit_node_classes(&mut self) -> &mut accesskit::NodeClassSet {
-        &mut self.style().accesskit_node_classes
-    }
-
     /// Calls the accessibility system and updates the accesskit node tree.
     pub fn process_tree_updates(
         &mut self,

--- a/crates/vizia_core/src/storage/animatable_set.rs
+++ b/crates/vizia_core/src/storage/animatable_set.rs
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_inline() {
-        DataIndex::inline(std::usize::MAX);
+        DataIndex::inline(usize::MAX);
     }
 
     /// Test for creating a shared data index and retrieving the index.

--- a/crates/vizia_core/src/storage/style_set.rs
+++ b/crates/vizia_core/src/storage/style_set.rs
@@ -388,7 +388,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_inline() {
-        DataIndex::inline(std::usize::MAX);
+        DataIndex::inline(usize::MAX);
     }
 
     /// Test for creating a shared data index and retrieving the index.
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_shared() {
-        DataIndex::shared(std::usize::MAX);
+        DataIndex::shared(usize::MAX);
     }
 
     /// Test of the is_inline() method.

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -210,8 +210,6 @@ pub struct Style {
     pub(crate) disabled: StyleSet<bool>,
     pub(crate) abilities: SparseSet<Abilities>,
 
-    pub(crate) accesskit_node_classes: accesskit::NodeClassSet,
-
     // Accessibility Properties
     pub name: StyleSet<String>,
     pub role: SparseSet<Role>,

--- a/crates/vizia_core/src/systems/accessibility.rs
+++ b/crates/vizia_core/src/systems/accessibility.rs
@@ -1,5 +1,5 @@
 use crate::{accessibility::IntoNode, events::ViewHandler, prelude::*};
-use accesskit::{Checked, NodeBuilder, NodeId, Rect, TreeUpdate};
+use accesskit::{NodeBuilder, NodeId, Rect, Toggled, TreeUpdate};
 use hashbrown::HashMap;
 use vizia_storage::LayoutTreeIterator;
 
@@ -36,19 +36,15 @@ pub(crate) fn accessibility_system(cx: &mut Context) {
                     continue;
                 }
 
-                let mut nodes = vec![(
-                    node.node_id(),
-                    node.node_builder.build(&mut cx.style.accesskit_node_classes),
-                )];
+                let mut nodes = vec![(node.node_id(), node.node_builder.build())];
 
                 // If child nodes were generated then append them to the nodes list
                 if !node.children.is_empty() {
-                    nodes.extend(node.children.into_iter().map(|child_node| {
-                        (
-                            child_node.node_id(),
-                            child_node.node_builder.build(&mut cx.style.accesskit_node_classes),
-                        )
-                    }));
+                    nodes.extend(
+                        node.children.into_iter().map(|child_node| {
+                            (child_node.node_id(), child_node.node_builder.build())
+                        }),
+                    );
                 }
 
                 cx.tree_updates.push(Some(TreeUpdate {
@@ -157,9 +153,9 @@ pub(crate) fn get_access_node(
             .map(|pseudoclass| pseudoclass.contains(PseudoClassFlags::CHECKED))
         {
             if checked {
-                node_builder.set_checked(Checked::True);
+                node_builder.set_toggled(Toggled::True);
             } else {
-                node_builder.set_checked(Checked::False);
+                node_builder.set_toggled(Toggled::False);
             }
         }
     }

--- a/crates/vizia_core/src/view.rs
+++ b/crates/vizia_core/src/view.rs
@@ -134,8 +134,8 @@ pub trait View: 'static + Sized {
         };
 
         if let Some(parent_node) = get_access_node(&mut access_context, &mut cx.views, parent_id) {
-            let parent_node = parent_node.node_builder.build(&mut cx.style.accesskit_node_classes);
-            let node = NodeBuilder::default().build(&mut cx.style.accesskit_node_classes);
+            let parent_node = parent_node.node_builder.build();
+            let node = NodeBuilder::default().build();
 
             cx.tree_updates.push(Some(TreeUpdate {
                 nodes: vec![(parent_node_id, parent_node), (node_id, node)],

--- a/crates/vizia_core/src/views/label.rs
+++ b/crates/vizia_core/src/views/label.rs
@@ -103,11 +103,7 @@ impl Label {
     where
         T: ToStringLocalized,
     {
-        Self { describing: None }
-            .build(cx, |_| {})
-            .text(text.clone())
-            .role(Role::StaticText)
-            .name(text)
+        Self { describing: None }.build(cx, |_| {}).text(text.clone()).role(Role::Label).name(text)
     }
 
     pub fn rich<T>(
@@ -123,7 +119,7 @@ impl Label {
                 children(cx);
             })
             .text(text.clone())
-            .role(Role::StaticText)
+            .role(Role::Label)
             .name(text)
     }
 }

--- a/crates/vizia_core/src/views/toggle_button.rs
+++ b/crates/vizia_core/src/views/toggle_button.rs
@@ -14,9 +14,10 @@ impl ToggleButton {
             .build(cx, |cx| {
                 (content)(cx).hoverable(false);
             })
-            .role(Role::ToggleButton)
+            .role(Role::Button)
             .navigable(true)
             .default_action_verb(DefaultActionVerb::Click)
+            .checkable(true) // to let the accesskit know button is toggleable
             .checked(lens)
     }
 }

--- a/crates/vizia_window/Cargo.toml
+++ b/crates/vizia_window/Cargo.toml
@@ -14,7 +14,7 @@ vizia_style = { path = "../vizia_style" }
 # morphorm = {path = "../../../morphorm" }
 morphorm = {git = "https://github.com/vizia/morphorm.git", branch = "auto-min-size2"}
 # morphorm = "0.6.4"
-accesskit = "0.12.0"
+accesskit = "0.16"
 bitflags = "2.6"
 
 [lints]

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -20,14 +20,13 @@ vizia_core = { path = "../vizia_core" }
 vizia_id = { path = "../vizia_id" }
 vizia_window = { path = "../vizia_window" }
 
-accesskit = "0.12"
+accesskit = "0.16"
 winit = { version = "0.30" }
 skia-safe = {version = "0.75", features = ["gl"]}
 glutin = { version = "0.32" }
 copypasta = {version = "0.10", optional = true, default-features = false }
-accesskit_winit = { version = "0.18", optional = true }
+accesskit_winit = { version = "0.22", optional = true }
 glutin-winit = { version = "0.5" }
-raw-window-handle = "0.5"
 gl-rs = { package = "gl", version = "0.14.0" }
 hashbrown = "0.14"
 

--- a/crates/vizia_winit/src/lib.rs
+++ b/crates/vizia_winit/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::type_complexity)] // TODO: Fix these
-
 pub mod application;
 mod convert;
 pub mod window;

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -281,10 +281,12 @@ pub fn create_surface(
     .expect("Could not create skia surface")
 }
 
+type WindowCallback = Option<Box<dyn Fn(&mut EventContext)>>;
+
 pub struct Window {
     pub window: Option<Arc<winit::window::Window>>,
-    pub on_close: Option<Box<dyn Fn(&mut EventContext)>>,
-    pub on_create: Option<Box<dyn Fn(&mut EventContext)>>,
+    pub on_close: WindowCallback,
+    pub on_create: WindowCallback,
     pub should_close: bool,
     pub(crate) custom_cursors: Arc<HashMap<CursorIcon, CustomCursor>>,
 }

--- a/examples/designer/src/app_data.rs
+++ b/examples/designer/src/app_data.rs
@@ -56,7 +56,7 @@ pub struct AppData {
 //     }
 // }
 
-pub const FONT_SIZES: &'static [f32] = &[12.0, 14.0];
+pub const FONT_SIZES: &[f32] = &[12.0, 14.0];
 
 pub enum AppEvent {
     SetCornerTopRightRadius(f32),
@@ -146,16 +146,16 @@ impl Model for AppData {
             }
             // AppEvent::SetShadowColor(idx, col) => todo!(),
             AppEvent::SetShadowX(idx, val) => {
-                self.shadows[*idx].x_offset = Length::px(*val).into();
+                self.shadows[*idx].x_offset = Length::px(*val);
             }
             AppEvent::SetShadowY(idx, val) => {
-                self.shadows[*idx].y_offset = Length::px(*val).into();
+                self.shadows[*idx].y_offset = Length::px(*val);
             }
             AppEvent::SetShadowBlur(idx, val) => {
-                self.shadows[*idx].blur_radius = Some(Length::px(*val).into());
+                self.shadows[*idx].blur_radius = Some(Length::px(*val));
             }
             AppEvent::SetShadowSpread(idx, val) => {
-                self.shadows[*idx].spread_radius = Some(Length::px(*val).into());
+                self.shadows[*idx].spread_radius = Some(Length::px(*val));
             }
             AppEvent::SetShadowType(idx, val) => {
                 self.shadows[*idx].inset = *val;


### PR DESCRIPTION
This PR update `accesskit` and `accesskit-winit` dependencies to latest version
I also removed `raw_window_handle` dependency from `vizia_winit` as its unused and fixed some small clippy warnings