### PR TITLE
Updated `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.79"
+rust-version = "1.80"
 
 [features]
 default = ["winit", "clipboard", "x11", "wayland"]
@@ -23,7 +23,6 @@ vizia_winit = { workspace = true, optional = true }
 vizia_baseview = { workspace = true, optional = true }
 
 [dev-dependencies]
-lazy_static = "1.4"
 chrono = "0.4"
 # reqwest = { version = "0.12", features = ["blocking"] }
 log = "0.4"
@@ -44,6 +43,12 @@ vizia = { version = "0.1.0", path = "." }
 vizia_core = { version = "0.1.0", path = "crates/vizia_core" }
 vizia_winit = { version = "0.1.0", path = "crates/vizia_winit" }
 vizia_baseview = { version = "0.1.0", path = "crates/vizia_baseview" }
+vizia_derive = { version = "0.1.0", path = "crates/vizia_derive" }
+vizia_id = { version = "0.1.0", path = "crates/vizia_id" }
+vizia_input = { version = "0.1.0", path = "crates/vizia_input" }
+vizia_storage = { version = "0.1.0", path = "crates/vizia_storage" }
+vizia_style = { version = "0.1.0", path = "crates/vizia_style" }
+vizia_window = { version = "0.1.0", path = "crates/vizia_window" }
 
 [workspace.lints.rust]
 # future_incompatible = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,64 @@
 [package]
 name = "vizia"
-version = "0.1.0"
-edition = "2021"
-license = "MIT"
 description = "A Rust GUI Framework"
 autoexamples = false
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.79"
+
+[features]
+default = ["winit", "clipboard", "x11", "wayland"]
+clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
+winit = ["vizia_winit"]
+baseview = ["vizia_baseview"]
+x11 = ["vizia_winit?/x11", "vizia_core/x11"]
+wayland = ["vizia_winit?/wayland", "vizia_core/wayland"]
+accesskit = ["vizia_winit?/accesskit"]
+
+[dependencies]
+vizia_core.workspace = true
+vizia_winit = { workspace = true, optional = true }
+vizia_baseview = { workspace = true, optional = true }
+
+[dev-dependencies]
+lazy_static = "1.4"
+chrono = "0.4"
+# reqwest = { version = "0.12", features = ["blocking"] }
+log = "0.4"
+fern = "0.6"
 
 [workspace]
 members = [ "crates/*", "examples/widget_gallery", "examples/designer"]
+
+[workspace.package]
+version = "0.1.0"
+authors = ["George Atkinson <geomyles@yahoo.co.uk>"]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/vizia/vizia"
+
+[workspace.dependencies]
+vizia = { version = "0.1.0", path = "." }
+vizia_core = { version = "0.1.0", path = "crates/vizia_core" }
+vizia_winit = { version = "0.1.0", path = "crates/vizia_winit" }
+vizia_baseview = { version = "0.1.0", path = "crates/vizia_baseview" }
+
+[workspace.lints.rust]
+# future_incompatible = "allow"
+# let_underscore = "allow"
+# nonstandard_style = "allow"
+# rust_2018_compatibility = "allow"
+# rust_2018_idioms = "allow"
+# rust_2021_compatibility = "allow"
+# unused = "allow"
+
+[workspace.lints.clippy]
+# cargo = "allow"
+# pedantic = "allow"
+# nursery = "allow"
+# separated_literal_suffix = "allow"
 
 [[example]]
 name = "counter"
@@ -284,39 +334,3 @@ path = "examples/views/svg.rs"
 [[example]]
 name = "debug"
 path = "examples/debug.rs"
-
-[features]
-default = ["winit", "clipboard", "x11", "wayland"]
-clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
-winit = ["vizia_winit"]
-baseview = ["vizia_baseview"]
-x11 = ["vizia_winit?/x11", "vizia_core/x11"]
-wayland = ["vizia_winit?/wayland", "vizia_core/wayland"]
-accesskit = ["vizia_winit?/accesskit"]
-
-[dependencies]
-vizia_core = { version = "0.1.0", path = "crates/vizia_core"}
-vizia_winit = { version = "0.1.0", path = "crates/vizia_winit", optional = true }
-vizia_baseview = { version = "0.1.0", path = "crates/vizia_baseview", optional = true }
-
-[dev-dependencies]
-lazy_static = "1.4.0"
-chrono = "0.4.34"
-reqwest = { version = "0.11.18", features = ["blocking"] }
-log = "0.4.19"
-fern = { version = "0.6" }
-
-[workspace.lints.rust]
-# future_incompatible = "allow"
-# let_underscore = "allow"
-# nonstandard_style = "allow"
-# rust_2018_compatibility = "allow"
-# rust_2018_idioms = "allow"
-# rust_2021_compatibility = "allow"
-# unused = "allow"
-
-[workspace.lints.clippy]
-# cargo = "allow"
-# pedantic = "allow"
-# nursery = "allow"
-# separated_literal_suffix = "allow"

--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "vizia_baseview"
-version = "0.1.0"
 authors = ["George Atkinson <geomyles@yahoo.co.uk>", "Billy Messenger <BillyDM@protonmail.com>"]
 description = "Baseview backend for vizia"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [dependencies]
-vizia_core = { path = "../vizia_core" }
-vizia_input = { path = "../vizia_input" }
-vizia_id = { path = "../vizia_id" }
+vizia_core.workspace = true
+vizia_input.workspace = true
+vizia_id.workspace = true
 
 baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "579130ecb4f9f315ae52190af42f0ea46aeaa4a2", features = ["opengl"] }
-raw-window-handle = "0.5.2"
-lazy_static = "1.4.0"
-gl-rs = { package = "gl", version = "0.14.0" }
+raw-window-handle = "0.5"
+gl-rs = { package = "gl", version = "0.14" }
 skia-safe = {version = "0.75", features = ["gl"]}
 
 [lints]

--- a/crates/vizia_baseview/Cargo.toml
+++ b/crates/vizia_baseview/Cargo.toml
@@ -2,10 +2,10 @@
 name = "vizia_baseview"
 version = "0.1.0"
 authors = ["George Atkinson <geomyles@yahoo.co.uk>", "Billy Messenger <BillyDM@protonmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
 description = "Baseview backend for vizia"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 vizia_core = { path = "../vizia_core" }

--- a/crates/vizia_baseview/src/proxy.rs
+++ b/crates/vizia_baseview/src/proxy.rs
@@ -14,7 +14,7 @@ pub(crate) fn queue_get() -> Option<Event> {
 }
 
 #[derive(Clone)]
-pub(crate) struct BaseviewProxy();
+pub(crate) struct BaseviewProxy;
 
 impl EventProxy for BaseviewProxy {
     fn send(&self, event: Event) -> Result<(), ()> {

--- a/crates/vizia_baseview/src/proxy.rs
+++ b/crates/vizia_baseview/src/proxy.rs
@@ -1,12 +1,9 @@
-use lazy_static::lazy_static;
 use std::collections::VecDeque;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use vizia_core::context::EventProxy;
 use vizia_core::events::Event;
 
-lazy_static! {
-    pub(crate) static ref PROXY_QUEUE: Mutex<VecDeque<Event>> = Mutex::new(VecDeque::new());
-}
+pub(crate) static PROXY_QUEUE: LazyLock<Mutex<VecDeque<Event>>> = LazyLock::new(Mutex::default);
 
 pub(crate) fn queue_put(event: Event) {
     PROXY_QUEUE.lock().unwrap().push_back(event)

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -156,7 +156,7 @@ impl ViziaWindow {
 
                 let mut cx = BackendContext::new(cx);
 
-                cx.set_event_proxy(Box::new(BaseviewProxy()));
+                cx.set_event_proxy(Box::new(BaseviewProxy));
                 ViziaWindow::new(cx, win_desc, scale_policy, window, Some(Box::new(app)), on_idle)
             },
         )
@@ -195,7 +195,7 @@ impl ViziaWindow {
 
                 let mut cx = BackendContext::new(cx);
 
-                cx.set_event_proxy(Box::new(BaseviewProxy()));
+                cx.set_event_proxy(Box::new(BaseviewProxy));
                 ViziaWindow::new(cx, win_desc, scale_policy, window, Some(Box::new(app)), on_idle)
             },
         )

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "vizia_core"
-version = "0.1.0"
 description = "Core components of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [features]
 clipboard = ["copypasta"]
@@ -14,12 +13,12 @@ x11 = ["copypasta?/x11"]
 wayland = ["copypasta?/wayland"]
 
 [dependencies]
-vizia_derive = { path = "../vizia_derive" }
-vizia_storage = { path = "../vizia_storage" }
-vizia_id = { path = "../vizia_id" }
-vizia_input = { path = "../vizia_input" }
-vizia_window = { path = "../vizia_window" }
-vizia_style = { path = "../vizia_style"}
+vizia_derive.workspace = true
+vizia_storage.workspace = true
+vizia_id.workspace = true
+vizia_input.workspace = true
+vizia_window.workspace = true
+vizia_style.workspace = true
 accesskit = "0.16"
 
 skia-safe = { version = "0.75", features = ["textlayout", "svg"] }
@@ -30,10 +29,10 @@ bitflags = "2.6"
 fnv = "1.0"
 fluent-bundle = "0.15"
 fluent-langneg = "0.13"
-unic-langid = {version = "0.9.4", features = ["macros"]}
-sys-locale = "0.3.1"
-unicode-segmentation = "1.11.0"
-copypasta = {version = "0.10.1", optional = true, default-features = false }
+unic-langid = {version = "0.9", features = ["macros"]}
+sys-locale = "0.3"
+unicode-segmentation = "1.11"
+copypasta = {version = "0.10", optional = true, default-features = false }
 chrono = "0.4"
 hashbrown = "0.14"
 log = "0.4"

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_core"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "Core components of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [features]

--- a/crates/vizia_derive/Cargo.toml
+++ b/crates/vizia_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_derive"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2018"
 description = "Derive macros for vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/vizia_derive/Cargo.toml
+++ b/crates/vizia_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vizia_derive"
-version = "0.1.0"
 description = "Derive macros for vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/vizia_id/Cargo.toml
+++ b/crates/vizia_id/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_id"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "Core components of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/vizia_id/Cargo.toml
+++ b/crates/vizia_id/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "vizia_id"
-version = "0.1.0"
 description = "Core components of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [dependencies]
 

--- a/crates/vizia_input/Cargo.toml
+++ b/crates/vizia_input/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
 name = "vizia_input"
-version = "0.1.0"
 description = "The input components of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [dependencies]
-vizia_id = { path = "../vizia_id" }
+vizia_id.workspace = true
 
 keyboard-types = { version = "0.6", default-features = false }
-bitflags = "2.4"
+bitflags = "2.6"
 
 [lints]
 workspace = true

--- a/crates/vizia_input/Cargo.toml
+++ b/crates/vizia_input/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_input"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "The input components of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/vizia_storage/Cargo.toml
+++ b/crates/vizia_storage/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 name = "vizia_storage"
-version = "0.1.0"
 description = "The storage data structures of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [dependencies]
-vizia_id = { path = "../vizia_id" }
+vizia_id.workspace = true
 
 # morphorm = {path = "../../../morphorm" }
 morphorm = {git = "https://github.com/vizia/morphorm.git", branch = "auto-min-size2"}

--- a/crates/vizia_storage/Cargo.toml
+++ b/crates/vizia_storage/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_storage"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "The storage data structures of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/vizia_style/Cargo.toml
+++ b/crates/vizia_style/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "vizia_style"
-version = "0.1.0"
 description = "The style components of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [dependencies]
 cssparser = "0.29.6"

--- a/crates/vizia_style/Cargo.toml
+++ b/crates/vizia_style/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_style"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "The style components of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/vizia_window/Cargo.toml
+++ b/crates/vizia_window/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "vizia_window"
-version = "0.1.0"
 description = "The window components of vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [dependencies]
-vizia_input = { path = "../vizia_input" }
-vizia_style = { path = "../vizia_style" }
+vizia_input.workspace = true
+vizia_style.workspace = true
 # morphorm = {path = "../../../morphorm" }
 morphorm = {git = "https://github.com/vizia/morphorm.git", branch = "auto-min-size2"}
 # morphorm = "0.6.4"

--- a/crates/vizia_window/Cargo.toml
+++ b/crates/vizia_window/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_window"
 version = "0.1.0"
-authors = ["George Atkinson"]
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
-edition = "2021"
 description = "The window components of vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vizia_winit"
 version = "0.1.0"
-authors = ["George Atkinson"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/vizia/vizia"
 description = "Winit backend for vizia"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 rust-version = "1.76"
 
 [features]

--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "vizia_winit"
-version = "0.1.0"
 description = "Winit backend for vizia"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version = "1.76"
 
 [features]
 x11 = ["winit/x11", "glutin/x11", "glutin-winit/x11"]
@@ -15,10 +14,10 @@ clipboard = ["copypasta"]
 accesskit = ["accesskit_winit"]
 
 [dependencies]
-vizia_input = { path = "../vizia_input" }
-vizia_core = { path = "../vizia_core" }
-vizia_id = { path = "../vizia_id" }
-vizia_window = { path = "../vizia_window" }
+vizia_input.workspace = true
+vizia_core.workspace = true
+vizia_id.workspace = true
+vizia_window.workspace = true
 
 accesskit = "0.16"
 winit = { version = "0.30" }

--- a/examples/designer/Cargo.toml
+++ b/examples/designer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vizia = {path = "../../../vizia"}
+vizia.workspace = true
 fern = "0.6"
 log = "0.4"
 chrono = "0.4"

--- a/examples/text_layout.rs
+++ b/examples/text_layout.rs
@@ -27,70 +27,68 @@ fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         AppData { text: String::from("This is some text"), text2: String::from("سلام") }.build(cx);
         VStack::new(cx, |cx| {
-            TabView::new(cx, StaticLens::<&[&str]>::new(&STATIC_LIST), |cx, item| {
-                match *item.get_ref(cx).unwrap() {
-                    "Wrapping" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx| {
-                            wrapping(cx);
-                        },
-                    ),
+            TabView::new(cx, &STATIC_LIST, |cx, item| match *item.get_ref(cx).unwrap() {
+                "Wrapping" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx| {
+                        wrapping(cx);
+                    },
+                ),
 
-                    "Alignment" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx| {
-                            alignment(cx);
-                        },
-                    ),
+                "Alignment" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx| {
+                        alignment(cx);
+                    },
+                ),
 
-                    "Alignment2" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx| {
-                            alignment2(cx);
-                        },
-                    ),
+                "Alignment2" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx| {
+                        alignment2(cx);
+                    },
+                ),
 
-                    "Alignment3" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx| {
-                            alignment3(cx);
-                        },
-                    ),
+                "Alignment3" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx| {
+                        alignment3(cx);
+                    },
+                ),
 
-                    "Alignment4" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx: &mut Context| {
-                            alignment4(cx);
-                        },
-                    ),
+                "Alignment4" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx: &mut Context| {
+                        alignment4(cx);
+                    },
+                ),
 
-                    "Alignment5" => TabPair::new(
-                        move |cx| {
-                            Label::new(cx, item).hoverable(false);
-                            Element::new(cx).class("indicator");
-                        },
-                        |cx: &mut Context| {
-                            alignment5(cx);
-                        },
-                    ),
+                "Alignment5" => TabPair::new(
+                    move |cx| {
+                        Label::new(cx, item).hoverable(false);
+                        Element::new(cx).class("indicator");
+                    },
+                    |cx: &mut Context| {
+                        alignment5(cx);
+                    },
+                ),
 
-                    _ => unreachable!(),
-                }
+                _ => unreachable!(),
             });
 
             // Textbox::new(cx, AppData::text.index(0))

--- a/examples/text_layout.rs
+++ b/examples/text_layout.rs
@@ -1,11 +1,8 @@
-use lazy_static::lazy_static;
 use vizia::prelude::*;
 use vizia_core::icons::ICON_MOON;
 
-lazy_static! {
-    pub static ref STATIC_LIST: Vec<&'static str> =
-        vec!["Wrapping", "Alignment", "Alignment2", "Alignment3", "Alignment4", "Alignment5"];
-}
+static STATIC_LIST: &[&str] =
+    &["Wrapping", "Alignment", "Alignment2", "Alignment3", "Alignment4", "Alignment5"];
 
 #[derive(Lens)]
 pub struct AppData {
@@ -30,10 +27,8 @@ fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         AppData { text: String::from("This is some text"), text2: String::from("سلام") }.build(cx);
         VStack::new(cx, |cx| {
-            TabView::new(
-                cx,
-                StaticLens::<Vec<&'static str>>::new(STATIC_LIST.as_ref()),
-                |cx, item| match *item.get_ref(cx).unwrap() {
+            TabView::new(cx, StaticLens::<&[&str]>::new(&STATIC_LIST), |cx, item| {
+                match *item.get_ref(cx).unwrap() {
                     "Wrapping" => TabPair::new(
                         move |cx| {
                             Label::new(cx, item).hoverable(false);
@@ -95,8 +90,8 @@ fn main() -> Result<(), ApplicationError> {
                     ),
 
                     _ => unreachable!(),
-                },
-            );
+                }
+            });
 
             // Textbox::new(cx, AppData::text.index(0))
             //     .on_submit(|ex, txt, _| ex.emit(AppEvent::SetText(0, txt.clone())));

--- a/examples/widget_gallery/Cargo.toml
+++ b/examples/widget_gallery/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vizia = {path = "../../../vizia"}
+vizia.workspace = true
 fern = "0.6.2"
 log = "0.4.19"
 chrono = "0.4.34"


### PR DESCRIPTION
Previously we were hardcoding `vizia` path in examples `widget_gallery` and `designer` and that caused cargo to fail compiling the project if we had renamed the vizia directory to something other then `vizia`... this PR aim to fix this problem.
we now have the `vizia` crate available as a workspace dependency, so we can use it directly in mentioned examples.

# Changes
- put some common package information in workspace and used them in all crates when possible.
- put vizia itself inside workspace dependencies so we can use it internally, without hardcoding vizia path.
- commented out 'reqwest' as its unused right now.

# Questions
- [x] I noticed most of `vizia_*` crates have their own `rust-version` set, should we deleted them? imo its unnecessary.
- [x] should we update `rust-version` to `1.80`? were already using `1.79` and updating it to `1.80` could give us some useful things like the new stabilized `LazyCell` and `LazyLock`, with these we can potentially remove the `lazy_static` crate from vizia.