### PR TITLE
fix(vizia_baseview): call handle_idle from on_frame

### DIFF
--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -224,6 +224,17 @@ impl WindowHandler for ViziaWindow {
     fn on_frame(&mut self, window: &mut Window) {
         self.application.on_frame_update(window);
 
+        // Run the embedder's idle callback on every frame tick, not only after
+        // an AppKit event. Mirrors what `vizia_winit` does in its
+        // `about_to_wait` handler: the idle callback is the documented hook
+        // for embedders to drain work queued from off-UI threads (e.g. a
+        // plugin host delivering keys on the host thread), and invoking it
+        // only from `on_event` means such work can stall indefinitely when
+        // AppKit events are sparse — observed in a macOS VST3 host where
+        // keystrokes queued from `IPlugView::onKeyDown` only drained when
+        // the next mouse move or key event happened to arrive.
+        self.application.handle_idle(&self.on_idle);
+
         self.application.render(window);
     }
 


### PR DESCRIPTION
## Summary

`vizia_baseview::ViziaWindow::on_frame` only invoked the embedder's `on_idle` callback from `on_event` — after an AppKit keyboard / mouse event arrived. It never fired from `on_frame`, which is the backend's per-iteration hook analogous to winit's `about_to_wait`.

`vizia_winit::Application::about_to_wait` (`crates/vizia_winit/src/application.rs:790`) invokes its idle callback on every event-loop iteration unconditionally. The two backends disagreed on when `on_idle` runs.

## Why it matters

The asymmetry surfaced in a `vizia-plug`-based VST3 plugin in a macOS DAW: the plugin implements `Editor::on_key_down` (called on the host UI thread by `IPlugView::onKeyDown`) by queueing characters into a `Mutex<VecDeque<char>>` and relying on the next `on_idle` tick to drain them into `TextEvent::InsertText`. With the old behavior, if the user queued a character via the host thread and then didn't trigger any AppKit event, the drain would only happen the next time `on_event` fired — measured at **3.3 seconds** in a trace, waiting for the user to press another key or move the mouse.

The existing comment at `window.rs:43-52` already states the intended wake mechanism:

> baseview ... drives `on_frame` at the host compositor's vsync rate anyway — signal changes from off-UI writes will be observed on the next frame (at most one frame of latency).

But the code then only drained from `on_event`, contradicting the promise. This PR makes the code match the comment.

## Change

One-line addition in `ViziaWindow::on_frame`:

```rust
self.application.handle_idle(&self.on_idle);
```

…called after `on_frame_update` and before `render`. The idle callback now runs at frame cadence plus on every event, matching `vizia_winit`'s behavior.

## Test plan

- [x] `cargo clippy -p vizia_baseview --all-targets -- -D warnings` — green.
- [x] `cargo fmt --all -- --check` — green.
- [x] Verified in a `vizia-plug`-based plugin in REAPER on macOS. Repro sequence: click into a text input, press Space via VST3 onKeyDown, wait without any follow-up event. Measured `on_idle` drain latency from a kbd-trace log:

  | Before fix | After fix |
  |---|---|
  | 3.3 s (drain triggered by next AppKit event) | 0–14 ms (drain on next frame tick) |
