### PR TITLE
fix(textbox): use native macOS modifiers and deduplicate Code::Space

### DIFF
--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -1106,12 +1106,27 @@ where
                     }
                 }
 
-                Code::Space => {
-                    cx.emit(TextEvent::InsertText(String::from(" ")));
-                }
+                // Note: no `Code::Space` arm — the space character arrives
+                // through `WindowEvent::CharInput(' ')` above, which already
+                // inserts it (and correctly suppresses insertion when Ctrl
+                // or Cmd is held). Handling it here as well produced double
+                // insertion on platforms that emit both events for a plain
+                // spacebar press.
 
                 Code::ArrowLeft => {
                     self.reset_caret_timer(cx);
+                    // macOS convention: Option (alt) for word movement,
+                    // Cmd (logo) for line-boundary movement.
+                    // Other platforms: Ctrl for word movement.
+                    #[cfg(target_os = "macos")]
+                    let movement = if cx.modifiers.logo() {
+                        Movement::LineStart
+                    } else if cx.modifiers.alt() {
+                        Movement::Word(Direction::Left)
+                    } else {
+                        Movement::Grapheme(Direction::Left)
+                    };
+                    #[cfg(not(target_os = "macos"))]
                     let movement = if cx.modifiers.ctrl() {
                         Movement::Word(Direction::Left)
                     } else {
@@ -1124,6 +1139,15 @@ where
                 Code::ArrowRight => {
                     self.reset_caret_timer(cx);
 
+                    #[cfg(target_os = "macos")]
+                    let movement = if cx.modifiers.logo() {
+                        Movement::LineEnd
+                    } else if cx.modifiers.alt() {
+                        Movement::Word(Direction::Right)
+                    } else {
+                        Movement::Grapheme(Direction::Right)
+                    };
+                    #[cfg(not(target_os = "macos"))]
                     let movement = if cx.modifiers.ctrl() {
                         Movement::Word(Direction::Right)
                     } else {
@@ -1156,24 +1180,43 @@ where
                 Code::Backspace => {
                     self.reset_caret_timer(cx);
                     if !cx.is_read_only() {
-                        if cx.modifiers.ctrl() {
-                            cx.emit(TextEvent::DeleteText(Movement::Word(Direction::Upstream)));
+                        #[cfg(target_os = "macos")]
+                        let movement = if cx.modifiers.logo() {
+                            // Cmd+Backspace deletes from caret to line start on macOS.
+                            Movement::ParagraphStart
+                        } else if cx.modifiers.alt() {
+                            Movement::Word(Direction::Upstream)
                         } else {
-                            cx.emit(TextEvent::DeleteText(Movement::Grapheme(Direction::Upstream)));
-                        }
+                            Movement::Grapheme(Direction::Upstream)
+                        };
+                        #[cfg(not(target_os = "macos"))]
+                        let movement = if cx.modifiers.ctrl() {
+                            Movement::Word(Direction::Upstream)
+                        } else {
+                            Movement::Grapheme(Direction::Upstream)
+                        };
+
+                        cx.emit(TextEvent::DeleteText(movement));
                     }
                 }
 
                 Code::Delete => {
                     self.reset_caret_timer(cx);
                     if !cx.is_read_only() {
-                        if cx.modifiers.ctrl() {
-                            cx.emit(TextEvent::DeleteText(Movement::Word(Direction::Downstream)));
+                        #[cfg(target_os = "macos")]
+                        let movement = if cx.modifiers.alt() {
+                            Movement::Word(Direction::Downstream)
                         } else {
-                            cx.emit(TextEvent::DeleteText(Movement::Grapheme(
-                                Direction::Downstream,
-                            )));
-                        }
+                            Movement::Grapheme(Direction::Downstream)
+                        };
+                        #[cfg(not(target_os = "macos"))]
+                        let movement = if cx.modifiers.ctrl() {
+                            Movement::Word(Direction::Downstream)
+                        } else {
+                            Movement::Grapheme(Direction::Downstream)
+                        };
+
+                        cx.emit(TextEvent::DeleteText(movement));
                     }
                 }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -1112,7 +1112,6 @@ where
                 // or Cmd is held). Handling it here as well produced double
                 // insertion on platforms that emit both events for a plain
                 // spacebar press.
-
                 Code::ArrowLeft => {
                     self.reset_caret_timer(cx);
                     // macOS convention: Option (alt) for word movement,
@@ -1182,8 +1181,10 @@ where
                     if !cx.is_read_only() {
                         #[cfg(target_os = "macos")]
                         let movement = if cx.modifiers.logo() {
-                            // Cmd+Backspace deletes from caret to line start on macOS.
-                            Movement::ParagraphStart
+                            // Cmd+Backspace deletes from caret to the visual
+                            // line start on macOS, matching Cmd+Left cursor
+                            // movement (which uses `Movement::LineStart`).
+                            Movement::LineStart
                         } else if cx.modifiers.alt() {
                             Movement::Word(Direction::Upstream)
                         } else {


### PR DESCRIPTION
## Summary

Two related fixes to keyboard behaviour in `Textbox`.

### 1. Platform-appropriate modifiers on macOS

Arrow / Backspace / Delete handlers assumed `Ctrl` is the word-movement modifier — correct for Windows/Linux but not macOS, where Option (Alt) is the word-navigation modifier and Cmd is the line-boundary modifier.

On macOS the handlers now map to:

| Keys                         | Action                            |
|------------------------------|-----------------------------------|
| `Option`+`←`/`→`             | Move by word                      |
| `Cmd`+`←`/`→`                | Move to line start / end          |
| `Option`+`Backspace`/`Delete`| Delete word                       |
| `Cmd`+`Backspace`            | Delete to line start              |
| `Shift` + any of the above   | Extends the selection             |

Other platforms keep the existing `Ctrl`-based bindings unchanged via `#[cfg(target_os = ...)]`.

### 2. Deduplicate `Code::Space` handling

A spacebar press dispatches both `WindowEvent::CharInput(' ')` (text-input path) and `WindowEvent::KeyDown(Code::Space)` (shortcut path). The `CharInput` handler already inserts the space and correctly suppresses insertion when Ctrl or Cmd is held. The separate `KeyDown(Code::Space)` arm inserted a second space unconditionally — producing two space characters on every press.

Removing the arm lets space follow the same modifier-aware path as every other printable character. This was previously masked by a separate bug that prevented keys from reliably reaching the `Textbox` at all — once that's fixed, the double-insertion is immediately visible.

## Test plan

- [x] On macOS: `Option+←/→`, `Option+Backspace`, `Cmd+←/→`, `Cmd+Backspace` behave as native Cocoa text fields expect; Shift with each extends the selection.
- [x] On Windows/Linux: `Ctrl+←/→` and `Ctrl+Backspace` still move/delete by word (no regression).
- [x] Pressing space inserts exactly one space.
- [x] Pressing `Cmd+Space` / `Ctrl+Space` does not insert a space character.