### PR TITLE
fix(baseview): report EventStatus::Captured for keys in focused textbox

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -537,6 +537,11 @@ impl ApplicationRunner {
             (idle_callback)(self.cx.context());
         }
     }
+
+    /// Element name of the view that currently has keyboard focus.
+    pub fn focused_element(&self) -> Option<&'static str> {
+        self.cx.focused_element()
+    }
 }
 
 /// Returns true if the provided event should cause an [`Application`] to

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -228,11 +228,7 @@ impl WindowHandler for ViziaWindow {
             window.close();
         }
 
-        if captured {
-            EventStatus::Captured
-        } else {
-            EventStatus::Ignored
-        }
+        if captured { EventStatus::Captured } else { EventStatus::Ignored }
     }
 }
 

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -212,6 +212,14 @@ impl WindowHandler for ViziaWindow {
     fn on_event(&mut self, window: &mut Window<'_>, event: Event) -> EventStatus {
         let mut should_quit = false;
 
+        // If a text input currently holds focus, a native keyboard event is
+        // intended for the plugin. Report it as `Captured` so the backend
+        // does not forward the platform event further — otherwise the host
+        // (e.g. a DAW) also processes the same keystroke, producing double
+        // handling and a system beep on macOS.
+        let captured = matches!(event, Event::Keyboard(_))
+            && self.application.focused_element() == Some("textbox");
+
         self.application.handle_event(event, &mut should_quit);
 
         self.application.handle_idle(&self.on_idle);
@@ -220,7 +228,11 @@ impl WindowHandler for ViziaWindow {
             window.close();
         }
 
-        EventStatus::Ignored
+        if captured {
+            EventStatus::Captured
+        } else {
+            EventStatus::Ignored
+        }
     }
 }
 

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -63,6 +63,18 @@ impl BackendContext {
         self.0.focused
     }
 
+    /// Returns the element name (e.g. `"textbox"`) of the currently focused
+    /// view, or `None` if the focused entity has no view or the view doesn't
+    /// declare an element name.
+    ///
+    /// Windowing backends can use this to decide whether a keyboard event
+    /// should be reported as captured so the platform does not forward the
+    /// event further — preventing the host from also processing keys
+    /// intended for a focused text input.
+    pub fn focused_element(&self) -> Option<&'static str> {
+        self.0.views.get(&self.0.focused).and_then(|view| view.element())
+    }
+
     pub fn add_main_window(
         &mut self,
         window_entity: Entity,


### PR DESCRIPTION
## Summary

`ViziaWindow::on_event` unconditionally returned `EventStatus::Ignored`, so baseview always forwarded native keyboard events up the platform responder chain after dispatching them to vizia. When the plugin runs inside a DAW on macOS, both the plugin **and** the host end up processing the same keystroke — typing into a `Textbox` in REAPER triggers a system beep per keypress and toggles transport on space; Ableton Live performs its own actions while the user types.

## Change

When a text input currently holds focus, report the keyboard event as `EventStatus::Captured` so the backend does not forward the native event further. When nothing (or a non-text view) has focus, behaviour is unchanged — keys still fall through to the host, preserving DAW shortcuts while the plugin window is open.

Adds `BackendContext::focused_element()` plus a passthrough on `ApplicationRunner` so the backend can inspect the focused view's element name without reaching into private fields.

## Why this shape

- Vizia's event dispatch is asynchronous, so `on_event` cannot know synchronously whether a listener will consume the key. A focused-element check is a principled lookahead — text input is the only view type that semantically consumes keys, so the `"textbox"` element name is a safe signal.
- Other editable widgets (combobox, picklist, spinbox, datepicker) embed a `Textbox` child which takes focus during editing, so this transitively covers them.

## Context

- User-visible bug report: [vizia-plug #7](https://github.com/vizia/vizia-plug/issues/7) — "Broken Keyboard Support".
- Earlier half of the fix: the `FocusIn → window.focus()` path wired up in `application.rs` ensures the NSView becomes first-responder so keys actually reach `Textbox`. Without the matching `Captured` return added here, keys *also* leaked back to the host. This PR completes the pair.

## Test plan

- [x] Typing into a `Textbox` in a nih-plug + vizia-plug plugin works in REAPER and Ableton Live on macOS, no system beep per keypress.
- [x] Pressing space / arrow keys / Cmd-modifiers while a `Textbox` has focus does not trigger DAW-level shortcuts.
- [x] With no `Textbox` focused, DAW shortcuts (space = transport) still work while the plugin window is open.