### PR TITLE
Revert "Remove 'static requirement for Label view"

### DIFF
--- a/crates/vizia_core/src/localization/mod.rs
+++ b/crates/vizia_core/src/localization/mod.rs
@@ -535,43 +535,18 @@ impl Res<String> for Localized {
     where
         F: 'static + Fn(&mut Context, Localized),
     {
-        bind_localized_updates(cx, self, Arc::new(closure));
-    }
-
-    fn to_signal(self, cx: &mut Context) -> Signal<String> {
-        let signal = Signal::new(self.get_value(cx));
-
-        bind_localized_updates(
-            cx,
-            self,
-            Arc::new(move |cx, localized| {
-                signal.set(localized.get_value(cx));
-            }),
-        );
-
-        signal
-    }
-}
-
-fn bind_localized_updates(
-    cx: &mut Context,
-    localized: Localized,
-    closure: Arc<dyn Fn(&mut Context, Localized)>,
-) {
-    let current = cx.current();
-    let localized_for_scope = localized.clone();
-    cx.with_current(current, move |cx| {
-        let stores = localized_for_scope.args.values().map(|x| x.make_clone()).collect::<Vec<_>>();
-        let localized_for_bind = localized_for_scope.clone();
-        let closure_for_bind = closure.clone();
-        bind_recursive(cx, &stores, move |cx| {
-            let localized_for_locale = localized_for_bind.clone();
-            let closure_for_locale = closure_for_bind.clone();
-            cx.environment().locale.set_or_bind(cx, move |cx, _| {
-                closure_for_locale(cx, localized_for_locale.clone());
+        let current = cx.current();
+        let self2 = self.clone();
+        let closure = Arc::new(closure);
+        cx.with_current(current, |cx| {
+            let stores = self2.args.values().map(|x| x.make_clone()).collect::<Vec<_>>();
+            let self3 = self2.clone();
+            let closure = closure.clone();
+            bind_recursive(cx, &stores, move |cx| {
+                closure(cx, self3.clone());
             });
         });
-    });
+    }
 }
 
 fn bind_recursive<F>(cx: &mut Context, stores: &[Box<dyn FluentStore>], closure: F)

--- a/crates/vizia_core/src/modifiers/text.rs
+++ b/crates/vizia_core/src/modifiers/text.rs
@@ -1,17 +1,51 @@
 use super::internal;
 use crate::prelude::*;
+use std::{cell::RefCell, rc::Rc};
 
 /// Modifiers for changing the text properties of a view.
 pub trait TextModifiers: internal::Modifiable {
     /// Sets the text content of the view.
-    fn text<T: ToStringLocalized>(mut self, value: impl Res<T>) -> Self {
+    fn text<T: ToStringLocalized, R: Res<T> + 'static>(mut self, value: R) -> Self {
         let entity = self.entity();
         let current = self.current();
         self.context().with_current(current, |cx| {
-            value.set_or_bind(cx, move |cx, val| {
-                let cx: &mut EventContext<'_> = &mut EventContext::new_with_current(cx, entity);
-                let text_data = val.get_value(cx).to_string_local(cx);
+            let value_store = Rc::new(RefCell::new(None::<R>));
+            let value_store_for_binding = value_store.clone();
 
+            value.set_or_bind(cx, move |cx, val| {
+                *value_store_for_binding.borrow_mut() = Some(val);
+                let cx: &mut EventContext<'_> = &mut EventContext::new_with_current(cx, entity);
+                let text_data = value_store_for_binding
+                    .borrow()
+                    .as_ref()
+                    .map(|value| value.get_value(cx).to_string_local(cx));
+
+                let Some(text_data) = text_data else {
+                    return;
+                };
+
+                // cx.text_context.set_text(entity, &text_data);
+                cx.style.text.insert(entity, text_data);
+
+                cx.style.needs_text_update(entity);
+                cx.needs_relayout();
+                cx.needs_redraw();
+            });
+
+            let value_store_for_locale = value_store;
+            let locale = cx.environment().locale;
+            locale.set_or_bind(cx, move |cx, _| {
+                let cx: &mut EventContext<'_> = &mut EventContext::new_with_current(cx, entity);
+                let text_data = value_store_for_locale
+                    .borrow()
+                    .as_ref()
+                    .map(|value| value.get_value(cx).to_string_local(cx));
+
+                let Some(text_data) = text_data else {
+                    return;
+                };
+
+                // cx.text_context.set_text(entity, &text_data);
                 cx.style.text.insert(entity, text_data);
 
                 cx.style.needs_text_update(entity);

--- a/crates/vizia_core/src/systems/accessibility.rs
+++ b/crates/vizia_core/src/systems/accessibility.rs
@@ -151,16 +151,6 @@ pub(crate) fn get_access_node(
         node_builder.set_value(value.clone().into_boxed_str());
     }
 
-    if let Some(text) = cx.style.text.get(entity) {
-        match cx.style.role.get(entity) {
-            Some(Role::Label | Role::TextRun) => {
-                node_builder.set_value(text.clone().into_boxed_str());
-            }
-            _ => {}
-        }
-    }
-
-    // TODO: Should name override text?
     if let Some(name) = cx.style.name.get(entity) {
         match cx.style.role.get(entity) {
             Some(Role::Label | Role::TextRun) => {

--- a/crates/vizia_core/src/views/label.rs
+++ b/crates/vizia_core/src/views/label.rs
@@ -88,11 +88,11 @@ impl Label {
     /// #
     /// Label::new(cx, "Text");
     /// ```
-    pub fn new<T>(cx: &mut Context, text: impl Res<T>) -> Handle<Self>
+    pub fn new<T>(cx: &mut Context, text: impl Res<T> + Clone + 'static) -> Handle<Self>
     where
-        T: ToStringLocalized,
+        T: ToStringLocalized + 'static,
     {
-        Self { describing: None }.build(cx, |_| {}).text(text).role(Role::Label)
+        Self { describing: None }.build(cx, |_| {}).text(text.clone()).role(Role::Label).name(text)
     }
 
     /// Creates a new rich [Label] view.


### PR DESCRIPTION
Okay so it turns out that the binding on locale in the text modifier is needed for localization to work properly for signals and memos, so 'static is required. I'll have to rethink this.