### PR TITLE
Style system cleanup

### DIFF
--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -462,8 +462,7 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             if *code == Code::KeyS
                 && cx.modifiers == Modifiers::CTRL | Modifiers::SHIFT | Modifiers::ALT
             {
-                let mut result = vec![];
-                compute_matched_rules(cx, cx.hovered, &mut result);
+                let result = compute_matched_rules(cx, cx.hovered);
 
                 let entity = cx.hovered;
                 debug!("/* Matched rules for Entity: {} Parent: {:?} View: {} posx: {} posy: {} width: {} height: {}",

--- a/crates/vizia_core/src/storage/animatable_set.rs
+++ b/crates/vizia_core/src/storage/animatable_set.rs
@@ -575,7 +575,7 @@ where
     }
 
     /// Link an entity to some shared data.
-    pub(crate) fn link(&mut self, entity: Entity, rules: &[Rule]) -> bool {
+    pub(crate) fn link(&mut self, entity: Entity, rules: &[(Rule, u32)]) -> bool {
         let entity_index = entity.index();
 
         // Check if the entity already has some data
@@ -588,7 +588,7 @@ where
         }
 
         // Loop through matched rules and link to the first valid rule
-        for rule in rules.iter() {
+        for (rule, _) in rules {
             if let Some(shared_data_index) = self.shared_data.dense_idx(*rule) {
                 // If the entity doesn't have any previous shared data then create space for it
                 if entity_index >= self.inline_data.sparse.len() {

--- a/crates/vizia_core/src/storage/style_set.rs
+++ b/crates/vizia_core/src/storage/style_set.rs
@@ -322,7 +322,7 @@ where
     }
 
     /// Link an entity to some shared data.
-    pub(crate) fn link(&mut self, entity: Entity, rules: &[Rule]) -> bool {
+    pub(crate) fn link(&mut self, entity: Entity, rules: &[(Rule, u32)]) -> bool {
         let entity_index = entity.index();
 
         // Check if the entity already has some data
@@ -335,7 +335,7 @@ where
         }
 
         // Loop through matched rules and link to the first valid rule
-        for rule in rules.iter() {
+        for (rule, _) in rules {
             if let Some(shared_data_index) = self.shared_data.dense_idx(*rule) {
                 // If the entity doesn't have any previous shared data then create space for it
                 if entity_index >= self.inline_data.sparse.len() {

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -307,7 +307,7 @@ fn link_style_data(
     tree: &Tree<Entity>,
     entity: Entity,
     redraw_entities: &mut Vec<Entity>,
-    matched_rules: &[Rule],
+    matched_rules: &[(Rule, u32)],
 ) {
     let mut should_relayout = false;
     let mut should_redraw = false;
@@ -884,7 +884,7 @@ pub(crate) fn style_system(cx: &mut Context) {
                     &cx.tree,
                     entity,
                     &mut redraw_entities,
-                    &matched_rules.iter().map(|(rule, _)| *rule).collect::<Vec<_>>(),
+                    &matched_rules,
                 );
             }
         }

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -1,5 +1,4 @@
-use crate::{cache::CachedData, events::ViewHandler, prelude::*};
-use hashbrown::HashMap;
+use crate::{cache::CachedData, prelude::*};
 use vizia_storage::{LayoutParentIterator, TreeBreadthIterator};
 use vizia_style::{
     matches_selector,
@@ -16,21 +15,20 @@ use vizia_style::{
 
 /// A node used for style matching.
 #[derive(Clone)]
-pub(crate) struct Node<'s, 't, 'v> {
+pub(crate) struct Node<'s, 't> {
     entity: Entity,
     store: &'s Style,
     tree: &'t Tree<Entity>,
-    views: &'v HashMap<Entity, Box<dyn ViewHandler>>,
 }
 
-impl std::fmt::Debug for Node<'_, '_, '_> {
+impl std::fmt::Debug for Node<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.entity)
     }
 }
 
 /// Used for selector matching.
-impl Element for Node<'_, '_, '_> {
+impl Element for Node<'_, '_> {
     type Impl = Selectors;
 
     fn opaque(&self) -> OpaqueElement {
@@ -54,7 +52,6 @@ impl Element for Node<'_, '_, '_> {
             entity: parent,
             store: self.store,
             tree: self.tree,
-            views: self.views,
         })
     }
 
@@ -63,7 +60,6 @@ impl Element for Node<'_, '_, '_> {
             entity: parent,
             store: self.store,
             tree: self.tree,
-            views: self.views,
         })
     }
 
@@ -72,7 +68,6 @@ impl Element for Node<'_, '_, '_> {
             entity: parent,
             store: self.store,
             tree: self.tree,
-            views: self.views,
         })
     }
 
@@ -737,13 +732,12 @@ pub(crate) fn compute_matched_rules(cx: &Context, entity: Entity) -> Vec<(Rule, 
             &rule.selector,
             0,
             Some(&rule.hashes),
-            &Node { entity, store: &cx.style, tree: &cx.tree, views: &cx.views },
+            &Node { entity, store: &cx.style, tree: &cx.tree },
             &mut context,
         );
 
         if matches {
             matched_rules.push((*rule_id, rule.selector.specificity()));
-            //break;
         }
     }
 
@@ -879,7 +873,7 @@ pub(crate) fn style_system(cx: &mut Context) {
                     &cx.tree,
                     entity,
                     &mut redraw_entities,
-                    &matched_rules,
+                    matched_rules,
                 );
             }
         }


### PR DESCRIPTION
Removes all `clone` usage in the `style_system` function.

Some of these were there just to satisfy function signatures, but those functions are private and only used in this one place, so I just adapted their signature to work without cloning.

The idea of substituting the inner loop's `clone_from` with an index into the cache was brought up in discord. Implementing this allowed the logic to be simplified and no longer need complicated break/continue labels.

Also replaced a `sort_by_cached_key` with just `sort_by_key`. The key function here was just a cheap `u32` read so the caching overhead is unnecessary.

Performance change from all of these is minimal, but this function is our primary performance bottleneck so I guess every bit helps!