### PR TITLE
Fix incorrect type used in `WindowEvent::SetSize` and related events.

### DIFF
--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -381,17 +381,20 @@ impl View for Window {
             }
 
             WindowEvent::SetSize(size) => {
-                let _ = self.window().request_inner_size(LogicalSize::new(size.width, size.height));
+                let _ =
+                    self.window().request_inner_size(PhysicalSize::new(size.width, size.height));
             }
 
             WindowEvent::SetMinSize(size) => {
-                self.window()
-                    .set_min_inner_size(size.map(|size| LogicalSize::new(size.width, size.height)));
+                self.window().set_min_inner_size(
+                    size.map(|size| PhysicalSize::new(size.width, size.height)),
+                );
             }
 
             WindowEvent::SetMaxSize(size) => {
-                self.window()
-                    .set_max_inner_size(size.map(|size| LogicalSize::new(size.width, size.height)));
+                self.window().set_max_inner_size(
+                    size.map(|size| PhysicalSize::new(size.width, size.height)),
+                );
             }
 
             WindowEvent::SetPosition(pos) => {


### PR DESCRIPTION
Fixes window size not being round-tripped correctly when being saved/loaded via `cx.window_size()` then `Application::inner_size()`. I believe it was previously working only on systems without DPI scaling; my windows desktop behaved as expected but macos laptop did not.

It seems to be the cause was that the `window_size()` method was retrieving the size from `cx.cache.get_bounds(parent_window)` which uses physical units rather than logical.