### PR TITLE
fix(core): proper fix for #637 — preserve hard newlines with text-wrap: false

### DIFF
--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -463,6 +463,7 @@ knob {
 
 label {
     size: auto;
+    text-wrap: false;
     direction: auto;
 }
 

--- a/crates/vizia_core/src/systems/text.rs
+++ b/crates/vizia_core/src/systems/text.rs
@@ -221,13 +221,6 @@ pub fn build_paragraph(
         paragraph_style.set_max_lines(line_clamp.0 as usize);
     }
 
-    if let Some(text_wrap) = style.text_wrap.get(entity).copied() {
-        if !text_wrap {
-            // Disable soft wrapping by constraining to a single visual line.
-            paragraph_style.set_max_lines(1);
-        }
-    }
-
     // Text Align
     paragraph_style.set_text_align(resolve_text_align(style, entity).into());
 


### PR DESCRIPTION
Apology first — my previous attempt at fixing #637, merged as #642, was misdiagnosed and made things significantly worse. Filing this PR to revert it and apply the actual fix, with the real root cause identified and runtime-tested end-to-end.

## Where #642 went wrong

My investigation for #637 was shallow — I removed `label { text-wrap: false; }` from `default_layout.css` on the assumption that rule was the cause, without verifying. It wasn't, and the side effect is bad: with the rule removed, `text-wrap` defaults to `true` on `label`. In `crates/vizia_core/src/layout/node.rs` `content_size`, `text-wrap=true` + `width: Auto` routes through `paragraph.min_intrinsic_width()` — the width of the longest single unbreakable word. Every short unconstrained Label collapses to per-word wrapping. This is worse than #637 itself.

## Actual root cause of #637

In `crates/vizia_core/src/systems/text.rs`, `build_paragraph`:

```rust
if let Some(text_wrap) = style.text_wrap.get(entity).copied() {
    if !text_wrap {
        // Disable soft wrapping by constraining to a single visual line.
        paragraph_style.set_max_lines(1);
    }
}
```

This block was **commented out** at `ea8e7144` (last known-good rev) and silently **uncommented** in `b39a138e` ("Add table and virtual_table views + examples", 2026-04-17) as an incidental 11-line edit inside an otherwise unrelated 1,300-line commit.

Skia's `ParagraphStyle::set_max_lines(1)` clamps the paragraph to exactly one *visual* line regardless of whether each break is soft (layout-driven reflow) or hard (`\n` in source text). So multi-line text collapses to its first line whenever `text-wrap: false` applies.

The block is also redundant for its stated purpose: the measure callback in `layout/node.rs` already guarantees no soft-wrap at `text-wrap=false` + `width: Auto` by handing the paragraph `paragraph.max_intrinsic_width()` at layout time. For `text-wrap=false` + a constrained width, keeping soft-wrap enabled is actually the correct behaviour — text flows within the given width while hard newlines still break.

## The fix

Two commits:
1. **Revert #642** — restores `label { text-wrap: false; }`.
2. **Remove the `set_max_lines(1)` block** — the real #637 fix.

Restores pre-`b39a138e` behaviour exactly:
- Short labels (`Auto` width, default `text-wrap: false`): single line at max-intrinsic width — unchanged.
- Multi-line labels with hard `\n` (default `text-wrap: false`): all lines render — fixes #637.
- Labels with explicit `.text_wrap(true)`: soft-wrap to container width — unchanged.

## Testing

Ran the fix end-to-end during my own plugin runtime validation. The symptom case is a large pre-formatted `\n`-delimited text block inside a `Label` with `width: Stretch(1.0)` — before this PR it was either broken (one line only, #637) or catastrophically broken (every short caption wrapping per-word, #642). With this PR: multi-line labels render every line, short labels stay single-line at natural width, explicit `.text_wrap(true)` callers are unaffected.

Sorry again for the churn. This one has been properly diagnosed and tested end-to-end.