### PR TITLE
Fix scrollbar offset not round-tripping through window minimize/restore.

### DIFF
--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -242,11 +242,7 @@ impl View for ScrollView {
                     let mut container_width = self.container_width.get();
                     let mut container_height = self.container_height.get();
 
-                    if inner_width != 0.0
-                        && inner_height != 0.0
-                        && container_width != 0.0
-                        && container_height != 0.0
-                    {
+                    if inner_width != 0.0 && inner_height != 0.0 {
                         let top =
                             ((inner_height - container_height) * scroll_y).round() / scale_factor;
                         let physical_scroll_x = ScrollView::map_scroll_x_to_physical(
@@ -368,11 +364,7 @@ impl View for ScrollView {
                     let mut container_width = self.container_width.get();
                     let mut container_height = self.container_height.get();
 
-                    if inner_width != 0.0
-                        && inner_height != 0.0
-                        && container_width != 0.0
-                        && container_height != 0.0
-                    {
+                    if inner_width != 0.0 && inner_height != 0.0 {
                         let top =
                             ((inner_height - container_height) * scroll_y).round() / scale_factor;
                         let physical_scroll_x = ScrollView::map_scroll_x_to_physical(


### PR DESCRIPTION
Minimizing then restoring the window would cause scrollbars to drift. Easy to see in the widget gallery example by scrolling the widget list down slightly and then repeatedly minimizing/restoring the window.

The bug was seemingly caused by these `container_width != 0.0 && container_height != 0.0` guards. The scroll position state would update when minimizing (i.e. before becoming size zero), but the guards prevent subsequent updates when restoring later (from size zero). After removing the guard the minimizing/restoring triggers should now be properly symmetrical.