### PR TITLE
Apply window_scale factor when resized

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -507,9 +507,9 @@ impl ApplicationRunner {
                         self.window_scale_factor = window_info.scale();
                     }
 
-                    //let user_scale_factor = self.cx.user_scale_factor();
-
-                    //self.cx.set_scale_factor(self.window_scale_factor * user_scale_factor);
+                    self.cx.set_scale_factor(
+                        self.window_scale_factor * self.window_description.user_scale_factor,
+                    );
 
                     let physical_size =
                         (window_info.physical_size().width, window_info.physical_size().height);


### PR DESCRIPTION
On my macOS system HiDPI scaling isn't applied. I'm using vizia in vizia-plug.
There's this note in "crates/vizia_baseview/src":
```
// NOTE: This is not correct, but we should get a `Resized` event to correct this
            //       immediately after the window is created
            WindowScalePolicy::SystemScaleFactor => (true, 1.25),
```

But the `Resized` event never corrects this initial 1.25 value. 
This PR fixes this by setting the new system scale factor when a `Resized` is received. 
Something similar was commented out by mistake I think.

Related to this Discord question: https://discord.com/channels/791142189005537332/1402216886623535226


