### PR TITLE
Upgrade comrak to 0.33

### DIFF
--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -38,7 +38,7 @@ indexmap = "2.4"
 qfilter = "0.2"
 # reqwest = { version = "0.11.9", features = ["blocking"] }
 web-time = "1.1"
-comrak = {version = "0.31", default-features = false }
+comrak = { version = "0.33", default-features = false }
 open = "5.2"
 sha2 = "0.10"
 


### PR DESCRIPTION
Build time for the `stylesheet` example improved slightly from ~24s to ~22s on my M1 pro machine. Dependency count is reduced from 264 to 250.