### PR TITLE
Fix stale draw_bounds when clipping container geometry changes

### DIFF
--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -1,5 +1,5 @@
 use morphorm::Node;
-use vizia_storage::{DrawChildIterator, LayoutTreeIterator};
+use vizia_storage::LayoutTreeIterator;
 
 use crate::layout::node::SubLayout;
 use crate::prelude::*;
@@ -93,13 +93,13 @@ pub(crate) fn layout_system(cx: &mut Context) {
 
                     // If the entity clips its children (Overflow::Hidden or ClipPath::Shape)
                     // and its geometry changed, the clip path has changed too, so invalidate
-                    // all children's cached draw_bounds.
+                    // all descendants' cached draw_bounds.
                     if matches!(cx.style.overflowx.get(entity), Some(Overflow::Hidden))
                         || matches!(cx.style.overflowy.get(entity), Some(Overflow::Hidden))
                         || matches!(cx.style.clip_path.get(entity), Some(ClipPath::Shape(_)))
                     {
-                        for child in DrawChildIterator::new(cx.tree, entity) {
-                            cx.cache.draw_bounds.remove(child);
+                        for descendant in LayoutTreeIterator::subtree(cx.tree, entity).skip(1) {
+                            cx.cache.draw_bounds.remove(descendant);
                         }
                     }
                 }

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -1,5 +1,5 @@
 use morphorm::Node;
-use vizia_storage::LayoutTreeIterator;
+use vizia_storage::{DrawChildIterator, LayoutTreeIterator};
 
 use crate::layout::node::SubLayout;
 use crate::prelude::*;
@@ -90,6 +90,18 @@ pub(crate) fn layout_system(cx: &mut Context) {
 
                     cx.needs_retransform();
                     cx.needs_reclip();
+
+                    // If the entity clips its children (Overflow::Hidden or ClipPath::Shape)
+                    // and its geometry changed, the clip path has changed too, so invalidate
+                    // all children's cached draw_bounds.
+                    if matches!(cx.style.overflowx.get(entity), Some(Overflow::Hidden))
+                        || matches!(cx.style.overflowy.get(entity), Some(Overflow::Hidden))
+                        || matches!(cx.style.clip_path.get(entity), Some(ClipPath::Shape(_)))
+                    {
+                        for child in DrawChildIterator::new(cx.tree, entity) {
+                            cx.cache.draw_bounds.remove(child);
+                        }
+                    }
                 }
 
                 // TODO: Use geo changed to determine whether an entity needs to be redrawn.


### PR DESCRIPTION
The Bug:

When a containers geometry changes during a transition, the child's cached draw_bounds become stale. They were computed against the original (possibly zero-size) container's clip path, but their own geometry hasn't changed, so they never get re-added to the redraw_list, and thus their cached bounds never get evicted.

Potential Fix:

In layout_system, after an entity with `Overflow:Hidden` or `ClipPath::Shape` has its geometry updated, invalidate the cached bounds for all of its children.

I'm not very happy with this fix though - it means `layout_system` now mutates `draw_bounds` which feels like an inappropriate mixing of concerns (there's a few other places this already happens that make optimizing `draw_system` awkward). But it's also the direct site I seen where the `geo_changed` check happens, making it theoretically the most efficient place to do this. Alternatively we could do the work in `draw_system`, or perhaps `clipping_system`, but I think they would have to do manual bounding box or clipping path comparisons to replicate their own `geo_changed` detection.

---

Here's a small example to reproduce the bug visually:

```rs
use vizia::prelude::*;

const STYLE: &str = r#"
    .container {
        background-color: darkgray;
        overflow: hidden;

        height: 0px;
        transition: height 300ms;
    }

    .container.expanded {
        height: 30px;
        transition: height 300ms;
    }

    .inner {
        size: 30px;
        background-color: red;
    }

    .inner:hover {
        background-color: green;
    }
"#;

fn main() -> Result<(), ApplicationError> {
    Application::new(|cx| {
        cx.add_stylesheet(STYLE).unwrap();

        let expanded = Signal::new(false);

        VStack::new(cx, |cx| {
            Button::new(cx, |cx| Label::new(cx, "Toggle"))
                .on_press(move |_| expanded.update(|v| *v = !*v));

            HStack::new(cx, |cx| {
                Element::new(cx).class("inner");
            })
            .class("container")
            .toggle_class("expanded", expanded);

            Label::new(cx, "Click me. A red square should animate into view.");
        });
    })
    .title("Stale draw_bounds repro")
    .inner_size((400, 160))
    .run()
}
```