### PR TITLE
fix(core): labels wrap by default again

### DIFF
--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -463,7 +463,6 @@ knob {
 
 label {
     size: auto;
-    text-wrap: false;
     direction: auto;
 }
 


### PR DESCRIPTION
## Problem

See #637 for the full repro. Briefly: a Label with long multi-line text (e.g. license blocks, help text, a 200+-line `include_str!`) renders only its first visual line with no clipping indicator — even inside a `ScrollView` with `.width(Stretch(1.0)).height(Auto)`. Adding `.text_wrap(true)` explicitly resolves it.

## Root cause

`crates/vizia_core/resources/themes/default_layout.css:466` carries:

```css
label {
    size: auto;
    text-wrap: false;   /* this */
    direction: auto;
}
```

Every Label resolves `style.text_wrap` to `Some(false)` via this cascade, and `build_paragraph` in `systems/text.rs` then sets `paragraph_style.set_max_lines(1)`:

```rust
if let Some(text_wrap) = style.text_wrap.get(entity).copied() {
    if !text_wrap {
        paragraph_style.set_max_lines(1);
    }
}
```

This contradicts the [`Label` rustdoc](https://github.com/vizia/vizia/blob/main/crates/vizia_core/src/views/label.rs#L32-L46) which says *"A label automatically wraps the text if it doesn't fit inside of the width of the label."*

## Fix

Remove the `text-wrap: false` declaration from the `label` selector. `style.text_wrap` now resolves to `None` by default, `build_paragraph`'s `if let Some(...)` branch is skipped, no `max_lines` constraint is applied, and Skia's own ParagraphStyle default (wrapping enabled) takes over. Labels now render their full paragraph height, matching the rustdoc promise.

## Explicit `.text_wrap(false)` callers

**Unaffected.** I understand from the discussion on #637 that there was previous work making `text_wrap(false)` actually work — I explicitly want to preserve that. The `.text_wrap(false)` modifier inserts `Some(false)` at the entity level, which overrides the CSS cascade regardless of whether the default is set or unset. `build_paragraph` still sees `Some(false)` for those entities and still applies `max_lines(1)`. So single-line labels that opt out explicitly keep working exactly as before.

The only behavioural change this PR introduces is for Labels that *never* called `.text_wrap(…)` at all — those now wrap, as the rustdoc already claimed they would.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (CI-equivalent with `RUSTFLAGS=-D warnings`)
- [x] `cargo build -p vizia_core` clean
- [x] Verified downstream: the 259-line license text block in my plugin's About modal (a Label inside a ScrollView with `width(Stretch(1.0)).height(Auto)`) now renders its full paragraph height without needing `.text_wrap(true)`.
- No dedicated regression test added — the `build_paragraph` branch is straightforward and the existing `text_wrap(false)` path is unchanged; happy to add one if you'd like, though the text layout system doesn't currently have a mocked-entity test harness and adding one feels out of scope for a one-line CSS fix.
