### PR TITLE
Warn instead of crash for positioning a window on wayland

### DIFF
--- a/crates/vizia_winit/Cargo.toml
+++ b/crates/vizia_winit/Cargo.toml
@@ -29,6 +29,7 @@ accesskit_winit = { version = "0.26", optional = true}
 glutin-winit = { version = "0.5", default-features = false, features = ["egl", "wgl", "glx"]}
 gl-rs = { package = "gl", version = "0.14.0" }
 hashbrown = "0.15"
+log = "0.4"
 
 [target."cfg(target_os = \"linux\")".dependencies.skia-safe]
 version = "0.84"


### PR DESCRIPTION
Closes #558

In order to support tilling window managers, wayland doesn't let you set or get the position of a window. In order to create popup windows with a particular anchor, the [xdg_popup](https://wayland.app/protocols/xdg-shell#xdg_popup) is provided. However this is unfortunately not supported in winit https://github.com/rust-windowing/winit/issues/403.

Since winit hasn't added support for popup windows for 7 years, it is probably best to just log a warning instead of crashing.