### PR TITLE
Fix init scaling + scaling for scroll

### DIFF
--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 
 use skia_safe::Surface;
+use vizia_storage::LayoutTreeIterator;
 use vizia_window::{WindowDescription, WindowPosition};
 
 use super::EventProxy;
@@ -252,6 +253,12 @@ impl BackendContext {
         self.0.needs_redraw(window_entity);
         self.0.style.needs_restyle(window_entity);
         self.0.style.needs_relayout();
+        let iter = LayoutTreeIterator::full(&self.0.tree);
+        for entity in iter {
+            self.0.style.needs_text_layout(entity);
+            self.0.style.needs_text_update(entity);
+            self.0.style.needs_restyle(entity);
+        }
     }
 
     pub fn process_timers(&mut self) {

--- a/crates/vizia_core/src/layout/node.rs
+++ b/crates/vizia_core/src/layout/node.rs
@@ -358,11 +358,11 @@ impl Node for Entity {
     }
 
     fn vertical_scroll(&self, store: &Self::Store) -> Option<f32> {
-        store.vertical_scroll.get(*self).copied()
+        store.vertical_scroll.get(*self).cloned().map(|val| store.logical_to_physical(val))
     }
 
     fn horizontal_scroll(&self, store: &Self::Store) -> Option<f32> {
-        store.horizontal_scroll.get(*self).copied()
+        store.horizontal_scroll.get(*self).cloned().map(|val| store.logical_to_physical(val))
     }
 
     fn min_vertical_gap(&self, store: &Self::Store) -> Option<Units> {

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -105,8 +105,8 @@ impl ScrollView {
             let scale_factor = handle.context().scale_factor();
             let top = ((data.inner_height - data.container_height) * data.scroll_y).round()
                 / scale_factor;
-            let left = ((data.inner_width - data.container_width) * data.scroll_x).round()
-                / scale_factor;
+            let left =
+                ((data.inner_width - data.container_width) * data.scroll_x).round() / scale_factor;
             handle.horizontal_scroll(-left.abs()).vertical_scroll(-top.abs());
         })
         .toggle_class(

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -276,7 +276,11 @@ impl ApplicationHandler<UserEvent> for Application {
                 .create_window(event_loop, Entity::root(), &self.window_description.clone(), None)
                 .expect("failed to create initial window");
             let custom_cursors = Arc::new(load_default_cursors(event_loop));
-            self.cx.add_main_window(Entity::root(), &self.window_description, 1.0);
+            self.cx.add_main_window(
+                Entity::root(),
+                &self.window_description,
+                main_window.scale_factor() as f32,
+            );
             self.cx.add_window(Window {
                 window: Some(main_window.clone()),
                 on_close: None,
@@ -331,7 +335,13 @@ impl ApplicationHandler<UserEvent> for Application {
                         owner,
                     )
                     .expect("Failed to create window");
-                self.cx.add_main_window(window_entity, &window_state.window_description, 1.0);
+
+                self.cx.add_main_window(
+                    window_entity,
+                    &window_state.window_description,
+                    window.scale_factor() as f32,
+                );
+
                 self.cx.0.with_current(window_entity, |cx| {
                     if let Some(content) = &window_state.content {
                         (content)(cx)
@@ -639,8 +649,6 @@ impl ApplicationHandler<UserEvent> for Application {
         if self.windows.len() != self.cx.0.windows.len() {
             for (window_entity, window_state) in self.cx.0.windows.clone().iter() {
                 if !self.window_ids.contains_key(window_entity) {
-                    self.cx.add_main_window(*window_entity, &window_state.window_description, 1.0);
-
                     let owner = window_state.owner.and_then(|entity| {
                         self.window_ids
                             .get(&entity)
@@ -655,6 +663,12 @@ impl ApplicationHandler<UserEvent> for Application {
                             owner,
                         )
                         .expect("Failed to create window");
+
+                    self.cx.add_main_window(
+                        *window_entity,
+                        &window_state.window_description,
+                        window.scale_factor() as f32,
+                    );
 
                     self.cx.0.with_current(*window_entity, |cx| {
                         if let Some(content) = &window_state.content {


### PR DESCRIPTION
Sets initial scale factor for windows and updates text when scale factor changes.

**Known Issues**
Scale factor is currently set per application rather than per window as it should be. Fixing this will require fixing layout so that it only runs per window rather than on the whole application. This itself will require a new iterator that skips sub-windows. This will be done in a follow-up PR.