### PR TITLE
fix(core): skip SVG SrcIn recolor when fill is transparent (escape hatch for multi-color SVGs)

### DIFF
--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -1137,12 +1137,24 @@ impl DrawContext<'_> {
                                                 self.current,
                                                 &self.style.custom_color_props,
                                             ) {
-                                                let mut paint = Paint::default();
-
-                                                paint.set_anti_alias(true);
-                                                paint.set_blend_mode(skia_safe::BlendMode::SrcIn);
-                                                paint.set_color(color);
-                                                canvas.draw_paint(&paint);
+                                                // Escape hatch for multi-color SVGs (logos,
+                                                // illustrations) that would otherwise be flooded
+                                                // by the root-level `fill: var(--foreground)`
+                                                // tint in the default theme. Setting
+                                                // `fill: transparent` on such elements makes the
+                                                // SrcIn pass a no-op, so the SVG's own path
+                                                // fills render untouched. Icon SVGs that want
+                                                // the tint still work — they set a
+                                                // non-transparent fill explicitly. See #636.
+                                                if color.a() != 0 {
+                                                    let mut paint = Paint::default();
+                                                    paint.set_anti_alias(true);
+                                                    paint.set_blend_mode(
+                                                        skia_safe::BlendMode::SrcIn,
+                                                    );
+                                                    paint.set_color(color);
+                                                    canvas.draw_paint(&paint);
+                                                }
                                             }
                                             canvas.restore();
                                         }


### PR DESCRIPTION
## Problem

See #636 for the full write-up. Briefly: widget-update's post-render `SrcIn` paint combined with the default theme's `:root { fill: var(--foreground); }` floods every `Svg::new(cx, …)` widget with the foreground color, which is exactly what you want for monochrome icons but silently destroys multi-color logos, illustrations, and brand SVGs.

There's currently no clean escape hatch — `fill` is typed as `Color` with no `None` variant, so `fill: none` doesn't parse.

## What this PR does

Adds a minimal escape hatch: when the resolved `fill` has alpha 0 (e.g. `fill: transparent` in CSS), skip the `SrcIn` paint entirely. The SVG's own path fills render untouched. Icon SVGs that want tinting still work — they opt in by setting a non-transparent fill.

Before:

```svg
<!-- logo.svg with literal hex fills -->
<path fill=\"#fc6b2d\" d=\"…\"/>
<path fill=\"#8f5bff\" d=\"…\"/>
```

```rust
Svg::new(cx, include_str!(\"logo.svg\"));  // rendered entirely in #1C1A15 (foreground)
```

After, with:

```css
svg.logo { fill: transparent; }
```

…the SVG renders with its native colors intact.

## Why this shape

Magic-value-ish, acknowledged. The principled fixes are bigger and both tracked in #636:

1. **`currentColor`-aware recolor** — parse the SVG, substitute `currentColor` references against the resolved fill, leave literal hex fills alone. Matches how SVG actually works in browsers; no consumer opt-in needed.
2. **Real `fill: none` CSS keyword** backed by a proper `Fill` enum (either a new type or a `Color::None` variant). Smaller footprint than (1), still a first-class semantic.

Either one supersedes this patch cleanly without breaking call sites — a consumer that wrote `fill: transparent` can switch to `fill: none` once the keyword exists, and/or drop the opt-out entirely once `currentColor`-aware recolor lands. I didn't want to gate unblocking downstream consumers on the larger design.

Happy to follow up with either (1) or (2) if there's direction.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy` clean (CI-equivalent)
- [x] Verified on a real multi-color brand SVG in a vizia-plug-backed plugin editor — logo renders with native hex fills; unrelated icon SVGs in the same editor still get tinted as before

## Context links

- #636 — tracking issue with the fuller design discussion
- vizia-plug#13 — the downstream PR this surfaced from