### PR TITLE
Fix ability to localize titles of popup windows.

### DIFF
--- a/crates/vizia_core/src/view/handle.rs
+++ b/crates/vizia_core/src/view/handle.rs
@@ -3,6 +3,7 @@ use std::{
     any::{Any, TypeId},
     marker::PhantomData,
 };
+use crate::context::LocalizationContext;
 
 /// A handle to a view which has been built into the tree.
 pub struct Handle<'a, V> {
@@ -36,6 +37,10 @@ impl<'a, V> DataContext for Handle<'a, V> {
         }
 
         None
+    }
+
+    fn as_context(&self) -> Option<LocalizationContext<'_>> {
+        Some(LocalizationContext::from_context(self.cx))
     }
 }
 

--- a/crates/vizia_core/src/view/handle.rs
+++ b/crates/vizia_core/src/view/handle.rs
@@ -1,9 +1,9 @@
+use crate::context::LocalizationContext;
 use crate::prelude::*;
 use std::{
     any::{Any, TypeId},
     marker::PhantomData,
 };
-use crate::context::LocalizationContext;
 
 /// A handle to a view which has been built into the tree.
 pub struct Handle<'a, V> {


### PR DESCRIPTION
adding this, to a popup window, causes a panic.
```rust
....
    .title(Localized::new("popup-new-project-title"))
```

stack trace from my app
```
thread 'main' panicked at D:\Users\Hydra\.cargo\git\checkouts\vizia-cb149d0347f9ee86\ced07cf\crates\vizia_core\src\localization\mod.rs:247:34:
Failed to get context
...
   5: vizia_core::localization::impl$5::get<vizia_core::view::handle::Handle<vizia_winit::window::Window> >
             at D:\Users\Hydra\.cargo\git\checkouts\vizia-cb149d0347f9ee86\ced07cf\crates\vizia_core\src\localization\mod.rs:247
```

after looking at the code, it's using the default implementation of `DataContext::as_context` on the `vizia_core::view::handle::Handle<vizia_winit::window::Window>` type (as per stacktrace).

after looking a bit more I found this in the impl of `WindowModifiders::title` for `Handle<'a, Window>`
```rust
let title = title.get(&self).to_string();
```

changing it to this seems to work, but I'm unfamiliar with the inner workings of Vizia.
```rust
let title = title.get(self.context()).to_string();
```

