### PR TITLE
Improve Slider view

### DIFF
--- a/crates/vizia_core/resources/themes/dark_theme.css
+++ b/crates/vizia_core/resources/themes/dark_theme.css
@@ -735,8 +735,7 @@ scrollview.v-scroll > scrollbar.vertical:active > .thumb {
 /* SLIDER */
 
 slider {
-    background-color: #51afef20;
-    corner-radius: 3px;
+    corner-radius: 2px;
 }
 
 slider:focus-visible {
@@ -746,9 +745,14 @@ slider:focus-visible {
     corner-radius: 4px;
 }
 
+slider .track {
+    background-color: #51afef20;
+    corner-radius: 2px;
+}
+
 slider .active {
     background-color: #51afef80;
-    corner-radius: 3px;
+    corner-radius: 2px;
 }
 
 slider .thumb {

--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -589,14 +589,30 @@ scrollbar.vertical .thumb {
 /* SLIDER */
 
 slider {
-    height: 5px;
+    height: 16px;
     width: 1s;
+    alignment: left;
     corner-radius: 50%;
 }
 
 slider.vertical {
     height: 1s;
-    width: 5px;
+    width: 16px;
+    alignment: bottom-center;
+}
+
+slider .track {
+    width: 1s;
+    height: 4px;
+    corner-radius: 50%;
+    alignment: left;
+}
+
+slider.vertical .track {
+    width: 4px;
+    height: 1s;
+    corner-radius: 50%;
+    alignment: bottom-center;
 }
 
 slider .thumb {

--- a/crates/vizia_core/resources/themes/light_theme.css
+++ b/crates/vizia_core/resources/themes/light_theme.css
@@ -794,7 +794,6 @@ scrollview.v-scroll > scrollbar.vertical:active > .thumb {
 
 /* SLIDER */
 slider * {
-    background-color: #51afef20;
     corner-radius: 2px;
 }
 
@@ -803,6 +802,11 @@ slider:focus-visible {
     outline-color: #51afef;
     outline-offset: 3px;
     corner-radius: 4px;
+}
+
+slider .track {
+    background-color: #51afef20;
+    corner-radius: 2px;
 }
 
 slider .active {

--- a/crates/vizia_core/src/binding/res.rs
+++ b/crates/vizia_core/src/binding/res.rs
@@ -144,6 +144,7 @@ impl_res_simple!(Alignment);
 impl_res_simple!(WindowPosition);
 impl_res_simple!(Anchor);
 impl_res_simple!(AnchorTarget);
+impl_res_clone!(std::ops::Range<f32>);
 
 impl<'i> ResGet<FontFamily<'i>> for FontFamily<'i> {
     fn get_ref<'a>(&'a self, _: &'a impl DataContext) -> Option<LensValue<'a, Self>> {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -199,6 +199,35 @@ impl<'a> EventContext<'a> {
         self.entity_identifiers.get(id).cloned()
     }
 
+    /// Returns the descendant [Entity] id, of the current view, with the given element name if it exists.
+    pub fn get_entity_by_element_id(&self, element: &str) -> Option<Entity> {
+        let descendants = LayoutTreeIterator::subtree(self.tree, self.current);
+        for descendant in descendants {
+            if let Some(id) = self.views.get(&descendant).and_then(|view| view.element()) {
+                if id == element {
+                    return Some(descendant);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Returns the descendant [Entity] ids, of the current view, with the given class name.
+    pub fn get_entities_by_class(&self, class: &str) -> Vec<Entity> {
+        let mut entities = Vec::new();
+        let descendants = LayoutTreeIterator::subtree(self.tree, self.current);
+        for descendant in descendants {
+            if let Some(class_list) = self.style.classes.get(descendant) {
+                if class_list.contains(class) {
+                    entities.push(descendant);
+                }
+            }
+        }
+
+        entities
+    }
+
     /// Returns the [Entity] id of the current view.
     pub fn current(&self) -> Entity {
         self.current

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -4,22 +4,11 @@ use accesskit::ActionData;
 
 use crate::prelude::*;
 
-#[derive(Debug)]
-enum SliderEventInternal {
-    SetThumbSize(f32, f32),
-    SetRange(Range<f32>),
-    SetKeyboardFraction(f32),
-}
-
 /// Internal data used by the slider.
 #[derive(Clone, Debug, Default, Data)]
 pub struct SliderDataInternal {
     /// The orientation of the slider.
     pub orientation: Orientation,
-    /// The size of the slider.
-    pub size: f32,
-    /// The size of the thumb of the slider.
-    pub thumb_size: f32,
     /// The range of the slider.
     pub range: Range<f32>,
     /// The step of the slider.
@@ -33,13 +22,10 @@ pub struct SliderDataInternal {
 /// The slider control consists of three main parts, a **thumb** element which can be moved between the extremes of a linear **track**,
 /// and an **active** element which fills the slider to indicate the current value.
 ///
-/// The slider orientation is determined by its dimensions. If the slider width is greater than the height then the thumb
-/// moves horizontally, whereas if the slider height is greater than the width the thumb moves vertically.
-///
 /// # Examples
 ///
 /// ## Basic Slider
-/// In the following example, a slider is bound to a value. The `on_changing` callback is used to send an event to mutate the
+/// In the following example, a slider is bound to a value. The `on_change` callback is used to send an event to mutate the
 /// bound value when the slider thumb is moved, or if the track is clicked on.
 /// ```
 /// # use vizia_core::prelude::*;
@@ -52,8 +38,8 @@ pub struct SliderDataInternal {
 /// # impl Model for AppData {}
 /// # AppData::default().build(cx);
 /// Slider::new(cx, AppData::value)
-///     .on_changing(|cx, value| {
-///         debug!("Slider on_changing: {}", value);
+///     .on_change(|cx, value| {
+///         debug!("Slider on_change: {}", value);
 ///     });
 /// ```
 ///
@@ -70,8 +56,8 @@ pub struct SliderDataInternal {
 /// # AppData::default().build(cx);
 /// HStack::new(cx, |cx|{
 ///     Slider::new(cx, AppData::value)
-///         .on_changing(|cx, value| {
-///             debug!("Slider on_changing: {}", value);
+///         .on_change(|cx, value| {
+///             debug!("Slider on_change: {}", value);
 ///         });
 ///     Label::new(cx, AppData::value.map(|val| format!("{:.2}", val)));
 /// });
@@ -81,7 +67,7 @@ pub struct Slider<L: Lens> {
     lens: L,
     is_dragging: bool,
     internal: SliderDataInternal,
-    on_changing: Option<Box<dyn Fn(&mut EventContext, f32)>>,
+    on_change: Option<Box<dyn Fn(&mut EventContext, f32)>>,
 }
 
 impl<L> Slider<L>
@@ -90,7 +76,6 @@ where
 {
     /// Creates a new slider bound to the value targeted by the lens.
     ///
-    /// # Example
     /// ```
     /// # use vizia_core::prelude::*;
     /// # use vizia_derive::*;
@@ -102,8 +87,8 @@ where
     /// # impl Model for AppData {}
     /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
-    ///     .on_changing(|cx, value| {
-    ///         debug!("Slider on_changing: {}", value);
+    ///     .on_change(|cx, value| {
+    ///         debug!("Slider on_change: {}", value);
     ///     });
     /// ```
     pub fn new(cx: &mut Context, lens: L) -> Handle<Self> {
@@ -113,80 +98,67 @@ where
 
             internal: SliderDataInternal {
                 orientation: Orientation::Horizontal,
-                thumb_size: 0.0,
-                size: 0.0,
                 range: 0.0..1.0,
                 step: 0.01,
                 keyboard_fraction: 0.1,
             },
 
-            on_changing: None,
+            on_change: None,
         }
         .build(cx, move |cx| {
             Binding::new(cx, Slider::<L>::internal, move |cx, slider_data| {
-                ZStack::new(cx, move |cx| {
+                // Track
+                HStack::new(cx, move |cx| {
                     let slider_data = slider_data.get(cx);
-                    let thumb_size = slider_data.thumb_size;
                     let orientation = slider_data.orientation;
-                    let size = slider_data.size;
                     let range = slider_data.range;
 
                     // Active track
-                    Element::new(cx).class("active").bind(lens, move |handle, value| {
+                    VStack::new(cx, |cx| {
+                        // Thumb
+                        Element::new(cx).class("thumb").bind(lens, move |handle, value| {
+                            let val = value.get(&handle).clamp(range.start, range.end);
+                            let normal_val = (val - range.start) / (range.end - range.start);
+                            if orientation == Orientation::Horizontal {
+                                handle.translate((
+                                    Percentage(100.0 * (1.0 - normal_val)),
+                                    Pixels(0.0),
+                                ));
+                            } else {
+                                handle.translate((
+                                    Pixels(0.0),
+                                    Percentage(-100.0 * (1.0 - normal_val)),
+                                ));
+                            }
+                        });
+                    })
+                    .class("active")
+                    .bind(lens, move |handle, value| {
                         let val = value.get(&handle).clamp(range.start, range.end);
-
                         let normal_val = (val - range.start) / (range.end - range.start);
-                        let min = thumb_size / size;
-                        let max = 1.0;
-                        let dx = min + normal_val * (max - min);
 
                         if orientation == Orientation::Horizontal {
                             handle
                                 .height(Stretch(1.0))
-                                .left(Pixels(0.0))
-                                .right(Stretch(1.0))
-                                .width(Percentage(dx * 100.0));
+                                .width(Percentage(normal_val * 100.0))
+                                .layout_type(LayoutType::Row)
+                                .alignment(Alignment::Right);
                         } else {
                             handle
                                 .width(Stretch(1.0))
-                                .top(Stretch(1.0))
-                                .bottom(Pixels(0.0))
-                                .height(Percentage(dx * 100.0));
+                                .height(Percentage(normal_val * 100.0))
+                                .layout_type(LayoutType::Column)
+                                .alignment(Alignment::TopCenter);
                         }
                     });
-
-                    // Thumb
-                    Element::new(cx)
-                        .class("thumb")
-                        .on_geo_changed(|cx, geo| {
-                            if geo.contains(GeoChanged::WIDTH_CHANGED)
-                                || geo.contains(GeoChanged::HEIGHT_CHANGED)
-                            {
-                                let bounds = cx.bounds();
-                                cx.emit(SliderEventInternal::SetThumbSize(bounds.w, bounds.h));
-                            }
-                        })
-                        .bind(lens, move |handle, value| {
-                            let val = value.get(&handle).clamp(range.start, range.end);
-                            let normal_val = (val - range.start) / (range.end - range.start);
-                            let px = normal_val * (1.0 - (thumb_size / size));
-                            if orientation == Orientation::Horizontal {
-                                handle
-                                    .right(Stretch(1.0))
-                                    .top(Stretch(1.0))
-                                    .bottom(Stretch(1.0))
-                                    .left(Percentage(100.0 * px));
-                            } else {
-                                handle
-                                    .top(Stretch(1.0))
-                                    .left(Stretch(1.0))
-                                    .right(Stretch(1.0))
-                                    .bottom(Percentage(100.0 * px));
-                            }
-                        });
-                });
+                })
+                .class("track");
             });
         })
+        .toggle_class(
+            "vertical",
+            Self::internal.map(|slider_data| slider_data.orientation == Orientation::Vertical),
+        )
         .role(Role::Slider)
         .numeric_value(lens.map(|val| (*val as f64 * 100.0).round() / 100.0))
         .text_value(lens.map(|val| {
@@ -209,43 +181,7 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
     }
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
-        event.map(|slider_event_internal, _| match slider_event_internal {
-            SliderEventInternal::SetThumbSize(width, height) => match self.internal.orientation {
-                Orientation::Horizontal => {
-                    self.internal.thumb_size = *width;
-                }
-
-                Orientation::Vertical => {
-                    self.internal.thumb_size = *height;
-                }
-            },
-
-            SliderEventInternal::SetRange(range) => {
-                let mut range = range.clone();
-                range.end = range.end.max(range.start);
-                self.internal.range = range;
-            }
-
-            SliderEventInternal::SetKeyboardFraction(keyboard_fraction) => {
-                self.internal.keyboard_fraction = *keyboard_fraction;
-            }
-        });
-
         event.map(|window_event, _| match window_event {
-            WindowEvent::GeometryChanged(_) => {
-                let current = cx.current();
-                let width = cx.cache.get_width(current);
-                let height = cx.cache.get_height(current);
-
-                if width >= height {
-                    self.internal.orientation = Orientation::Horizontal;
-                    self.internal.size = width;
-                } else {
-                    self.internal.orientation = Orientation::Vertical;
-                    self.internal.size = height;
-                }
-            }
-
             WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
                 if !cx.is_disabled() {
                     self.is_dragging = true;
@@ -255,7 +191,11 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                         cx.set_pointer_events(false);
                     });
 
-                    let thumb_size = self.internal.thumb_size;
+                    let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                    let thumb_size = match self.internal.orientation {
+                        Orientation::Horizontal => cx.cache.get_width(thumb),
+                        Orientation::Vertical => cx.cache.get_height(thumb),
+                    };
                     let min = self.internal.range.start;
                     let max = self.internal.range.end;
                     let step = self.internal.step;
@@ -285,10 +225,10 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                     val = step * (val / step).ceil();
                     val = val.clamp(min, max);
 
-                    if let Some(callback) = self.on_changing.take() {
+                    if let Some(callback) = self.on_change.take() {
                         (callback)(cx, val);
 
-                        self.on_changing = Some(callback);
+                        self.on_change = Some(callback);
                     }
                 }
             }
@@ -304,7 +244,11 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
 
             WindowEvent::MouseMove(x, y) => {
                 if self.is_dragging {
-                    let thumb_size = self.internal.thumb_size;
+                    let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                    let thumb_size = match self.internal.orientation {
+                        Orientation::Horizontal => cx.cache.get_width(thumb),
+                        Orientation::Vertical => cx.cache.get_height(thumb),
+                    };
 
                     let min = self.internal.range.start;
                     let max = self.internal.range.end;
@@ -333,7 +277,7 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                     val = step * (val / step).ceil();
                     val = val.clamp(min, max);
 
-                    if let Some(callback) = &self.on_changing {
+                    if let Some(callback) = &self.on_change {
                         (callback)(cx, val);
                     }
                 }
@@ -344,9 +288,8 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                 let max = self.internal.range.end;
                 let step = self.internal.step;
                 let mut val = self.lens.get(cx) + step;
-                // val = step * (val / step).ceil();
                 val = val.clamp(min, max);
-                if let Some(callback) = &self.on_changing {
+                if let Some(callback) = &self.on_change {
                     (callback)(cx, val);
                 }
             }
@@ -356,9 +299,8 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                 let max = self.internal.range.end;
                 let step = self.internal.step;
                 let mut val = self.lens.get(cx) - step;
-                // val = step * (val / step).ceil();
                 val = val.clamp(min, max);
-                if let Some(callback) = &self.on_changing {
+                if let Some(callback) = &self.on_change {
                     (callback)(cx, val);
                 }
             }
@@ -371,7 +313,7 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                     let mut val = self.lens.get(cx) + step;
                     val = step * (val / step).ceil();
                     val = val.clamp(min, max);
-                    if let Some(callback) = &self.on_changing {
+                    if let Some(callback) = &self.on_change {
                         (callback)(cx, val);
                     }
                 }
@@ -383,7 +325,7 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                     let mut val = self.lens.get(cx) - step;
                     val = step * (val / step).ceil();
                     val = val.clamp(min, max);
-                    if let Some(callback) = &self.on_changing {
+                    if let Some(callback) = &self.on_change {
                         (callback)(cx, val);
                     }
                 }
@@ -394,7 +336,7 @@ impl<L: Lens<Target = f32>> View for Slider<L> {
                         let max = self.internal.range.end;
                         let mut v = val as f32;
                         v = v.clamp(min, max);
-                        if let Some(callback) = &self.on_changing {
+                        if let Some(callback) = &self.on_change {
                             (callback)(cx, v);
                         }
                     }
@@ -414,8 +356,6 @@ impl<L: Lens> Handle<'_, Slider<L>> {
     /// Takes a closure which triggers when the slider value is changed,
     /// either by pressing the track or dragging the thumb along the track.
     ///
-    /// # Example
-    ///
     /// ```
     /// # use vizia_core::prelude::*;
     /// # use vizia_derive::*;
@@ -428,21 +368,20 @@ impl<L: Lens> Handle<'_, Slider<L>> {
     /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .on_change(|cx, value| {
-    ///         debug!("Slider on_changing: {}", value);
+    ///         debug!("Slider on_change: {}", value);
     ///     });
     /// ```
     pub fn on_change<F>(self, callback: F) -> Self
     where
         F: 'static + Fn(&mut EventContext, f32),
     {
-        self.modify(|slider| slider.on_changing = Some(Box::new(callback)))
+        self.modify(|slider| slider.on_change = Some(Box::new(callback)))
     }
 
     /// Sets the range of the slider.
     ///
     /// If the bound data is outside of the range then the slider will clip to min/max of the range.
     ///
-    /// # Example
     /// ```
     /// # use vizia_core::prelude::*;
     /// # use vizia_derive::*;
@@ -455,24 +394,75 @@ impl<L: Lens> Handle<'_, Slider<L>> {
     /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .range(-20.0..50.0)
-    ///     .on_changing(|cx, value| {
-    ///         debug!("Slider on_changing: {}", value);
+    ///     .on_change(|cx, value| {
+    ///         debug!("Slider on_change: {}", value);
     ///     });
     /// ```
-    pub fn range(self, range: Range<f32>) -> Self {
-        self.cx.emit_to(self.entity, SliderEventInternal::SetRange(range));
+    pub fn range<U: Into<Range<f32>>>(self, range: impl Res<U>) -> Self {
+        self.bind(range, |handle, range| {
+            let range = range.get(&handle).into();
+            handle.modify(|slider| {
+                slider.internal.range = range;
+            });
+        })
+    }
 
-        self
+    /// Sets the orientation of the slider.
+    ///
+    /// ```
+    /// # use vizia_core::prelude::*;
+    /// # use vizia_derive::*;
+    /// # let mut cx = &mut Context::default();
+    /// # #[derive(Lens, Default)]
+    /// # pub struct AppData {
+    /// #     value: f32,
+    /// # }
+    /// # impl Model for AppData {}
+    /// # AppData::default().build(cx);
+    /// Slider::new(cx, AppData::value)
+    ///     .orientation(Orientation::Vertical)
+    ///     .on_change(|cx, value| {
+    ///         debug!("Slider on_change: {}", value);
+    ///     });
+    /// ```
+    pub fn orientation<U: Into<Orientation>>(self, orientation: impl Res<U>) -> Self {
+        self.bind(orientation, |handle, orientation| {
+            let orientation = orientation.get(&handle).into();
+            handle.modify(|slider: &mut Slider<L>| {
+                slider.internal.orientation = orientation;
+            });
+        })
     }
 
     /// Set the step value for the slider.
-    pub fn step(self, step: f32) -> Self {
-        self.modify(|slider: &mut Slider<L>| slider.internal.step = step)
+    ///
+    /// ```
+    /// # use vizia_core::prelude::*;
+    /// # use vizia_derive::*;
+    /// # let mut cx = &mut Context::default();
+    /// # #[derive(Lens, Default)]
+    /// # pub struct AppData {
+    /// #     value: f32,
+    /// # }
+    /// # impl Model for AppData {}
+    /// # AppData::default().build(cx);
+    /// Slider::new(cx, AppData::value)
+    ///     .step(0.1)
+    ///     .on_change(|cx, value| {
+    ///         debug!("Slider on_change: {}", value);
+    ///     });
+    /// ```
+    pub fn step<U: Into<f32>>(self, step: impl Res<U>) -> Self {
+        self.bind(step, |handle, step| {
+            let step = step.get(&handle).into();
+            handle.modify(|slider| {
+                slider.internal.step = step;
+            });
+        })
     }
 
     /// Sets the fraction of a slider that a press of an arrow key will change.
     ///
-    /// # Example
     /// ```
     /// # use vizia_core::prelude::*;
     /// # use vizia_derive::*;
@@ -485,13 +475,16 @@ impl<L: Lens> Handle<'_, Slider<L>> {
     /// # AppData::default().build(cx);
     /// Slider::new(cx, AppData::value)
     ///     .keyboard_fraction(0.05)
-    ///     .on_changing(|cx, value| {
-    ///         debug!("Slider on_changing: {}", value);
+    ///     .on_change(|cx, value| {
+    ///         debug!("Slider on_change: {}", value);
     ///     });
     /// ```
-    pub fn keyboard_fraction(self, keyboard_fraction: f32) -> Self {
-        self.cx.emit_to(self.entity, SliderEventInternal::SetKeyboardFraction(keyboard_fraction));
-
-        self
+    pub fn keyboard_fraction<U: Into<f32>>(self, keyboard_fraction: impl Res<U>) -> Self {
+        self.bind(keyboard_fraction, |handle, keyboard_fraction| {
+            let keyboard_fraction = keyboard_fraction.get(&handle).into();
+            handle.modify(|slider| {
+                slider.internal.keyboard_fraction = keyboard_fraction;
+            });
+        })
     }
 }

--- a/examples/views/slider.rs
+++ b/examples/views/slider.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), ApplicationError> {
                 Slider::new(cx, AppData::value)
                     .range(-50.0..50.0)
                     .on_change(move |cx, val| cx.emit(AppEvent::SetValue(val)))
-                    .class("vertical");
+                    .orientation(Orientation::Vertical);
                 Label::new(cx, AppData::value.map(|val| format!("{:.2}", val)))
                     .alignment(Alignment::Center)
                     .width(Pixels(50.0));


### PR DESCRIPTION
- Removes the need for `GeoChanged` events by adding methods to `EventContext` to retrieve entity ids by element name and class id.
- Add a dedicated track element so the slider can encompass both the track and the thumb making it less fiddly to manipulate.
- Makes all slider modifiers bindable and removes internal slider events.