### PR TITLE
Add anchoring for popup window

### DIFF
--- a/crates/vizia_core/src/binding/res.rs
+++ b/crates/vizia_core/src/binding/res.rs
@@ -141,6 +141,9 @@ impl_res_simple!(TextDecorationLine);
 impl_res_clone!(TextStroke);
 impl_res_clone!(TextStrokeStyle);
 impl_res_simple!(Alignment);
+impl_res_simple!(WindowPosition);
+impl_res_simple!(Anchor);
+impl_res_simple!(AnchorTarget);
 
 impl<'i> ResGet<FontFamily<'i>> for FontFamily<'i> {
     fn get_ref<'a>(&'a self, _: &'a impl DataContext) -> Option<LensValue<'a, Self>> {

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use skia_safe::Surface;
 use vizia_storage::LayoutTreeIterator;
-use vizia_window::{WindowDescription, WindowPosition};
+use vizia_window::WindowDescription;
 
 use super::EventProxy;
 use crate::{cache::CachedData, prelude::*, systems::*};
@@ -96,10 +96,10 @@ impl BackendContext {
 
         self.0.tree.set_window(window_entity, true);
 
-        let physical_x = window_description.position.unwrap_or_default().x as f32 * dpi_factor;
-        let physical_y = window_description.position.unwrap_or_default().y as f32 * dpi_factor;
+        // let physical_x = window_description.position.unwrap_or_default().x as f32 * dpi_factor;
+        // let physical_y = window_description.position.unwrap_or_default().y as f32 * dpi_factor;
 
-        self.set_window_position(window_entity, physical_x, physical_y);
+        // self.set_window_position(window_entity, physical_x, physical_y);
     }
 
     /// Returns a reference to the [`Environment`] model.
@@ -150,16 +150,6 @@ impl BackendContext {
         let logical_height = self.0.style.physical_to_logical(physical_height);
         self.0.style.width.insert(window_entity, Units::Pixels(logical_width));
         self.0.style.height.insert(window_entity, Units::Pixels(logical_height));
-    }
-
-    pub fn set_window_position(&mut self, window_entity: Entity, physical_x: f32, physical_y: f32) {
-        let logical_x = self.0.style.physical_to_logical(physical_x);
-        let logical_y = self.0.style.physical_to_logical(physical_y);
-
-        if let Some(state) = self.0.windows.get_mut(&window_entity) {
-            state.position =
-                WindowPosition::new(logical_x.round() as u32, logical_y.round() as u32);
-        }
     }
 
     /// Temporarily sets the current entity, calls the provided closure, and then resets the current entity back to previous.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 
 use hashbrown::{HashMap, HashSet};
 use vizia_storage::{LayoutTreeIterator, TreeIterator};
-use vizia_window::WindowPosition;
 
 use crate::animation::{AnimId, Interpolator};
 use crate::cache::CachedData;
@@ -193,21 +192,6 @@ impl<'a> EventContext<'a> {
         if let Some(state) = self.windows.get_mut(&self.current) {
             state.should_close = true;
         }
-    }
-
-    pub fn window_position(&self) -> WindowPosition {
-        let parent_window = self.parent_window();
-        if let Some(state) = self.windows.get(&parent_window) {
-            return state.position;
-        }
-
-        WindowPosition::new(0, 0)
-    }
-
-    pub fn window_size(&self) -> WindowSize {
-        let parent_window = self.parent_window();
-        let bounds = self.cache.get_bounds(parent_window);
-        WindowSize::new(bounds.width() as u32, bounds.height() as u32)
     }
 
     /// Returns the [Entity] id associated with the given identifier.

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -23,7 +23,7 @@ use std::{
     sync::Arc,
 };
 use vizia_id::IdManager;
-use vizia_window::{WindowDescription, WindowPosition};
+use vizia_window::WindowDescription;
 
 #[cfg(all(feature = "clipboard", feature = "x11"))]
 use copypasta::ClipboardContext;
@@ -85,7 +85,6 @@ pub struct WindowState {
     pub owner: Option<Entity>,
     pub is_modal: bool,
     pub should_close: bool,
-    pub position: WindowPosition,
     pub content: Option<Arc<dyn Fn(&mut Context)>>,
 }
 

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -93,7 +93,7 @@ pub mod prelude {
     pub use vizia_id::GenerationalId;
     pub use vizia_input::{Code, Key, KeyChord, Modifiers, MouseButton, MouseButtonState};
     pub use vizia_storage::{Tree, TreeExt};
-    pub use vizia_window::{WindowButtons, WindowPosition, WindowSize};
+    pub use vizia_window::{Anchor, AnchorTarget, WindowButtons, WindowPosition, WindowSize};
 
     pub use super::style::*;
 

--- a/crates/vizia_window/src/window_description.rs
+++ b/crates/vizia_window/src/window_description.rs
@@ -26,6 +26,44 @@ impl From<WindowSize> for (u32, u32) {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Anchor {
+    #[default]
+    TopLeft,
+    TopCenter,
+    TopRight,
+    Left,
+    Center,
+    Right,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+}
+
+impl Anchor {
+    pub fn opposite(&self) -> Self {
+        match self {
+            Anchor::TopLeft => Anchor::BottomLeft,
+            Anchor::TopCenter => Anchor::BottomCenter,
+            Anchor::TopRight => Anchor::BottomRight,
+            Anchor::Left => Anchor::Right,
+            Anchor::Center => Anchor::Center,
+            Anchor::Right => Anchor::Left,
+            Anchor::BottomLeft => Anchor::TopLeft,
+            Anchor::BottomCenter => Anchor::TopCenter,
+            Anchor::BottomRight => Anchor::TopRight,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorTarget {
+    #[default]
+    Monitor,
+    Window,
+    Mouse,
+}
+
 /// The logical position of a window in screen coordinates.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowPosition {
@@ -73,6 +111,10 @@ pub struct WindowDescription {
     /// A scale factor applied on top of any DPI scaling, defaults to 1.0.
     pub user_scale_factor: f64,
     pub position: Option<WindowPosition>,
+    pub offset: Option<WindowPosition>,
+    pub anchor: Option<Anchor>,
+    pub anchor_target: Option<AnchorTarget>,
+    pub parent_anchor: Option<Anchor>,
     pub resizable: bool,
     pub minimized: bool,
     pub maximized: bool,
@@ -98,6 +140,10 @@ impl Default for WindowDescription {
             max_inner_size: None,
             user_scale_factor: 1.0,
             position: None,
+            offset: None,
+            anchor: None,
+            anchor_target: None,
+            parent_anchor: None,
             resizable: true,
             minimized: true,
             maximized: false,

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -1,6 +1,7 @@
 use crate::window_modifiers::WindowModifiers;
 use glutin::context::GlProfile;
 use vizia_core::context::TreeProps;
+use vizia_window::AnchorTarget;
 #[cfg(target_os = "windows")]
 use winit::platform::windows::WindowExtWindows;
 #[cfg(target_os = "windows")]
@@ -412,6 +413,7 @@ impl Window {
             );
             cx.tree.set_window(cx.current(), true);
         })
+        .anchor_target(AnchorTarget::Window)
         .lock_focus_to_within()
     }
 }
@@ -475,15 +477,7 @@ impl View for Window {
             }
 
             WindowEvent::SetPosition(pos) => {
-                let parent_window_position = if cx.current() == Entity::root() {
-                    WindowPosition::new(0, 0)
-                } else {
-                    cx.window_position()
-                };
-                self.window().set_outer_position(LogicalPosition::new(
-                    parent_window_position.x + pos.x,
-                    parent_window_position.y + pos.y,
-                ));
+                self.window().set_outer_position(LogicalPosition::new(pos.x, pos.y));
                 meta.consume();
             }
 
@@ -617,6 +611,49 @@ impl WindowModifiers for Handle<'_, Window> {
         let pos = Some(position.get(&self).into());
         if let Some(win_state) = self.context().windows.get_mut(&entity) {
             win_state.window_description.position = pos;
+        }
+
+        self
+    }
+
+    fn offset<P: Into<vizia_window::WindowPosition>>(mut self, offset: impl Res<P>) -> Self {
+        let entity = self.entity();
+        let offset = Some(offset.get(&self).into());
+        if let Some(win_state) = self.context().windows.get_mut(&entity) {
+            win_state.window_description.offset = offset;
+        }
+
+        self
+    }
+
+    fn anchor<P: Into<vizia_window::Anchor>>(mut self, anchor: impl Res<P>) -> Self {
+        let entity = self.entity();
+        let anchor = Some(anchor.get(&self).into());
+        if let Some(win_state) = self.context().windows.get_mut(&entity) {
+            win_state.window_description.anchor = anchor;
+        }
+
+        self
+    }
+
+    fn anchor_target<P: Into<vizia_window::AnchorTarget>>(
+        mut self,
+        anchor_target: impl Res<P>,
+    ) -> Self {
+        let entity = self.entity();
+        let anchor_target = Some(anchor_target.get(&self).into());
+        if let Some(win_state) = self.context().windows.get_mut(&entity) {
+            win_state.window_description.anchor_target = anchor_target;
+        }
+
+        self
+    }
+
+    fn parent_anchor<P: Into<Anchor>>(mut self, parent_anchor: impl Res<P>) -> Self {
+        let entity = self.entity();
+        let parent_anchor = Some(parent_anchor.get(&self).into());
+        if let Some(win_state) = self.context().windows.get_mut(&entity) {
+            win_state.window_description.parent_anchor = parent_anchor;
         }
 
         self

--- a/crates/vizia_winit/src/window_modifiers.rs
+++ b/crates/vizia_winit/src/window_modifiers.rs
@@ -1,5 +1,5 @@
 use vizia_core::{binding::Res, context::EventContext};
-use vizia_window::{WindowButtons, WindowPosition, WindowSize};
+use vizia_window::{Anchor, AnchorTarget, WindowButtons, WindowPosition, WindowSize};
 
 /// Modifiers for setting the properties of a window.
 pub trait WindowModifiers {
@@ -76,6 +76,15 @@ pub trait WindowModifiers {
     /// .run();
     /// ```
     fn position<P: Into<WindowPosition>>(self, position: impl Res<P>) -> Self;
+
+    fn offset<P: Into<WindowPosition>>(self, offset: impl Res<P>) -> Self;
+
+    fn anchor<P: Into<Anchor>>(self, anchor: impl Res<P>) -> Self;
+
+    fn anchor_target<P: Into<AnchorTarget>>(self, anchor_target: impl Res<P>) -> Self;
+
+    fn parent_anchor<P: Into<Anchor>>(self, anchor: impl Res<P>) -> Self;
+
     /// Sets whether the window can be resized. Accepts a boolean value, or lens to a boolean value.
     ///
     /// # Example

--- a/examples/popup_window.rs
+++ b/examples/popup_window.rs
@@ -62,7 +62,9 @@ fn main() -> Result<(), ApplicationError> {
                 })
                 .title("Set color...")
                 .inner_size((400, 200))
-                .position((500, 100));
+                .anchor(Anchor::TopRight)
+                .parent_anchor(Anchor::TopLeft)
+                .anchor_target(AnchorTarget::Mouse);
             }
         });
 
@@ -74,5 +76,6 @@ fn main() -> Result<(), ApplicationError> {
         .background_color(AppData::color);
     })
     .title("Main")
+    .position((100, 100))
     .run()
 }


### PR DESCRIPTION
This PR adds 4 new window modifiers for positioning popup windows.

## Anchor and Parent Anchor
Determines the anchor point for the window and its parent (determined by anchor target). There are nine possible anchor positions: top-left, top-center, top-right, left, center, right, bottom-left, bottom-center, bottom-right.

If the anchor and parent anchor are both the same, e.g. top-left, then the window will be placed within its parent, e.g. top-left. If the anchor positions are opposite, e.g. top-left and bottom-left, then the window will be placed outside of its parent.

If only the anchor position is set then the parent anchor will be set to the same. Therefore setting only the anchor will position the window within its parent.

If only the parent anchor position is set then the anchor position will be set to the opposite. Therefore setting only the parent anchor will position the window outside of its parent (if possible). This only applies when the anchor target is set to a parent window. A window cannot be placed outside of the monitor and for a mouse position the parent anchor acts as a single point.

## Anchor Target
Determines what is used as the parent anchor. The monitor, window, or mouse position.

## Offset
Applies an offset to the window after it's been positioned by its anchor and parent anchor.

These four properties determine the window position, so if the window position is set explicitly, with the position window modifier, it will override these options. This is useful for when you have a window position saved/loaded within some external config file.