### PR TITLE
Make markdown (via comrak) an optional feature to save on deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ baseview = ["vizia_baseview"]
 x11 = ["vizia_winit?/x11", "vizia_core/x11"]
 wayland = ["vizia_winit?/wayland", "vizia_core/wayland"]
 accesskit = ["vizia_winit?/accesskit"]
+markdown = ["vizia_core/markdown"]
 
 [dependencies]
 vizia_core.workspace = true
@@ -324,10 +325,12 @@ path = "examples/timers.rs"
 [[example]]
 name = "markdown"
 path = "examples/views/markdown.rs"
+required-features = ["markdown"]
 
 [[example]]
 name = "rich_text"
 path = "examples/rich_text.rs"
+required-features = ["markdown"]
 
 [[example]]
 name = "multiwindow"

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 clipboard = ["copypasta"]
 x11 = ["copypasta?/x11"]
 wayland = ["copypasta?/wayland"]
+markdown = ["comrak"]
 
 [dependencies]
 vizia_derive.workspace = true
@@ -38,7 +39,7 @@ indexmap = "2.4"
 qfilter = "0.2"
 # reqwest = { version = "0.11.9", features = ["blocking"] }
 web-time = "1.1"
-comrak = { version = "0.33", default-features = false }
+comrak = { version = "0.33", default-features = false, optional = true }
 open = "5.2"
 sha2 = "0.10"
 

--- a/crates/vizia_core/src/views/markdown.rs
+++ b/crates/vizia_core/src/views/markdown.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "markdown")]
+
 use std::cell::RefCell;
 
 use comrak::nodes::{Ast, NodeValue};

--- a/crates/vizia_core/src/views/mod.rs
+++ b/crates/vizia_core/src/views/mod.rs
@@ -52,6 +52,7 @@ pub use image::*;
 pub use knob::{ArcTrack, Knob, KnobMode, TickKnob, Ticks};
 pub use label::Label;
 pub use list::*;
+#[cfg(feature = "markdown")]
 pub use markdown::*;
 pub use menu::*;
 pub use picklist::{PickList, ScrollList};


### PR DESCRIPTION
Previously, `cargo build --release`: 985M target/ ,~1m50s build, ~300 deps

Now (default): ~1m30s build, 650M target, ~270 deps.

Could make this enabled by default, but at the very least it's nice to be able to turn it off.