### PR TITLE
fix(core): on_press modifier must respect the FOCUSABLE ability

### DIFF
--- a/crates/vizia_core/src/modifiers/actions.rs
+++ b/crates/vizia_core/src/modifiers/actions.rs
@@ -177,7 +177,22 @@ impl Model for ActionsModel {
                 }
 
                 if !cx.is_disabled() && cx.current == meta.target {
-                    cx.focus();
+                    // Only grab keyboard focus if the view has opted in via
+                    // the FOCUSABLE ability. Without this gate, any view with
+                    // an `on_press` callback steals focus on click even when
+                    // `.focusable(false)` is set, and every subsequent
+                    // Space / Enter keypress then re-dispatches
+                    // `WindowEvent::Press` straight back to the clicked view
+                    // and re-runs its action — a confusing non-feature for
+                    // chrome buttons that are mouse-only by design.
+                    let focusable = cx
+                        .style
+                        .abilities
+                        .get(cx.current())
+                        .is_some_and(|abilities| abilities.contains(Abilities::FOCUSABLE));
+                    if focusable {
+                        cx.focus();
+                    }
                     if let Some(action) = &self.on_press {
                         (action)(cx);
                     }


### PR DESCRIPTION
## Summary

The `Press` event handler in the `on_press` action modifier (`crates/vizia_core/src/modifiers/actions.rs:180`) calls `cx.focus()` unconditionally on the pressed view, bypassing the `FOCUSABLE` ability flag. Any view with an `on_press` callback grabs keyboard focus on click even when `.focusable(false)` is set — and because the default `Abilities` is `HOVERABLE`-only (most views, including `HStack`, `Element`, `Label`, are not FOCUSABLE by default), this is a footgun for chrome-style buttons.

## The problem

User clicks a button with an `on_press` handler → the handler fires, and as a side effect the clicked view becomes `cx.focused`. Any subsequent Space / Enter keypress re-dispatches `WindowEvent::Press` to `cx.focused` via `events/event_manager.rs:662`, re-running the same `on_press` action — without the user intending to.

Reproduction in a real downstream plug-in host (VST3 synth built on vizia-plug → vizia, running in a DAW on macOS): user clicks a button that generates a new preset, then presses Space — a very common key in a DAW, where it normally toggles transport (play / stop). In this bug, Space does both things: toggles transport *and* re-triggers the preset-generate button, producing an unwanted new preset on every Space press.

The only way to suppress this today is a per-app workaround — every downstream consumer has to manually move focus to a dummy entity at the end of every `on_press` callback. This is obviously not the right layer to fix it; every consumer has to rediscover and re-implement the same patch.

## The fix

Gate `cx.focus()` on whether the view has `Abilities::FOCUSABLE`:

```rust
if !cx.is_disabled() && cx.current == meta.target {
    let focusable = cx
        .style
        .abilities
        .get(cx.current())
        .is_some_and(|abilities| abilities.contains(Abilities::FOCUSABLE));
    if focusable {
        cx.focus();
    }
    if let Some(action) = &self.on_press {
        (action)(cx);
    }
}
```

This matches the mouse-click-to-focus path already in `events/event_manager.rs:305–317`, which uses the same ability check. Restores the semantic `.focusable(false)` already implies — "this view should not receive keyboard focus" — and removes the outlier behavior of `on_press` silently overriding it.

## Behavior changes

- Views declared `.focusable(false)` (or that never opt into `FOCUSABLE` — `HStack`, `Element`, etc. by default): `on_press` fires normally, view does not become `cx.focused`, Space / Enter cannot retrigger the callback.
- Views declared `.focusable(true)` (or views whose impl adds `FOCUSABLE` — `Textbox` etc.): unchanged. Click-to-focus and Space / Enter activation both work as before.
- Buttons that previously gained focus from `on_press` *without* declaring `.focusable(true)`: those views now don't. Consumers relying on this surprising side effect should add `.focusable(true)` explicitly. In practice I don't expect this to break anything — the existing behavior was more confusing than load-bearing.

## Testing

Verified in a real downstream plug-in by temporarily removing the app-side focus-release workaround, then running the reproducer: click the offending button, hold Space for ~5 seconds, confirm the button's action does **not** re-trigger. With the fix, Space presses are no-ops because the clicked view never becomes focused.

Tested in Ableton Live 12.3.7 and REAPER 7.69 on macOS 15.5 before / after to confirm no regression in textbox focus (textboxes have `.navigable(true)` / `FOCUSABLE` set via their view impl and still receive focus on click normally).