### PR TITLE
fix(resource): fall back to registered bundle when requested locale is missing

### DIFF
--- a/crates/vizia_core/src/resource/mod.rs
+++ b/crates/vizia_core/src/resource/mod.rs
@@ -346,11 +346,8 @@ impl ResourceManager {
         // is one of them, otherwise the first registered translation. `available` is
         // non-empty here (checked above), so `available.first()` is always `Some`.
         let first_available = *available.first().expect("non-empty checked above");
-        let fallback = if available.iter().any(|&l| l == &self.language) {
-            &self.language
-        } else {
-            first_available
-        };
+        let fallback =
+            if available.contains(&&self.language) { &self.language } else { first_available };
         let langs = fluent_langneg::negotiate::negotiate_languages(
             &[locale],
             &available,

--- a/crates/vizia_core/src/resource/mod.rs
+++ b/crates/vizia_core/src/resource/mod.rs
@@ -342,16 +342,23 @@ impl ResourceManager {
             return LanguageIdentifier::default();
         }
 
-        let default = LanguageIdentifier::default();
-        let default_ref = &default;
+        // Pick a fallback from the registered translations: prefer `self.language` if it
+        // is one of them, otherwise the first registered translation. `available` is
+        // non-empty here (checked above), so `available.first()` is always `Some`.
+        let first_available = *available.first().expect("non-empty checked above");
+        let fallback = if available.iter().any(|&l| l == &self.language) {
+            &self.language
+        } else {
+            first_available
+        };
         let langs = fluent_langneg::negotiate::negotiate_languages(
             &[locale],
             &available,
-            Some(&default_ref),
+            Some(&fallback),
             fluent_langneg::NegotiationStrategy::Filtering,
         );
 
-        langs.first().map(|lang| (**lang).clone()).unwrap_or(default)
+        langs.first().map(|lang| (**lang).clone()).unwrap_or_else(|| fallback.clone())
     }
 
     pub fn translation_locales(&self, locale: &LanguageIdentifier) -> Vec<LanguageIdentifier> {
@@ -471,15 +478,37 @@ mod tests {
     }
 
     #[test]
-    fn current_translation_uses_default_bundle_when_requested_locale_missing() {
+    fn current_translation_falls_back_to_registered_bundle_when_requested_locale_missing() {
         let mut manager = ResourceManager::new();
 
         manager.add_translation("en-US".parse().unwrap(), "hello = Hello".to_string()).unwrap();
 
         let bundle = manager.current_translation(&"zz-ZZ".parse().unwrap());
+
+        assert!(bundle.get_message("hello").is_some());
+    }
+
+    #[test]
+    fn current_translation_returns_registered_bundle_for_exact_match() {
+        let mut manager = ResourceManager::new();
+
+        manager.add_translation("fr".parse().unwrap(), "hello = Bonjour".to_string()).unwrap();
+
+        let bundle = manager.current_translation(&"fr".parse().unwrap());
         let message = bundle.get_message("hello");
 
         assert!(message.is_some());
+    }
+
+    #[test]
+    fn current_translation_returns_empty_default_when_no_translations_registered() {
+        let manager = ResourceManager::new();
+
+        // No `add_translation` call. The only entry in `translations` is the seeded empty
+        // default. A miss must not panic — it falls back to that default bundle.
+        let bundle = manager.current_translation(&"zz-ZZ".parse().unwrap());
+
+        assert!(bundle.get_message("hello").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

See #639 for the full diagnosis. Summary: `ResourceManager::current_translation` for a locale that has no registered translation routes through a fallback that targets `LanguageIdentifier::default()` — the empty seed bundle constructed in `ResourceManager::new`. So misses land there instead of on any registered translation, and `get_message` returns `None` even when a real translation exists right next to the seed in the map.

## Fix

In `negotiate_translation_locale`, build the fluent-langneg fallback from the registered translations themselves:

1. Prefer `self.language` if it happens to be one of the registered locales (common case when the user's system locale matches a registered translation, after `add_translation` runs `renegotiate_language`).
2. Otherwise pick the first registered translation. This covers the case where `renegotiate_language` couldn't match `sys_locale` against any registered locale and left `self.language` at the empty default — typical on systems whose locale doesn't match the registered translations (e.g. `ru-RU` system, only `en-US` registered).

The early-return for "only the default seed is registered" is unchanged — that path still returns the empty default without panicking.

This is direction (1) from the issue body, which you endorsed.

## Test plan

- [x] Renames the existing failing regression test (`current_translation_uses_default_bundle_when_requested_locale_missing`) to accurately describe the new behaviour — it now passes.
- [x] Adds `current_translation_returns_registered_bundle_for_exact_match` as a forward-direction sanity check (registered exact-match returns its own bundle).
- [x] Adds `current_translation_returns_empty_default_when_no_translations_registered` to pin the "seed-only" edge case — that path is unchanged and still returns the empty default.
- [x] `cargo test -p vizia_core --lib resource::` — 7/7 pass.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy` clean (CI-equivalent).
