### PR TITLE
fix(reactive): SyncSignal::set_if_changed actually skips on unchanged values

### DIFF
--- a/crates/vizia_reactive/src/sync_signal.rs
+++ b/crates/vizia_reactive/src/sync_signal.rs
@@ -445,3 +445,55 @@ impl<T: Send + Sync> SignalWrite<T> for SyncWriteSignal<T> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::{Scope, SignalGet, SignalUpdate, SyncSignal, UpdaterEffect};
+
+    /// Regression: `set_if_changed` must not notify subscribers when the new value equals the
+    /// stored value. The previous implementation delegated to `try_update`, which fires effects
+    /// unconditionally — so the equality guard on the internal assignment was ineffective and
+    /// every `set_if_changed` call behaved like `set`.
+    ///
+    /// Deliberately does NOT call `Runtime::init_on_ui_thread()`: that flips the global
+    /// UI-thread-enforcement flag, which would retroactively panic any other reactive test
+    /// running on a different thread under `cargo test`'s default parallel executor.
+    #[test]
+    fn set_if_changed_skips_notifications_when_value_unchanged() {
+        let scope = Scope::new();
+
+        let signal = SyncSignal::new(42_i32);
+        let fires = Arc::new(AtomicUsize::new(0));
+
+        let fires_in_effect = fires.clone();
+        scope.enter(|| {
+            UpdaterEffect::new(
+                move || signal.get(),
+                move |_| {
+                    fires_in_effect.fetch_add(1, Ordering::SeqCst);
+                },
+            );
+        });
+
+        // `UpdaterEffect::new` runs `compute` once at registration but does not invoke
+        // `on_change` until a signal write fires effects. Baseline should be 0.
+        assert_eq!(fires.load(Ordering::SeqCst), 0, "baseline: on_change not yet fired");
+
+        // Same-value write: equality guard must short-circuit before any effect fires.
+        signal.set_if_changed(42);
+        assert_eq!(fires.load(Ordering::SeqCst), 0, "same-value write should skip");
+
+        // Different-value write: must fire once.
+        signal.set_if_changed(100);
+        assert_eq!(fires.load(Ordering::SeqCst), 1, "different-value write should fire");
+
+        // Second same-value write (the new current is now 100): must skip again.
+        signal.set_if_changed(100);
+        assert_eq!(fires.load(Ordering::SeqCst), 1, "same-value re-write should skip");
+
+        scope.dispose();
+    }
+}

--- a/crates/vizia_reactive/src/write.rs
+++ b/crates/vizia_reactive/src/write.rs
@@ -100,12 +100,6 @@ pub trait SignalUpdate<T> {
     }
 
     /// Sets the new_value to the Signal and triggers effect run only if the value has changed.
-    ///
-    /// The previous implementation delegated to `try_update` with an internal equality guard
-    /// on the assignment, but `try_update` fires effects unconditionally regardless of whether
-    /// the closure mutated the value — so `set_if_changed` behaved like `set` for every caller,
-    /// in violation of its documented contract. This short-circuits with a non-tracking read
-    /// and only falls through to `set` when the new value genuinely differs.
     fn set_if_changed(&self, new_value: T)
     where
         T: PartialEq + 'static,

--- a/crates/vizia_reactive/src/write.rs
+++ b/crates/vizia_reactive/src/write.rs
@@ -111,10 +111,7 @@ pub trait SignalUpdate<T> {
         T: PartialEq + 'static,
         Self: SignalRead<T>,
     {
-        let equal = self
-            .try_read_untracked()
-            .map(|current| *current == new_value)
-            .unwrap_or(false);
+        let equal = self.try_read_untracked().map(|current| *current == new_value).unwrap_or(false);
         if !equal {
             self.set(new_value);
         }

--- a/crates/vizia_reactive/src/write.rs
+++ b/crates/vizia_reactive/src/write.rs
@@ -6,7 +6,7 @@ use std::{
 
 use parking_lot::{Mutex, MutexGuard};
 
-use crate::{id::Id, signal::TrackedRefCell};
+use crate::{id::Id, read::SignalRead, signal::TrackedRefCell};
 
 pub struct SyncWriteRef<'a, T> {
     id: Id,
@@ -99,16 +99,25 @@ pub trait SignalUpdate<T> {
         let _ = self.try_update(|v| *v = new_value);
     }
 
-    /// Sets the new_value to the Signal and triggers effect run only if the value has changed
+    /// Sets the new_value to the Signal and triggers effect run only if the value has changed.
+    ///
+    /// The previous implementation delegated to `try_update` with an internal equality guard
+    /// on the assignment, but `try_update` fires effects unconditionally regardless of whether
+    /// the closure mutated the value — so `set_if_changed` behaved like `set` for every caller,
+    /// in violation of its documented contract. This short-circuits with a non-tracking read
+    /// and only falls through to `set` when the new value genuinely differs.
     fn set_if_changed(&self, new_value: T)
     where
         T: PartialEq + 'static,
+        Self: SignalRead<T>,
     {
-        let _ = self.try_update(|v| {
-            if *v != new_value {
-                *v = new_value;
-            }
-        });
+        let equal = self
+            .try_read_untracked()
+            .map(|current| *current == new_value)
+            .unwrap_or(false);
+        if !equal {
+            self.set(new_value);
+        }
     }
 
     /// Update the stored value with the given function and triggers effect run


### PR DESCRIPTION
## Problem

`SyncSignal::set_if_changed` (default `SignalUpdate` impl, used by both `Signal` and `SyncSignal`) is documented as _"Sets the new_value to the Signal and triggers effect run **only if the value has changed**"_. The current implementation doesn't do that:

```rust
fn set_if_changed(&self, new_value: T)
where
    T: PartialEq + 'static,
{
    let _ = self.try_update(|v| {
        if *v != new_value {
            *v = new_value;
        }
    });
}
```

`try_update` fires effects unconditionally regardless of whether the closure mutated the value — the inner `if` guards only the assignment. Every call to `set_if_changed` therefore behaves like `set` as far as subscribers are concerned.

## Impact

Observable in any consumer that fans current values into a batch of signals on an external event (parameter registry flush, ECS snapshot push, server-sync diff). Every such flush cascades notifications to every subscriber regardless of whether values actually changed.

Concretely, this bit me downstream in a [vizia-plug `ParamRegistry::flush_all()`](https://github.com/vizia/vizia-plug/pull/13) run: dragging one parameter wrote one signal, which re-fired every subscriber of every other signal in the registry — collapsing `Binding`-wrapped subtrees mid-gesture and breaking interactive widgets across the editor.

## Fix

Short-circuit before `try_update`: read the current value via `try_read_untracked` and only fall through to `set` when the new value genuinely differs. Matches the documented contract.

Also adds a regression test in `sync_signal.rs`'s existing convention (inline `#[cfg(test)] mod tests`) verifying:
- `set_if_changed(same_value)` → 0 effect fires
- `set_if_changed(different_value)` → 1 effect fire

The test deliberately avoids calling `Runtime::init_on_ui_thread()` — that flips the global UI-thread-enforcement flag, which would retroactively panic any other reactive test running on a different thread under `cargo test`'s default parallel executor.

## Test plan

- [x] `cargo test -p vizia_reactive` — all 7 tests pass (the new one + the 6 existing)
- [x] `cargo check --workspace` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)