### PR TITLE
Fix clipboard feature not working when `x11` feature is disabled.

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -25,10 +25,8 @@ use std::{
 use vizia_id::IdManager;
 use vizia_window::WindowDescription;
 
-#[cfg(all(feature = "clipboard", feature = "x11"))]
-use copypasta::ClipboardContext;
 #[cfg(feature = "clipboard")]
-use copypasta::{nop_clipboard::NopClipboardContext, ClipboardProvider};
+use copypasta::{nop_clipboard::NopClipboardContext, ClipboardContext, ClipboardProvider};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 
 pub use access::*;
@@ -207,14 +205,11 @@ impl Context {
 
             #[cfg(feature = "clipboard")]
             clipboard: {
-                #[cfg(feature = "x11")]
                 if let Ok(context) = ClipboardContext::new() {
                     Box::new(context)
                 } else {
                     Box::new(NopClipboardContext::new().unwrap())
                 }
-                #[cfg(not(feature = "x11"))]
-                Box::new(NopClipboardContext::new().unwrap())
             },
             click_time: Instant::now(),
             clicks: 0,


### PR DESCRIPTION
Clipboard wasn't working on my Windows machine. I did not test it on others, but I think this will fix the problem.

We already forward the `x11` and `wayland` feature flags to `copypasta` in our [Cargo.toml](https://github.com/vizia/vizia/blob/main/crates/vizia_core/Cargo.toml#L11), so (I think) the appropriate implementation should be automatically selected for us by the `copypasta` crate itself. See their [feature handling code](https://github.com/alacritty/copypasta/blob/master/src/lib.rs#L59) for reference.