### PR TITLE
Fix window visibility modifier

### DIFF
--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -725,8 +725,12 @@ impl WindowModifiers for Application {
         self
     }
 
-    fn visible(mut self, flag: bool) -> Self {
-        self.window_description.visible = flag;
+    fn visible(mut self, flag: impl Res<bool>) -> Self {
+        self.window_description.visible = flag.get(&self.cx.0);
+
+        flag.set_or_bind(&mut self.cx.0, Entity::root(), |cx, flag| {
+            cx.emit(WindowEvent::SetVisible(flag.get(cx)));
+        });
 
         self
     }

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -575,8 +575,9 @@ impl WindowModifiers for Handle<'_, Window> {
         self
     }
 
-    fn visible(mut self, flag: bool) -> Self {
+    fn visible(mut self, flag: impl Res<bool>) -> Self {
         let entity = self.entity();
+        let flag = flag.get(&self);
         if let Some(win_state) = self.context().windows.get_mut(&entity) {
             win_state.window_description.visible = flag
         }

--- a/crates/vizia_winit/src/window_modifiers.rs
+++ b/crates/vizia_winit/src/window_modifiers.rs
@@ -127,7 +127,7 @@ pub trait WindowModifiers {
     /// .visible(false)
     /// .run();
     /// ```
-    fn visible(self, flag: bool) -> Self;
+    fn visible(self, flag: impl Res<bool>) -> Self;
     /// Sets whether the window is transparent. Accepts a boolean value, or lens to a boolean value.
     ///
     /// # Example


### PR DESCRIPTION
Makes it possibile to set the window visibility via Lens:

```rust
#[derive(Lens)]
struct AppData {
    pub visible: bool,
}

fn main() {
    let _ = Application::new(|cx| {
        AppData { visible: true }.build(cx);
    })
    .visible(AppData::visible)
    .run();
}
```

Issue: When visible(false) is used, the window still pops up and hides then. This should be hidden and should not popup.