### PR TITLE
Fix `display` modifier bugs.

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -323,6 +323,10 @@ impl Context {
     }
 
     pub(crate) fn set_system_flags(&mut self, entity: Entity, system_flags: SystemFlags) {
+        if system_flags.contains(SystemFlags::RELAYOUT) {
+            self.needs_relayout();
+        }
+
         if system_flags.contains(SystemFlags::RESTYLE) {
             self.needs_restyle(entity);
         }

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -248,7 +248,7 @@ pub trait StyleModifiers: internal::Modifiable {
         /// A display value of `Display::None` causes the view to be ignored by both layout and rendering.
         display,
         Display,
-        SystemFlags::RELAYOUT | SystemFlags::REDRAW
+        SystemFlags::RELAYOUT | SystemFlags::REDRAW | SystemFlags::REFLOW
     );
 
     modifier!(

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -45,25 +45,18 @@ pub(crate) fn draw_system(
 
         if entity.visible(&cx.style) {
             let draw_bounds = draw_bounds(&cx.style, &cx.cache, &cx.tree, entity);
-
-            let mut dirty_bounds = draw_bounds;
-
-            if let Some(previous_draw_bounds) = cx.cache.draw_bounds.get(entity) {
-                dirty_bounds = dirty_bounds.union(previous_draw_bounds);
-            }
-
-            if dirty_bounds.w > 0.0 && dirty_bounds.h > 0.0 {
-                if let Some(dr) = &mut dirty_rect {
-                    *dr = dr.union(&dirty_bounds);
-                } else {
-                    dirty_rect = Some(dirty_bounds);
-                }
-            }
-
-            if let Some(dr) = cx.cache.draw_bounds.get_mut(entity) {
-                *dr = draw_bounds;
-            } else {
-                cx.cache.draw_bounds.insert(entity, draw_bounds);
+            let dirty_bounds = cx
+                .cache
+                .draw_bounds
+                .get(entity)
+                .map_or(draw_bounds, |prev_bounds| draw_bounds.union(prev_bounds));
+            union_dirty_rect(&mut dirty_rect, dirty_bounds);
+            cx.cache.draw_bounds.insert(entity, draw_bounds);
+        } else {
+            // If the entity was previously visible but is no longer, we must dirty
+            // its previous area so that it is correctly cleared from the screen.
+            if let Some(previous_draw_bounds) = cx.cache.draw_bounds.remove(entity) {
+                union_dirty_rect(&mut dirty_rect, previous_draw_bounds);
             }
         }
     }
@@ -87,11 +80,7 @@ pub(crate) fn draw_system(
                     let filter_current_bounds = draw_bounds(&cx.style, &cx.cache, &cx.tree, entity);
 
                     // Update cache for visible entity
-                    if let Some(dr) = cx.cache.draw_bounds.get_mut(entity) {
-                        *dr = filter_current_bounds;
-                    } else {
-                        cx.cache.draw_bounds.insert(entity, filter_current_bounds);
-                    }
+                    cx.cache.draw_bounds.insert(entity, filter_current_bounds);
 
                     if filter_current_bounds.w > 0.0 && filter_current_bounds.h > 0.0 {
                         // Ensure bounds are valid
@@ -112,16 +101,7 @@ pub(crate) fn draw_system(
                 // Entity is INVISIBLE but has (or had) a filter style.
                 // Its *previous* bounds need to be added to dirty_rect.
                 if let Some(previous_draw_bounds) = cx.cache.draw_bounds.get(entity).copied() {
-                    if previous_draw_bounds.w > 0.0 && previous_draw_bounds.h > 0.0 {
-                        // Ensure previous bounds were valid
-                        // Union previous_draw_bounds into dirty_rect.
-                        // If dirty_rect is None, it becomes Some(previous_draw_bounds).
-                        // If dirty_rect is Some, it's unioned with previous_draw_bounds.
-                        dirty_rect =
-                            Some(dirty_rect.map_or(previous_draw_bounds, |current_dr_val| {
-                                current_dr_val.union(&previous_draw_bounds)
-                            }));
-                    }
+                    union_dirty_rect(&mut dirty_rect, previous_draw_bounds);
                 }
 
                 // Remove from cache as it's no longer visible with these bounds.
@@ -188,6 +168,18 @@ pub(crate) fn draw_system(
     // }
 
     true
+}
+
+fn union_dirty_rect(dirty_rect: &mut Option<BoundingBox>, bounds: BoundingBox) {
+    if bounds.w <= 0.0 || bounds.h <= 0.0 {
+        return;
+    }
+
+    if let Some(current) = dirty_rect.as_mut() {
+        *current = current.union(&bounds);
+    } else {
+        *dirty_rect = Some(bounds);
+    }
 }
 
 fn draw_entity(

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -546,6 +546,7 @@ fn link_style_data(
     if style.display.link(entity, matched_rules) {
         should_relayout = true;
         should_redraw = true;
+        should_reflow = true;
     }
 
     if style.visibility.link(entity, matched_rules) {


### PR DESCRIPTION
Bug 1:

When an element changes state from `Display::None` to `Display::Flex`, we were setting `RELAYOUT` and `REDRAW` flags, but not `REFLOW`, which is needed to tell the text layout system to rebuild internal paragraphs.

Bug 2:

When a previously visible entity becomes `Display::None`, the draw system was skipping it entirely without marking its previous area as dirty, leaving the last rendered frame of the label stuck on the screen.

---

Small standalone example to reproduce the bugs:

```rs
use vizia::prelude::*;

fn main() -> Result<(), ApplicationError> {
    Application::new(|cx| {
        let show_label = Signal::new(false);
        VStack::new(cx, move |cx| {
            Button::new(cx, |cx| Label::new(cx, "Toggle Label Display"))
                .on_press(move |_| show_label.update(|show| *show = !*show));
            // This label starts with Display::None.
            // Without the fix, when toggled to Display::Flex, vizia would not
            // force the REFLOW system flag. So the text engine wouldn't build
            // the paragraph for the label, causing it to render as empty space
            // until a global reflow was forced (such as minimize/maximize).
            // The second bug would only manifest after fixing that one. When
            // pressing the button to re-hide the label, it would remain due to
            // the space it occupied not being detected as dirty by the draw system.
            Label::new(cx, "Hello, world!").display(show_label);
        });
    })
    .title("Display None -> Flex Bug Repro")
    .run()
}
```

---

Updating `draw_system` to fix this ended up with identical rect-union code being repeated in 3 different places so I went ahead and added a small helper function for code reuse. Also added missing `RELAYOUT` handling to `set_system_flags`, not certain it is necessary but it missing looks unintended to me.



