### PR TITLE
fix(baseview): integrate sync reactive runtime

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -210,6 +210,11 @@ impl ApplicationRunner {
     /// Handle all reactivity within a frame. The window instance is used to resize the window when
     /// needed.
     pub fn on_frame_update(&mut self, window: &mut Window) {
+        // Pick up any effects enqueued by off-UI-thread `SyncSignal` writes since the last
+        // frame. These sit in `SYNC_RUNTIME` until a UI-thread call processes them — this
+        // is the analogue of the `drain_pending_work` call in `vizia_winit`'s frame loop.
+        Runtime::drain_pending_work();
+
         while let Some(event) = queue_get() {
             self.cx.send_event(event);
         }

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -32,6 +32,24 @@ impl ViziaWindow {
         builder: Option<Box<dyn FnOnce(&mut Context) + Send>>,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
     ) -> ViziaWindow {
+        // Reactive runtime setup — mirrors what `vizia_winit::Application::new` does.
+        //
+        // Mark this thread as the UI thread so off-thread `SyncSignal` writes correctly
+        // enqueue effects via `SYNC_RUNTIME` instead of the thread-local `RUNTIME` (which
+        // nobody drains). `on_frame_update` later calls `Runtime::drain_pending_work` to
+        // apply those effects on this thread.
+        Runtime::init_on_ui_thread();
+
+        // Register a no-op sync waker. baseview doesn't expose a proxy-event primitive we
+        // can use to wake the event loop from another thread, but it drives `on_frame` at
+        // the host compositor's vsync rate anyway — signal changes from off-UI writes will
+        // be observed on the next frame (at most one frame of latency).
+        //
+        // Registering the waker here — even as a no-op — has two benefits: (1) it matches
+        // the pattern in `vizia_winit`, so embedders don't have to know about sync-runtime
+        // internals; (2) if a future baseview release gains a window-wake mechanism, only
+        // this one line needs to change.
+        Runtime::set_sync_effect_waker(|| {});
         let context = window.gl_context().expect("Window was created without OpenGL support");
 
         unsafe { context.make_current() };

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -64,7 +64,7 @@ pub mod prelude {
     pub use super::binding::{Binding, Res};
 
     pub use vizia_reactive::{
-        Effect, Memo, ReadSignal, Signal, SignalGet, SignalMap, SignalRead, SignalTrack,
+        Effect, Memo, ReadSignal, Runtime, Signal, SignalGet, SignalMap, SignalRead, SignalTrack,
         SignalUpdate, SignalWith, SignalWrite, SyncDerivedSignal, SyncReadSignal, SyncSignal,
         SyncWriteSignal, UpdaterEffect, WriteSignal,
     };


### PR DESCRIPTION
## Summary

`vizia_baseview` is missing the sync-runtime integration that `vizia_winit` does at `Application::new`. Without it, embedders using `Binding::new` to observe a `SyncSignal` written from an off-UI thread never see their bindings rebuild — effects enqueue into `SYNC_RUNTIME` but nothing on the UI side calls `Runtime::drain_pending_work()` to process them.

## Context

Please read [vizia-plug#13](https://github.com/vizia/vizia-plug/pull/13) first — it's the motivating use case and explains the shape of the fix. In short: audio plugins using vizia-plug bridge parameter changes from the host/audio thread into `SyncSignal<f32>` values, then bind widget properties to those signals via `Binding::new`. Without `drain_pending_work` on the baseview side, widgets don't update until something else forces an event loop iteration.

## Changes

Three small changes in vizia that together mirror `vizia_winit`'s sync-runtime setup:

### `vizia_baseview/src/window.rs` — register sync-runtime at window setup

- `Runtime::init_on_ui_thread()` so off-thread `SyncSignal` writes route to `SYNC_RUNTIME` instead of the thread-local runtime.
- `Runtime::set_sync_effect_waker(|| {})` — a no-op waker. `baseview` doesn't currently expose a proxy-event primitive that would let another thread wake the event loop, but `on_frame` already fires at the compositor's vsync rate, so pending effects are observed on the next frame. Registering the waker (even as a no-op) matches the embedder contract `vizia_winit` sets.

### `vizia_baseview/src/application.rs` — drain pending work each frame

`Runtime::drain_pending_work()` at the start of `on_frame_update`, before `flush_events`, so queued off-thread effects run and mark bindings for rebuild before the binding system walks them. This mirrors the equivalent call at the top of `vizia_winit::Application::about_to_wait`.

### `vizia_core/src/lib.rs` — re-export `Runtime` from `prelude`

`Runtime` lives alongside `Signal`, `Memo`, `SignalGet`, etc. in `vizia_reactive`, but the rest of that module is already re-exported from `vizia_core::prelude` while `Runtime` wasn't. With this change, embedders can call `Runtime::drain_pending_work()` (or `Runtime::set_sync_effect_waker`) via `vizia::prelude::Runtime` without adding a direct `vizia_reactive` dep.

## Testing

- Verified `cargo check --workspace` passes clean on current main (`12ff2584`) with these changes.
- Verified end-to-end in vizia-plug: with a local `[patch]` pointing at this branch, vizia-plug's `ParamRegistry::flush_all()` → `SyncSignal::set_if_changed` → `Binding::new` observer rebuild chain works for parameters changed from the audio thread.

## Impact on vizia-plug#13

vizia-plug#13 currently compensates for the missing drain by carrying a direct `vizia_reactive` dep and calling `Runtime::drain_pending_work()` from its own `on_idle` callback. Once this lands and vizia-plug bumps its vizia rev, both the direct dep and the manual `on_idle` drain can be removed — vizia-plug becomes a plain consumer of the re-exported `Runtime` (or doesn't need to touch `Runtime` at all, since `on_frame_update` handles draining).

---

Small, isolated, matches the existing winit-side pattern. No behavior change for existing baseview consumers that don't use `SyncSignal`.