### PR TITLE
style: fix clippy warnings to unblock CI

### DIFF
--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -208,33 +208,31 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             cx.drop_data = Some(drop_data.clone());
         }
 
-        WindowEvent::MouseMove(x, y) => {
-            if !x.is_nan() && !y.is_nan() {
-                cx.mouse.previous_cursor_x = cx.mouse.cursor_x;
-                cx.mouse.previous_cursor_y = cx.mouse.cursor_y;
-                cx.mouse.cursor_x = *x;
-                cx.mouse.cursor_y = *y;
+        WindowEvent::MouseMove(x, y) if !x.is_nan() && !y.is_nan() => {
+            cx.mouse.previous_cursor_x = cx.mouse.cursor_x;
+            cx.mouse.previous_cursor_y = cx.mouse.cursor_y;
+            cx.mouse.cursor_x = *x;
+            cx.mouse.cursor_y = *y;
 
-                hover_system(cx, meta.origin);
+            hover_system(cx, meta.origin);
 
-                mutate_direct_or_up(meta, cx.captured, cx.hovered, false);
-            }
-
-            // if cx.mouse.cursor_x != cx.mouse.previous_cursor_x
-            //     || cx.mouse.cursor_y != cx.mouse.previous_cursor_y
-            // {
-            // }
-
-            // if let Some(dropped_file) = cx.dropped_file.take() {
-            //     emit_direct_or_up(
-            //         cx,
-            //         WindowEvent::DroppedFile(dropped_file),
-            //         cx.captured,
-            //         cx.hovered,
-            //         true,
-            //     );
-            // }
+            mutate_direct_or_up(meta, cx.captured, cx.hovered, false);
         }
+
+        // if cx.mouse.cursor_x != cx.mouse.previous_cursor_x
+        //     || cx.mouse.cursor_y != cx.mouse.previous_cursor_y
+        // {
+        // }
+
+        // if let Some(dropped_file) = cx.dropped_file.take() {
+        //     emit_direct_or_up(
+        //         cx,
+        //         WindowEvent::DroppedFile(dropped_file),
+        //         cx.captured,
+        //         cx.hovered,
+        //         true,
+        //     );
+        // }
         WindowEvent::MouseDown(button) => {
             // do direct state-updates
             match button {

--- a/crates/vizia_core/src/modifiers/actions.rs
+++ b/crates/vizia_core/src/modifiers/actions.rs
@@ -39,16 +39,12 @@ impl Model for ModalModel {
         });
 
         event.map(|window_event, _| match window_event {
-            WindowEvent::MouseOver => {
-                if !self.tooltip_visible.get().0 {
-                    self.tooltip_visible.set((true, true));
-                }
+            WindowEvent::MouseOver if !self.tooltip_visible.get().0 => {
+                self.tooltip_visible.set((true, true));
             }
             WindowEvent::MouseOut => self.tooltip_visible.set((false, true)),
-            WindowEvent::FocusIn => {
-                if !self.tooltip_visible.get().0 {
-                    self.tooltip_visible.set((true, false));
-                }
+            WindowEvent::FocusIn if !self.tooltip_visible.get().0 => {
+                self.tooltip_visible.set((true, false));
             }
             WindowEvent::FocusOut => self.tooltip_visible.set((false, false)),
             WindowEvent::FocusVisibility(vis) if !(*vis) => {
@@ -195,27 +191,23 @@ impl Model for ActionsModel {
                 }
             }
 
-            WindowEvent::MouseDoubleClick(button) => {
-                if meta.target == cx.current && !cx.is_disabled() {
-                    if let Some(action) = &self.on_double_click {
-                        (action)(cx, *button);
-                    }
+            WindowEvent::MouseDoubleClick(button)
+                if meta.target == cx.current && !cx.is_disabled() =>
+            {
+                if let Some(action) = &self.on_double_click {
+                    (action)(cx, *button);
                 }
             }
 
-            WindowEvent::MouseEnter => {
-                if meta.target == cx.current() {
-                    if let Some(action) = &self.on_hover {
-                        (action)(cx);
-                    }
+            WindowEvent::MouseEnter if meta.target == cx.current() => {
+                if let Some(action) = &self.on_hover {
+                    (action)(cx);
                 }
             }
 
-            WindowEvent::MouseLeave => {
-                if meta.target == cx.current() {
-                    if let Some(action) = &self.on_hover_out {
-                        (action)(cx);
-                    }
+            WindowEvent::MouseLeave if meta.target == cx.current() => {
+                if let Some(action) = &self.on_hover_out {
+                    (action)(cx);
                 }
             }
 
@@ -284,11 +276,9 @@ impl Model for ActionsModel {
                 }
             }
 
-            WindowEvent::GeometryChanged(geo) => {
-                if meta.target == cx.current() {
-                    if let Some(action) = &self.on_geo_changed {
-                        (action)(cx, *geo);
-                    }
+            WindowEvent::GeometryChanged(geo) if meta.target == cx.current() => {
+                if let Some(action) = &self.on_geo_changed {
+                    (action)(cx, *geo);
                 }
             }
 

--- a/crates/vizia_core/src/text/editable_text.rs
+++ b/crates/vizia_core/src/text/editable_text.rs
@@ -192,13 +192,11 @@ impl EditableText for String {
 
     fn next_line_break(&self, from: usize) -> usize {
         let from = clamp_to_char_boundary(self, from);
-        let mut offset = from;
 
-        for char in self.get(from..).unwrap_or("").bytes() {
+        for (offset, char) in (from..).zip(self.get(from..).unwrap_or("").bytes()) {
             if char == 0x0a {
                 return offset;
             }
-            offset += 1;
         }
 
         self.len()

--- a/crates/vizia_core/src/views/button.rs
+++ b/crates/vizia_core/src/views/button.rs
@@ -106,17 +106,13 @@ impl View for Button {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::PressDown { mouse: _ } => {
-                if meta.target == cx.current {
-                    cx.focus();
-                }
+            WindowEvent::PressDown { mouse: _ } if meta.target == cx.current => {
+                cx.focus();
             }
 
-            WindowEvent::Press { .. } => {
-                if meta.target == cx.current {
-                    if let Some(action) = &self.action {
-                        (action)(cx);
-                    }
+            WindowEvent::Press { .. } if meta.target == cx.current => {
+                if let Some(action) = &self.action {
+                    (action)(cx);
                 }
             }
 

--- a/crates/vizia_core/src/views/checkbox.rs
+++ b/crates/vizia_core/src/views/checkbox.rs
@@ -275,17 +275,13 @@ impl View for Checkbox {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::PressDown { mouse: _ } => {
-                if meta.target == cx.current {
-                    cx.focus();
-                }
+            WindowEvent::PressDown { mouse: _ } if meta.target == cx.current => {
+                cx.focus();
             }
 
-            WindowEvent::Press { mouse: _ } => {
-                if meta.target == cx.current {
-                    if let Some(callback) = &self.on_toggle {
-                        (callback)(cx);
-                    }
+            WindowEvent::Press { mouse: _ } if meta.target == cx.current => {
+                if let Some(callback) = &self.on_toggle {
+                    (callback)(cx);
                 }
             }
 

--- a/crates/vizia_core/src/views/combobox.rs
+++ b/crates/vizia_core/src/views/combobox.rs
@@ -61,19 +61,18 @@ where
             cx.add_listener(move |popup: &mut Self, cx, event| {
                 let open = popup.is_open.get();
                 event.map(|window_event, meta| match window_event {
-                    WindowEvent::MouseDown(_) => {
+                    WindowEvent::MouseDown(_)
                         if open
                             && meta.origin != cx.current()
-                            && !cx.hovered.is_descendant_of(cx.tree, cx.current)
-                        {
-                            cx.emit(TextEvent::Submit(false));
-                            cx.emit_custom(
-                                Event::new(TextEvent::EndEdit)
-                                    .target(cx.current)
-                                    .propagate(Propagation::Subtree),
-                            );
-                            meta.consume();
-                        }
+                            && !cx.hovered.is_descendant_of(cx.tree, cx.current) =>
+                    {
+                        cx.emit(TextEvent::Submit(false));
+                        cx.emit_custom(
+                            Event::new(TextEvent::EndEdit)
+                                .target(cx.current)
+                                .propagate(Propagation::Subtree),
+                        );
+                        meta.consume();
                     }
 
                     _ => {}
@@ -253,58 +252,52 @@ where
 
         event.map(|window_event, meta| match window_event {
             WindowEvent::KeyDown(code, _) => match code {
-                Code::ArrowDown => {
-                    if self.is_open.get() {
-                        let filtered = self.filtered_indices();
-                        if !filtered.is_empty() {
-                            let current_pos = self
-                                .highlighted
-                                .get()
-                                .and_then(|h| filtered.iter().position(|index| *index == h))
-                                .unwrap_or_else(|| {
-                                    filtered
-                                        .iter()
-                                        .position(|index| *index == self.selected.get())
-                                        .unwrap_or(0)
-                                });
+                Code::ArrowDown if self.is_open.get() => {
+                    let filtered = self.filtered_indices();
+                    if !filtered.is_empty() {
+                        let current_pos = self
+                            .highlighted
+                            .get()
+                            .and_then(|h| filtered.iter().position(|index| *index == h))
+                            .unwrap_or_else(|| {
+                                filtered
+                                    .iter()
+                                    .position(|index| *index == self.selected.get())
+                                    .unwrap_or(0)
+                            });
 
-                            let next_pos = (current_pos + 1) % filtered.len();
-                            self.highlighted.set(Some(filtered[next_pos]));
-                            meta.consume();
-                        }
+                        let next_pos = (current_pos + 1) % filtered.len();
+                        self.highlighted.set(Some(filtered[next_pos]));
+                        meta.consume();
                     }
                 }
 
-                Code::ArrowUp => {
-                    if self.is_open.get() {
-                        let filtered = self.filtered_indices();
-                        if !filtered.is_empty() {
-                            let current_pos = self
-                                .highlighted
-                                .get()
-                                .and_then(|h| filtered.iter().position(|index| *index == h))
-                                .unwrap_or_else(|| {
-                                    filtered
-                                        .iter()
-                                        .position(|index| *index == self.selected.get())
-                                        .unwrap_or(0)
-                                });
+                Code::ArrowUp if self.is_open.get() => {
+                    let filtered = self.filtered_indices();
+                    if !filtered.is_empty() {
+                        let current_pos = self
+                            .highlighted
+                            .get()
+                            .and_then(|h| filtered.iter().position(|index| *index == h))
+                            .unwrap_or_else(|| {
+                                filtered
+                                    .iter()
+                                    .position(|index| *index == self.selected.get())
+                                    .unwrap_or(0)
+                            });
 
-                            let prev_pos =
-                                if current_pos == 0 { filtered.len() - 1 } else { current_pos - 1 };
+                        let prev_pos =
+                            if current_pos == 0 { filtered.len() - 1 } else { current_pos - 1 };
 
-                            self.highlighted.set(Some(filtered[prev_pos]));
-                            meta.consume();
-                        }
+                        self.highlighted.set(Some(filtered[prev_pos]));
+                        meta.consume();
                     }
                 }
 
-                Code::Enter => {
-                    if self.is_open.get() {
-                        if let Some(index) = self.highlighted.get() {
-                            cx.emit(ComboBoxEvent::SetOption(index));
-                            meta.consume();
-                        }
+                Code::Enter if self.is_open.get() => {
+                    if let Some(index) = self.highlighted.get() {
+                        cx.emit(ComboBoxEvent::SetOption(index));
+                        meta.consume();
                     }
                 }
 

--- a/crates/vizia_core/src/views/knob.rs
+++ b/crates/vizia_core/src/views/knob.rs
@@ -179,30 +179,26 @@ impl<T: Res<f32> + 'static> View for Knob<T> {
                 cx.release();
             }
 
-            WindowEvent::MouseMove(_, y) => {
-                if self.is_dragging && !cx.is_disabled() {
-                    let mut delta_normal = (*y - self.prev_drag_y) * self.drag_scalar;
+            WindowEvent::MouseMove(_, y) if self.is_dragging && !cx.is_disabled() => {
+                let mut delta_normal = (*y - self.prev_drag_y) * self.drag_scalar;
 
-                    self.prev_drag_y = *y;
+                self.prev_drag_y = *y;
 
-                    if cx.modifiers.shift() {
-                        delta_normal *= self.modifier_scalar;
-                    }
-
-                    let new_normal = self.continuous_normal - delta_normal;
-
-                    move_virtual_slider(self, cx, new_normal);
+                if cx.modifiers.shift() {
+                    delta_normal *= self.modifier_scalar;
                 }
+
+                let new_normal = self.continuous_normal - delta_normal;
+
+                move_virtual_slider(self, cx, new_normal);
             }
 
-            WindowEvent::MouseScroll(_, y) => {
-                if *y != 0.0 {
-                    let delta_normal = -*y * self.wheel_scalar;
+            WindowEvent::MouseScroll(_, y) if *y != 0.0 => {
+                let delta_normal = -*y * self.wheel_scalar;
 
-                    let new_normal = self.continuous_normal - delta_normal;
+                let new_normal = self.continuous_normal - delta_normal;
 
-                    move_virtual_slider(self, cx, new_normal);
-                }
+                move_virtual_slider(self, cx, new_normal);
             }
 
             WindowEvent::MouseDoubleClick(button) if *button == MouseButton::Left => {

--- a/crates/vizia_core/src/views/label.rs
+++ b/crates/vizia_core/src/views/label.rs
@@ -156,24 +156,24 @@ impl View for Label {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::Press { .. } | WindowEvent::PressDown { .. } => {
-                if cx.current() == cx.mouse.left.pressed && meta.target == cx.current() {
-                    if let Some(describing) = self
-                        .describing
-                        .as_ref()
-                        .and_then(|identity| cx.resolve_entity_identifier(identity))
-                    {
-                        let old = cx.current;
-                        cx.current = describing;
-                        cx.focus_with_visibility(false);
-                        let message = if matches!(window_event, WindowEvent::Press { .. }) {
-                            WindowEvent::Press { mouse: false }
-                        } else {
-                            WindowEvent::PressDown { mouse: false }
-                        };
-                        cx.emit_to(describing, message);
-                        cx.current = old;
-                    }
+            WindowEvent::Press { .. } | WindowEvent::PressDown { .. }
+                if cx.current() == cx.mouse.left.pressed && meta.target == cx.current() =>
+            {
+                if let Some(describing) = self
+                    .describing
+                    .as_ref()
+                    .and_then(|identity| cx.resolve_entity_identifier(identity))
+                {
+                    let old = cx.current;
+                    cx.current = describing;
+                    cx.focus_with_visibility(false);
+                    let message = if matches!(window_event, WindowEvent::Press { .. }) {
+                        WindowEvent::Press { mouse: false }
+                    } else {
+                        WindowEvent::PressDown { mouse: false }
+                    };
+                    cx.emit_to(describing, message);
+                    cx.current = old;
                 }
             }
             _ => {}

--- a/crates/vizia_core/src/views/menu.rs
+++ b/crates/vizia_core/src/views/menu.rs
@@ -17,13 +17,13 @@ impl MenuBar {
                     let flag = menu_bar.is_open.get();
                     event.map(
                         |window_event, meta: &mut crate::events::EventMeta| match window_event {
-                            WindowEvent::MouseDown(_) => {
-                                if flag && meta.origin != cx.current() {
-                                    // Check if the mouse was pressed outside of any descendants
-                                    if !cx.hovered.is_descendant_of(cx.tree, cx.current) {
-                                        cx.emit(MenuEvent::CloseAll);
-                                    }
-                                }
+                            // Check if the mouse was pressed outside of any descendants
+                            WindowEvent::MouseDown(_)
+                                if flag
+                                    && meta.origin != cx.current()
+                                    && !cx.hovered.is_descendant_of(cx.tree, cx.current) =>
+                            {
+                                cx.emit(MenuEvent::CloseAll);
                             }
 
                             _ => {}
@@ -98,16 +98,16 @@ impl Submenu {
                     let flag = menu_button.is_open.get();
                     event.map(
                         |window_event, meta: &mut crate::events::EventMeta| match window_event {
-                            WindowEvent::MouseDown(_) => {
-                                if flag && meta.origin != cx.current() {
-                                    // Check if the mouse was pressed outside of any descendants
-                                    if !cx.hovered.is_descendant_of(cx.tree, cx.current) {
-                                        cx.emit(MenuEvent::CloseAll);
-                                        cx.emit(MenuEvent::Close);
-                                        // TODO: This might be needed
-                                        // meta.consume();
-                                    }
-                                }
+                            // Check if the mouse was pressed outside of any descendants
+                            WindowEvent::MouseDown(_)
+                                if flag
+                                    && meta.origin != cx.current()
+                                    && !cx.hovered.is_descendant_of(cx.tree, cx.current) =>
+                            {
+                                cx.emit(MenuEvent::CloseAll);
+                                cx.emit(MenuEvent::Close);
+                                // TODO: This might be needed
+                                // meta.consume();
                             }
 
                             _ => {}
@@ -163,41 +163,33 @@ impl View for Submenu {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseEnter => {
-                if meta.target == cx.current {
-                    // if self.open_on_hover {
-                    //     cx.focus();
-                    // }
-                    if self.open_on_hover {
-                        // Close any open submenus of the parent
-                        let parent = cx.tree.get_parent(cx.current).unwrap();
-                        cx.emit_custom(
-                            Event::new(MenuEvent::Close)
-                                .target(parent)
-                                .propagate(Propagation::Subtree),
-                        );
-                        // Open this submenu
-                        cx.emit(MenuEvent::Open);
-                    }
-                }
+            // if self.open_on_hover {
+            //     cx.focus();
+            // }
+            WindowEvent::MouseEnter if meta.target == cx.current && self.open_on_hover => {
+                // Close any open submenus of the parent
+                let parent = cx.tree.get_parent(cx.current).unwrap();
+                cx.emit_custom(
+                    Event::new(MenuEvent::Close).target(parent).propagate(Propagation::Subtree),
+                );
+                // Open this submenu
+                cx.emit(MenuEvent::Open);
             }
 
             WindowEvent::KeyDown(code, _) => match code {
-                Code::ArrowLeft => {
+                Code::ArrowLeft
                     // if cx.is_focused() {
-                    if self.is_open.get() {
+                    if self.is_open.get() => {
                         self.is_open.set(false);
                         cx.focus();
                         meta.consume();
                     }
                     // }
-                }
 
-                Code::ArrowRight => {
-                    if !self.is_open.get() {
+                Code::ArrowRight
+                    if !self.is_open.get() => {
                         self.is_open.set(true);
                     }
-                }
 
                 _ => {}
             },
@@ -270,13 +262,11 @@ impl View for MenuButton {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, meta| match window_event {
-            WindowEvent::MouseEnter => {
-                if meta.target == cx.current {
-                    let parent = cx.tree.get_parent(cx.current).unwrap();
-                    cx.emit_custom(
-                        Event::new(MenuEvent::Close).target(parent).propagate(Propagation::Subtree),
-                    );
-                }
+            WindowEvent::MouseEnter if meta.target == cx.current => {
+                let parent = cx.tree.get_parent(cx.current).unwrap();
+                cx.emit_custom(
+                    Event::new(MenuEvent::Close).target(parent).propagate(Propagation::Subtree),
+                );
             }
 
             _ => {}

--- a/crates/vizia_core/src/views/popup.rs
+++ b/crates/vizia_core/src/views/popup.rs
@@ -457,20 +457,17 @@ impl Handle<'_, Popup> {
         self.cx.with_current(self.entity, |cx| {
             cx.add_listener(move |_: &mut Popup, cx, event| {
                 event.map(|window_event, meta| match window_event {
-                    WindowEvent::MouseDown(_) => {
-                        if meta.origin != cx.current() {
-                            // Check if the mouse was pressed outside of any descendants
-                            if !cx.hovered.is_descendant_of(cx.tree, cx.current) {
-                                (focus_event)(cx);
-                                meta.consume();
-                            }
-                        }
+                    // Check if the mouse was pressed outside of any descendants
+                    WindowEvent::MouseDown(_)
+                        if meta.origin != cx.current()
+                            && !cx.hovered.is_descendant_of(cx.tree, cx.current) =>
+                    {
+                        (focus_event)(cx);
+                        meta.consume();
                     }
 
-                    WindowEvent::KeyDown(code, _) => {
-                        if *code == Code::Escape {
-                            (focus_event)(cx);
-                        }
+                    WindowEvent::KeyDown(code, _) if *code == Code::Escape => {
+                        (focus_event)(cx);
                     }
 
                     _ => {}

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -204,34 +204,30 @@ impl View for Scrollbar {
                     });
                 }
 
-                WindowEvent::MouseMove(_, _) => {
-                    if self.dragging {
-                        if let Some((mouse_ref, value_ref)) = self.reference_points {
-                            let physical_delta = pos - mouse_ref;
-                            let changed = self.compute_new_value(cx, physical_delta, value_ref);
-                            self.change(cx, changed);
-                        } else if self.scroll_to_cursor {
-                            let thumb_bounds = self.thumb_bounds(cx);
-                            let bounds = cx.bounds();
-                            let sx = bounds.w - thumb_bounds.w;
-                            let sy = bounds.h - thumb_bounds.h;
-                            match self.orientation {
-                                Orientation::Horizontal => {
-                                    let px =
-                                        cx.mouse.cursor_x - cx.bounds().x - thumb_bounds.w / 2.0;
-                                    let x = (px / sx).clamp(0.0, 1.0);
-                                    if let Some(callback) = &self.on_changing {
-                                        (callback)(cx, x);
-                                    }
+                WindowEvent::MouseMove(_, _) if self.dragging => {
+                    if let Some((mouse_ref, value_ref)) = self.reference_points {
+                        let physical_delta = pos - mouse_ref;
+                        let changed = self.compute_new_value(cx, physical_delta, value_ref);
+                        self.change(cx, changed);
+                    } else if self.scroll_to_cursor {
+                        let thumb_bounds = self.thumb_bounds(cx);
+                        let bounds = cx.bounds();
+                        let sx = bounds.w - thumb_bounds.w;
+                        let sy = bounds.h - thumb_bounds.h;
+                        match self.orientation {
+                            Orientation::Horizontal => {
+                                let px = cx.mouse.cursor_x - cx.bounds().x - thumb_bounds.w / 2.0;
+                                let x = (px / sx).clamp(0.0, 1.0);
+                                if let Some(callback) = &self.on_changing {
+                                    (callback)(cx, x);
                                 }
+                            }
 
-                                Orientation::Vertical => {
-                                    let py =
-                                        cx.mouse.cursor_y - cx.bounds().y - thumb_bounds.h / 2.0;
-                                    let y = (py / sy).clamp(0.0, 1.0);
-                                    if let Some(callback) = &self.on_changing {
-                                        (callback)(cx, y);
-                                    }
+                            Orientation::Vertical => {
+                                let py = cx.mouse.cursor_y - cx.bounds().y - thumb_bounds.h / 2.0;
+                                let y = (py / sy).clamp(0.0, 1.0);
+                                if let Some(callback) = &self.on_changing {
+                                    (callback)(cx, y);
                                 }
                             }
                         }

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -307,62 +307,59 @@ impl View for ScrollView {
         });
 
         event.map(|window_event, meta| match window_event {
-            WindowEvent::GeometryChanged(geo) => {
-                if geo.contains(GeoChanged::WIDTH_CHANGED)
-                    || geo.contains(GeoChanged::HEIGHT_CHANGED)
+            WindowEvent::GeometryChanged(geo)
+                if (geo.contains(GeoChanged::WIDTH_CHANGED)
+                    || geo.contains(GeoChanged::HEIGHT_CHANGED)) =>
+            {
+                let bounds = cx.bounds();
+                let scale_factor = cx.scale_factor();
+
+                let mut scroll_x = self.scroll_x.get();
+                let mut scroll_y = self.scroll_y.get();
+                let inner_width = self.inner_width.get();
+                let inner_height = self.inner_height.get();
+                let mut container_width = self.container_width.get();
+                let mut container_height = self.container_height.get();
+
+                if inner_width != 0.0
+                    && inner_height != 0.0
+                    && container_width != 0.0
+                    && container_height != 0.0
                 {
-                    let bounds = cx.bounds();
-                    let scale_factor = cx.scale_factor();
+                    let top = ((inner_height - container_height) * scroll_y).round() / scale_factor;
+                    let left = ((inner_width - container_width) * scroll_x).round() / scale_factor;
 
-                    let mut scroll_x = self.scroll_x.get();
-                    let mut scroll_y = self.scroll_y.get();
-                    let inner_width = self.inner_width.get();
-                    let inner_height = self.inner_height.get();
-                    let mut container_width = self.container_width.get();
-                    let mut container_height = self.container_height.get();
+                    container_width = bounds.width();
+                    container_height = bounds.height();
 
-                    if inner_width != 0.0
-                        && inner_height != 0.0
-                        && container_width != 0.0
-                        && container_height != 0.0
-                    {
-                        let top =
-                            ((inner_height - container_height) * scroll_y).round() / scale_factor;
-                        let left =
-                            ((inner_width - container_width) * scroll_x).round() / scale_factor;
-
-                        container_width = bounds.width();
-                        container_height = bounds.height();
-
-                        if inner_width != container_width {
-                            scroll_x = ((left * scale_factor) / (inner_width - container_width))
-                                .clamp(0.0, 1.0);
-                        } else {
-                            scroll_x = 0.0;
-                        }
-
-                        if inner_height != container_height {
-                            scroll_y = ((top * scale_factor) / (inner_height - container_height))
-                                .clamp(0.0, 1.0);
-                        } else {
-                            scroll_y = 0.0;
-                        }
-
-                        self.scroll_x.set(scroll_x);
-                        self.scroll_y.set(scroll_y);
-                        self.container_width.set(container_width);
-                        self.container_height.set(container_height);
-
-                        if let Some(callback) = &self.on_scroll {
-                            (callback)(cx, self.scroll_x.get(), self.scroll_y.get());
-                        }
-
-                        self.reset();
+                    if inner_width != container_width {
+                        scroll_x = ((left * scale_factor) / (inner_width - container_width))
+                            .clamp(0.0, 1.0);
+                    } else {
+                        scroll_x = 0.0;
                     }
 
-                    self.container_width.set(bounds.width());
-                    self.container_height.set(bounds.height());
+                    if inner_height != container_height {
+                        scroll_y = ((top * scale_factor) / (inner_height - container_height))
+                            .clamp(0.0, 1.0);
+                    } else {
+                        scroll_y = 0.0;
+                    }
+
+                    self.scroll_x.set(scroll_x);
+                    self.scroll_y.set(scroll_y);
+                    self.container_width.set(container_width);
+                    self.container_height.set(container_height);
+
+                    if let Some(callback) = &self.on_scroll {
+                        (callback)(cx, self.scroll_x.get(), self.scroll_y.get());
+                    }
+
+                    self.reset();
                 }
+
+                self.container_width.set(bounds.width());
+                self.container_height.set(bounds.height());
             }
 
             WindowEvent::MouseScroll(x, y) => {
@@ -464,14 +461,13 @@ impl View for ScrollContent {
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, _| match window_event {
-            WindowEvent::GeometryChanged(geo) => {
-                if geo.contains(GeoChanged::WIDTH_CHANGED)
-                    || geo.contains(GeoChanged::HEIGHT_CHANGED)
-                {
-                    let bounds = cx.bounds();
-                    // If the width or height have changed then send this back up to the ScrollData.
-                    cx.emit(ScrollEvent::ChildGeo(bounds.w, bounds.h));
-                }
+            WindowEvent::GeometryChanged(geo)
+                if (geo.contains(GeoChanged::WIDTH_CHANGED)
+                    || geo.contains(GeoChanged::HEIGHT_CHANGED)) =>
+            {
+                let bounds = cx.bounds();
+                // If the width or height have changed then send this back up to the ScrollData.
+                cx.emit(ScrollEvent::ChildGeo(bounds.w, bounds.h));
             }
 
             _ => {}

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -186,54 +186,51 @@ where
 
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|window_event, _| match window_event {
-            WindowEvent::MouseDown(button) if *button == MouseButton::Left => {
-                if !cx.is_disabled() {
-                    self.is_dragging = true;
-                    cx.capture();
-                    cx.focus_with_visibility(false);
-                    cx.with_current(Entity::root(), |cx| {
-                        cx.set_pointer_events(false);
-                    });
+            WindowEvent::MouseDown(button) if *button == MouseButton::Left && !cx.is_disabled() => {
+                self.is_dragging = true;
+                cx.capture();
+                cx.focus_with_visibility(false);
+                cx.with_current(Entity::root(), |cx| {
+                    cx.set_pointer_events(false);
+                });
 
-                    let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
-                    let thumb_size = match self.orientation.get() {
-                        Orientation::Horizontal => cx.cache.get_width(thumb),
-                        Orientation::Vertical => cx.cache.get_height(thumb),
-                    };
-                    let min = self.range.get().start;
-                    let max = self.range.get().end;
-                    let step = self.step.get();
+                let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                let thumb_size = match self.orientation.get() {
+                    Orientation::Horizontal => cx.cache.get_width(thumb),
+                    Orientation::Vertical => cx.cache.get_height(thumb),
+                };
+                let min = self.range.get().start;
+                let max = self.range.get().end;
+                let step = self.step.get();
 
-                    let current = cx.current();
-                    let width = cx.cache.get_width(current);
-                    let height = cx.cache.get_height(current);
-                    let posx = cx.cache.get_posx(current);
-                    let posy = cx.cache.get_posy(current);
+                let current = cx.current();
+                let width = cx.cache.get_width(current);
+                let height = cx.cache.get_height(current);
+                let posx = cx.cache.get_posx(current);
+                let posy = cx.cache.get_posy(current);
 
-                    let mut dx = match self.orientation.get() {
-                        Orientation::Horizontal => {
-                            (cx.mouse.left.pos_down.0 - posx - thumb_size / 2.0)
-                                / (width - thumb_size)
-                        }
-
-                        Orientation::Vertical => {
-                            (height - (cx.mouse.left.pos_down.1 - posy) - thumb_size / 2.0)
-                                / (height - thumb_size)
-                        }
-                    };
-
-                    dx = dx.clamp(0.0, 1.0);
-
-                    let mut val = min + dx * (max - min);
-
-                    val = step * (val / step).ceil();
-                    val = val.clamp(min, max);
-
-                    if let Some(callback) = self.on_change.take() {
-                        (callback)(cx, val);
-
-                        self.on_change = Some(callback);
+                let mut dx = match self.orientation.get() {
+                    Orientation::Horizontal => {
+                        (cx.mouse.left.pos_down.0 - posx - thumb_size / 2.0) / (width - thumb_size)
                     }
+
+                    Orientation::Vertical => {
+                        (height - (cx.mouse.left.pos_down.1 - posy) - thumb_size / 2.0)
+                            / (height - thumb_size)
+                    }
+                };
+
+                dx = dx.clamp(0.0, 1.0);
+
+                let mut val = min + dx * (max - min);
+
+                val = step * (val / step).ceil();
+                val = val.clamp(min, max);
+
+                if let Some(callback) = self.on_change.take() {
+                    (callback)(cx, val);
+
+                    self.on_change = Some(callback);
                 }
             }
 
@@ -246,44 +243,42 @@ where
                 });
             }
 
-            WindowEvent::MouseMove(x, y) => {
-                if self.is_dragging {
-                    let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
-                    let thumb_size = match self.orientation.get() {
-                        Orientation::Horizontal => cx.cache.get_width(thumb),
-                        Orientation::Vertical => cx.cache.get_height(thumb),
-                    };
+            WindowEvent::MouseMove(x, y) if self.is_dragging => {
+                let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                let thumb_size = match self.orientation.get() {
+                    Orientation::Horizontal => cx.cache.get_width(thumb),
+                    Orientation::Vertical => cx.cache.get_height(thumb),
+                };
 
-                    let min = self.range.get().start;
-                    let max = self.range.get().end;
-                    let step = self.step.get();
+                let min = self.range.get().start;
+                let max = self.range.get().end;
+                let step = self.step.get();
 
-                    let current = cx.current();
-                    let width = cx.cache.get_width(current);
-                    let height = cx.cache.get_height(current);
-                    let posx = cx.cache.get_posx(current);
-                    let posy = cx.cache.get_posy(current);
+                let current = cx.current();
+                let width = cx.cache.get_width(current);
+                let height = cx.cache.get_height(current);
+                let posx = cx.cache.get_posx(current);
+                let posy = cx.cache.get_posy(current);
 
-                    let mut dx = match self.orientation.get() {
-                        Orientation::Horizontal => {
-                            (*x - posx - thumb_size / 2.0) / (width - thumb_size)
-                        }
-
-                        Orientation::Vertical => {
-                            (height - (*y - posy) - thumb_size / 2.0) / (height - thumb_size)
-                        }
-                    };
-
-                    dx = dx.clamp(0.0, 1.0);
-
-                    let mut val = min + dx * (max - min);
-
-                    val = step * (val / step).ceil();
-                    val = val.clamp(min, max);
-
-                    if let Some(callback) = &self.on_change {
-                        (callback)(cx, val);
+                let mut dx = match self.orientation.get() {
+                    Orientation::Horizontal => {
+                        (*x - posx - thumb_size / 2.0) / (width - thumb_size)
                     }
+
+                    Orientation::Vertical => {
+                        (height - (*y - posy) - thumb_size / 2.0) / (height - thumb_size)
+                    }
+                };
+
+                dx = dx.clamp(0.0, 1.0);
+
+                let mut val = min + dx * (max - min);
+
+                val = step * (val / step).ceil();
+                val = val.clamp(min, max);
+
+                if let Some(callback) = &self.on_change {
+                    (callback)(cx, val);
                 }
             }
 

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -189,10 +189,10 @@ where
             cx.add_listener(move |textbox: &mut Self, cx, event| {
                 let flag: bool = textbox.edit;
                 event.map(|window_event, meta| match window_event {
-                    WindowEvent::MouseDown(_) => {
-                        if flag && meta.origin != cx.current() && cx.hovered() != cx.current() {
-                            cx.emit(TextEvent::Blur);
-                        }
+                    WindowEvent::MouseDown(_)
+                        if flag && meta.origin != cx.current() && cx.hovered() != cx.current() =>
+                    {
+                        cx.emit(TextEvent::Blur);
                     }
 
                     _ => {}
@@ -1020,12 +1020,11 @@ where
                 }
             }
 
-            WindowEvent::FocusIn => {
-                if cx.mouse.left.pressed != cx.current()
-                    || cx.mouse.left.state == MouseButtonState::Released
-                {
-                    cx.emit(TextEvent::StartEdit);
-                }
+            WindowEvent::FocusIn
+                if (cx.mouse.left.pressed != cx.current()
+                    || cx.mouse.left.state == MouseButtonState::Released) =>
+            {
+                cx.emit(TextEvent::StartEdit);
             }
 
             WindowEvent::FocusOut => {
@@ -1046,16 +1045,15 @@ where
                 cx.release();
             }
 
-            WindowEvent::MouseMove(x, y) => {
+            WindowEvent::MouseMove(x, y)
                 if cx.mouse.left.state == MouseButtonState::Pressed
-                    && cx.mouse.left.pressed == cx.current
-                {
-                    if self.edit {
-                        self.reset_caret_timer(cx);
-                    }
-                    if cx.mouse.left.pos_down.0 != *x || cx.mouse.left.pos_down.1 != *y {
-                        cx.emit(TextEvent::Drag(cx.mouse.cursor_x, cx.mouse.cursor_y));
-                    }
+                    && cx.mouse.left.pressed == cx.current =>
+            {
+                if self.edit {
+                    self.reset_caret_timer(cx);
+                }
+                if cx.mouse.left.pos_down.0 != *x || cx.mouse.left.pos_down.1 != *y {
+                    cx.emit(TextEvent::Drag(cx.mouse.cursor_x, cx.mouse.cursor_y));
                 }
             }
 
@@ -1063,7 +1061,7 @@ where
                 cx.emit(TextEvent::Scroll(*x, *y));
             }
 
-            WindowEvent::CharInput(c) => {
+            WindowEvent::CharInput(c)
                 if *c != '\u{1b}' && // Escape
                     *c != '\u{8}' && // Backspace
                     *c != '\u{9}' && // Tab
@@ -1072,28 +1070,33 @@ where
                     !cx.modifiers.ctrl() &&
                     !cx.modifiers.logo() &&
                     self.edit &&
-                    !cx.is_read_only()
-                {
-                    self.reset_caret_timer(cx);
-                    cx.emit(TextEvent::InsertText(String::from(*c)));
-                }
+                    !cx.is_read_only() =>
+            {
+                self.reset_caret_timer(cx);
+                cx.emit(TextEvent::InsertText(String::from(*c)));
             }
 
-            WindowEvent::ImeCommit(text) => {
-                if !cx.modifiers.ctrl() && !cx.modifiers.logo() && self.edit && !cx.is_read_only() {
-                    self.reset_caret_timer(cx);
-                    cx.emit(TextEvent::ClearPreedit);
-                    cx.emit(TextEvent::InsertText(text.to_string()));
+            WindowEvent::ImeCommit(text)
+                if !cx.modifiers.ctrl()
+                    && !cx.modifiers.logo()
+                    && self.edit
+                    && !cx.is_read_only() =>
+            {
+                self.reset_caret_timer(cx);
+                cx.emit(TextEvent::ClearPreedit);
+                cx.emit(TextEvent::InsertText(text.to_string()));
 
-                    self.reset_ime_position(cx);
-                }
+                self.reset_ime_position(cx);
             }
 
-            WindowEvent::ImePreedit(text, cursor) => {
-                if !cx.modifiers.ctrl() && !cx.modifiers.logo() && self.edit && !cx.is_read_only() {
-                    self.reset_caret_timer(cx);
-                    cx.emit(TextEvent::UpdatePreedit(text.to_string(), *cursor));
-                }
+            WindowEvent::ImePreedit(text, cursor)
+                if !cx.modifiers.ctrl()
+                    && !cx.modifiers.logo()
+                    && self.edit
+                    && !cx.is_read_only() =>
+            {
+                self.reset_caret_timer(cx);
+                cx.emit(TextEvent::UpdatePreedit(text.to_string(), *cursor));
             }
 
             WindowEvent::KeyDown(code, _) => match code {

--- a/crates/vizia_core/src/views/tooltip.rs
+++ b/crates/vizia_core/src/views/tooltip.rs
@@ -75,19 +75,19 @@ impl Tooltip {
             .on_build(|ex| {
                 ex.add_listener(move |tooltip: &mut Tooltip, ex, event| {
                     event.map(|window_event, _| match window_event {
-                        WindowEvent::MouseMove(x, y) => {
-                            if tooltip.placement == Placement::Cursor && !x.is_nan() && !y.is_nan()
-                            {
-                                let scale = ex.scale_factor();
-                                let parent = ex.parent();
-                                let parent_bounds = ex.cache.get_bounds(parent);
-                                if parent_bounds.contains_point(*x, *y) {
-                                    ex.set_left(Pixels(
-                                        ((*x - parent_bounds.x) - ex.bounds().width() / 2.0)
-                                            / scale,
-                                    ));
-                                    ex.set_top(Pixels((*y - parent_bounds.y) / scale));
-                                }
+                        WindowEvent::MouseMove(x, y)
+                            if tooltip.placement == Placement::Cursor
+                                && !x.is_nan()
+                                && !y.is_nan() =>
+                        {
+                            let scale = ex.scale_factor();
+                            let parent = ex.parent();
+                            let parent_bounds = ex.cache.get_bounds(parent);
+                            if parent_bounds.contains_point(*x, *y) {
+                                ex.set_left(Pixels(
+                                    ((*x - parent_bounds.x) - ex.bounds().width() / 2.0) / scale,
+                                ));
+                                ex.set_top(Pixels((*y - parent_bounds.y) / scale));
                             }
                         }
 

--- a/crates/vizia_core/src/views/virtual_list.rs
+++ b/crates/vizia_core/src/views/virtual_list.rs
@@ -375,10 +375,10 @@ impl View for VirtualList {
         });
 
         event.map(|window_event, _| match window_event {
-            WindowEvent::GeometryChanged(geo) => {
-                if geo.intersects(GeoChanged::WIDTH_CHANGED | GeoChanged::HEIGHT_CHANGED) {
-                    self.recalc(cx);
-                }
+            WindowEvent::GeometryChanged(geo)
+                if geo.intersects(GeoChanged::WIDTH_CHANGED | GeoChanged::HEIGHT_CHANGED) =>
+            {
+                self.recalc(cx);
             }
 
             _ => {}

--- a/crates/vizia_core/src/views/xypad.rs
+++ b/crates/vizia_core/src/views/xypad.rs
@@ -77,18 +77,16 @@ impl View for XYPad {
                 }
             }
 
-            WindowEvent::MouseMove(x, y) => {
-                if self.is_dragging {
-                    let current = cx.current();
-                    let mut dx = (*x - cx.cache.get_posx(current)) / cx.cache.get_width(current);
-                    let mut dy = (*y - cx.cache.get_posy(current)) / cx.cache.get_height(current);
+            WindowEvent::MouseMove(x, y) if self.is_dragging => {
+                let current = cx.current();
+                let mut dx = (*x - cx.cache.get_posx(current)) / cx.cache.get_width(current);
+                let mut dy = (*y - cx.cache.get_posy(current)) / cx.cache.get_height(current);
 
-                    dx = dx.clamp(0.0, 1.0);
-                    dy = dy.clamp(0.0, 1.0);
+                dx = dx.clamp(0.0, 1.0);
+                dy = dy.clamp(0.0, 1.0);
 
-                    if let Some(callback) = &self.on_change {
-                        (callback)(cx, dx, 1.0 - dy);
-                    }
+                if let Some(callback) = &self.on_change {
+                    (callback)(cx, dx, 1.0 - dy);
                 }
             }
 

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -282,8 +282,8 @@ impl Application {
                     );
 
                     window.set_outer_position(PhysicalPosition::new(
-                        parent_position.x + x as i32 + offset.x,
-                        parent_position.y + y as i32 + offset.y,
+                        parent_position.x + x + offset.x,
+                        parent_position.y + y + offset.y,
                     ));
                 }
             }


### PR DESCRIPTION
The Test workflow runs `cargo clippy` with `RUSTFLAGS: '-D warnings'`, which turns clippy warnings into errors. `main` currently has 41 such warnings that fail CI on every PR.

This PR addresses them all:

- `collapsible_match`: rewrite nested `if` blocks inside `match` arms as match guards. Auto-applied by `cargo clippy --fix` for most cases; four remaining instances in `views/menu.rs` and `views/popup.rs` adjusted manually due to control-flow nuance.
- `unnecessary_cast` in `vizia_winit/src/application.rs`: drop two `as i32` casts where the operand is already `i32`.
- `needless_range_loop` in `text/editable_text.rs::next_line_break`: replace manual index counter with `(from..).zip(bytes)`.

All fixes are mechanical — no behaviour change. Workspace reformatted with `cargo fmt --all` to satisfy the `Check Format` step.