### PR TITLE
Add basic support for IME

### DIFF
--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -13,7 +13,7 @@ use crate::events::{TimedEvent, TimedEventHandle, TimerState, ViewHandler};
 use crate::prelude::*;
 use crate::resource::ResourceManager;
 use crate::tree::{focus_backward, focus_forward, is_navigatable};
-use vizia_input::MouseState;
+use vizia_input::{ImeState, MouseState};
 
 use skia_safe::Matrix;
 
@@ -76,6 +76,7 @@ pub struct EventContext<'a> {
     pub(crate) text_context: &'a mut TextContext,
     pub(crate) modifiers: &'a Modifiers,
     pub(crate) mouse: &'a MouseState<Entity>,
+    pub(crate) ime_state: &'a mut ImeState,
     pub(crate) event_queue: &'a mut VecDeque<Event>,
     pub(crate) event_schedule: &'a mut BinaryHeap<TimedEvent>,
     pub(crate) next_event_id: &'a mut usize,
@@ -129,6 +130,7 @@ impl<'a> EventContext<'a> {
             text_context: &mut cx.text_context,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
+            ime_state: &mut cx.ime_state,
             event_queue: &mut cx.event_queue,
             event_schedule: &mut cx.event_schedule,
             next_event_id: &mut cx.next_event_id,
@@ -163,6 +165,7 @@ impl<'a> EventContext<'a> {
             text_context: &mut cx.text_context,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
+            ime_state: &mut cx.ime_state,
             event_queue: &mut cx.event_queue,
             event_schedule: &mut cx.event_schedule,
             next_event_id: &mut cx.next_event_id,

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -13,7 +13,7 @@ use crate::events::{TimedEvent, TimedEventHandle, TimerState, ViewHandler};
 use crate::prelude::*;
 use crate::resource::ResourceManager;
 use crate::tree::{focus_backward, focus_forward, is_navigatable};
-use vizia_input::{ImeState, MouseState};
+use vizia_input::MouseState;
 
 use skia_safe::Matrix;
 
@@ -76,7 +76,6 @@ pub struct EventContext<'a> {
     pub(crate) text_context: &'a mut TextContext,
     pub(crate) modifiers: &'a Modifiers,
     pub(crate) mouse: &'a MouseState<Entity>,
-    pub(crate) ime_state: &'a mut ImeState,
     pub(crate) event_queue: &'a mut VecDeque<Event>,
     pub(crate) event_schedule: &'a mut BinaryHeap<TimedEvent>,
     pub(crate) next_event_id: &'a mut usize,
@@ -130,7 +129,6 @@ impl<'a> EventContext<'a> {
             text_context: &mut cx.text_context,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
-            ime_state: &mut cx.ime_state,
             event_queue: &mut cx.event_queue,
             event_schedule: &mut cx.event_schedule,
             next_event_id: &mut cx.next_event_id,
@@ -165,7 +163,6 @@ impl<'a> EventContext<'a> {
             text_context: &mut cx.text_context,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
-            ime_state: &mut cx.ime_state,
             event_queue: &mut cx.event_queue,
             event_schedule: &mut cx.event_schedule,
             next_event_id: &mut cx.next_event_id,

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -52,7 +52,7 @@ use crate::{cache::CachedData, resource::ImageOrSvg};
 use crate::prelude::*;
 use crate::resource::ResourceManager;
 use crate::text::TextContext;
-use vizia_input::MouseState;
+use vizia_input::{ImeState, MouseState};
 use vizia_storage::{ChildIterator, LayoutTreeIterator};
 
 static DEFAULT_LAYOUT: &str = include_str!("../../resources/themes/default_layout.css");
@@ -137,6 +137,7 @@ pub struct Context {
 
     pub ignore_default_theme: bool,
     pub window_has_focus: bool,
+    pub ime_state: ImeState,
 
     pub(crate) drop_data: Option<DropData>,
 }
@@ -222,6 +223,8 @@ impl Context {
 
             ignore_default_theme: false,
             window_has_focus: true,
+
+            ime_state: Default::default(),
 
             drop_data: None,
         };
@@ -889,6 +892,10 @@ impl Context {
         }
 
         self.style.needs_restyle(self.current);
+    }
+
+    pub fn set_ime_state(&mut self, new_state: ImeState) {
+        self.ime_state = new_state;
     }
 }
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -615,6 +615,18 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
         WindowEvent::CharInput(_) => {
             meta.target = cx.focused;
         }
+        WindowEvent::ImeActivate(_) => {
+            meta.target = cx.focused;
+        }
+        WindowEvent::ImeCommit(_) => {
+            meta.target = cx.focused;
+        }
+        WindowEvent::ImePreedit(_, _) => {
+            meta.target = cx.focused;
+        }
+        WindowEvent::SetImeCursorArea(_, _) => {
+            meta.target = cx.focused;
+        }
         WindowEvent::WindowFocused(is_focused) => {
             if *is_focused {
                 cx.set_focus_pseudo_classes(cx.focused, true, true);

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -514,6 +514,10 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             }
 
             if *code == Code::Tab {
+                if cx.ime_state.is_composing() {
+                    return;
+                }
+
                 let lock_focus_to = cx.tree.lock_focus_within(cx.focused);
                 if cx.modifiers.shift() {
                     let prev_focused = if let Some(prev_focused) =

--- a/crates/vizia_core/src/text/mod.rs
+++ b/crates/vizia_core/src/text/mod.rs
@@ -15,3 +15,6 @@ pub use selection::*;
 
 pub mod backspace;
 pub use backspace::*;
+
+pub mod preedit_backup;
+pub use preedit_backup::*;

--- a/crates/vizia_core/src/text/preedit_backup.rs
+++ b/crates/vizia_core/src/text/preedit_backup.rs
@@ -1,0 +1,24 @@
+use super::Selection;
+
+#[derive(Debug, Clone)]
+pub struct PreeditBackup {
+    pub prev_preedit: String,
+    pub original_selection: Selection,
+}
+
+impl PreeditBackup {
+    pub fn new(prev_preedit: String, original_selection: Selection) -> Self {
+        Self { prev_preedit, original_selection }
+    }
+
+    pub fn prev_selection(&self) -> Selection {
+        let min = self.original_selection.min();
+        let len = self.prev_preedit.len();
+        let active = min + len;
+        Selection { anchor: min, active, h_pos: None }
+    }
+
+    pub fn set_prev_preedit(&mut self, preedit: String) {
+        self.prev_preedit = preedit;
+    }
+}

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -383,10 +383,6 @@ where
     ///
     /// [`update_preedit`]: Textbox::update_preedit
     fn move_cursor(&mut self, cx: &mut EventContext, movement: Movement, selection: bool) {
-        if self.preedit_backup.is_some() {
-            return;
-        }
-
         if let Some(text) = cx.style.text.get_mut(cx.current) {
             if let Some(paragraph) = cx.text_context.text_paragraphs.get(cx.current) {
                 let new_selection =

--- a/crates/vizia_core/src/window/window_event.rs
+++ b/crates/vizia_core/src/window/window_event.rs
@@ -76,6 +76,14 @@ pub enum WindowEvent {
     WindowFocused(bool),
     /// Emitted when a character is typed.
     CharInput(char),
+    /// Emitted when the input method (IME) is activated or deactivated.
+    ImeActivate(bool),
+    /// Emitted when an input method (IME) commits a string.
+    ImeCommit(String),
+    /// Emitted when an input method (IME) changes the preedit string.
+    ImePreedit(String, Option<(usize, usize)>),
+    /// Emitted when the input method (IME) area needs to be updated.
+    SetImeCursorArea((u32, u32), (u32, u32)),
     /// Emitted when a keyboard key is pressed.
     KeyDown(Code, Option<Key>),
     /// Emitted when a keyboard key is released.

--- a/crates/vizia_input/src/ime.rs
+++ b/crates/vizia_input/src/ime.rs
@@ -1,15 +1,10 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum ImeState {
+    #[default]
     Inactive,
     StartComposition,
     Composing { preedit: Option<String>, cursor_pos: Option<(usize, usize)> },
     EndComposition,
-}
-
-impl Default for ImeState {
-    fn default() -> Self {
-        ImeState::Inactive
-    }
 }
 
 impl ImeState {

--- a/crates/vizia_input/src/ime.rs
+++ b/crates/vizia_input/src/ime.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum ImeState {
+    Inactive,
+    StartComposition,
+    Composing { preedit: Option<String>, cursor_pos: Option<(usize, usize)> },
+    EndComposition,
+}
+
+impl Default for ImeState {
+    fn default() -> Self {
+        ImeState::Inactive
+    }
+}
+
+impl ImeState {
+    pub fn is_inactive(&self) -> bool {
+        matches!(self, ImeState::Inactive)
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self, ImeState::StartComposition | ImeState::Composing { .. })
+    }
+
+    pub fn is_composing(&self) -> bool {
+        matches!(self, ImeState::Composing { .. })
+    }
+
+    pub fn get_preedit_text(&self) -> Option<&str> {
+        if let ImeState::Composing { preedit, .. } = self {
+            preedit.as_deref()
+        } else {
+            None
+        }
+    }
+
+    pub fn get_cursor_pos(&self) -> Option<(usize, usize)> {
+        if let ImeState::Composing { cursor_pos, .. } = self {
+            *cursor_pos
+        } else {
+            None
+        }
+    }
+}

--- a/crates/vizia_input/src/ime.rs
+++ b/crates/vizia_input/src/ime.rs
@@ -3,7 +3,10 @@ pub enum ImeState {
     #[default]
     Inactive,
     StartComposition,
-    Composing { preedit: Option<String>, cursor_pos: Option<(usize, usize)> },
+    Composing {
+        preedit: Option<String>,
+        cursor_pos: Option<(usize, usize)>,
+    },
     EndComposition,
 }
 

--- a/crates/vizia_input/src/lib.rs
+++ b/crates/vizia_input/src/lib.rs
@@ -1,8 +1,10 @@
 mod chord;
+mod ime;
 mod modifiers;
 mod mouse;
 
 pub use chord::*;
+pub use ime::*;
 pub use modifiers::*;
 pub use mouse::*;
 

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -552,6 +552,12 @@ impl View for Window {
                 });
             }
 
+            WindowEvent::SetImeCursorArea(position, size) => {
+                let position = PhysicalPosition::new(position.0 as i32, position.1 as i32);
+                let size = PhysicalSize::new(size.0 as u32, size.1 as u32);
+                self.window().set_ime_cursor_area(position, size);
+            }
+
             _ => {}
         })
     }

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -554,7 +554,7 @@ impl View for Window {
 
             WindowEvent::SetImeCursorArea(position, size) => {
                 let position = PhysicalPosition::new(position.0 as i32, position.1 as i32);
-                let size = PhysicalSize::new(size.0 as u32, size.1 as u32);
+                let size = PhysicalSize::new(size.0, size.1);
                 self.window().set_ime_cursor_area(position, size);
             }
 


### PR DESCRIPTION
Tested on Windows 10 and 11 with Microsoft IME (Chinese and Japanese).  

There might be some issues with the Japanese IME, but I’m not familiar with how it works, so I’m not sure if it functions correctly.  

Currently, the IME window does not follow the cursor movement—it is only positioned at the textbox. I will address this issue in a separate PR.