### PR TITLE
Ensure child windows have proper dirty bounds

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -279,6 +279,14 @@ impl Context {
             if let Some(window_state) = self.windows.get_mut(&parent_window) {
                 window_state.redraw_list.insert(entity);
             }
+
+            // If a child window needs redrawing, add itself to the redraw list.
+            // This ensures that the entire window is redrawn: https://github.com/vizia/vizia/issues/580
+            if self.tree.is_window(entity) {
+                if let Some(window_state) = self.windows.get_mut(&entity) {
+                    window_state.redraw_list.insert(entity);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #580

New popup windows did not have the dirty bounds set properly. The dirty bounds included only entities within the window, not the window itself. This is significant as the size of the entity inside is not necessarily the same as the window itself. For example in the reproduction case, the label widget was used.

The fix currently adds the window to the parent redraw list as well as the child redraw list. I'm not sure if it is necessary to add it to the parent redraw list?

I also noticed that creating a new popup window will temporarily shift the contents of the parent window
![with shift](https://github.com/user-attachments/assets/a841952a-ff2d-4624-961d-e4231d0640d4)
![without shift](https://github.com/user-attachments/assets/45cbee67-b358-4d8d-9331-3e7bf21ec2df)

I assume this is because the popup is laid out before the position type is set to absolute. However I'm not really sure how to fix this.