### PR TITLE
fix(core): invalidate focus when the focused entity becomes non-visible

### DIFF
--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -1472,4 +1472,58 @@ pub(crate) fn style_system(cx: &mut Context) {
     for entity in redraw_entities {
         cx.needs_redraw(entity);
     }
+
+    invalidate_focus_on_hidden(cx);
+}
+
+/// Re-validates `cx.focused` after style resolution.
+///
+/// `WindowEvent::KeyDown` dispatch in `event_manager` routes to
+/// `cx.focused` regardless of the focused view's visibility. Without
+/// re-validation, an entity that becomes `Display::None` (or whose
+/// ancestor does) via either a CSS rule or the `.display(...)` modifier
+/// keeps focus indefinitely; the existing cleanup in `Context::remove`
+/// only fires when an entity is *removed from the tree*, not when it
+/// merely becomes non-visible. The most user-visible symptom is a
+/// plug-in `Textbox` inside a modal that gets hidden via
+/// `Display::None` — every subsequent host keystroke continues to be
+/// routed to the invisible textbox.
+///
+/// Runs at the end of [`style_system`]: at this point `display` and
+/// `disabled` are authoritative for the frame, but layout / draw
+/// haven't consumed them yet, so re-routing here avoids one frame of
+/// incorrect dispatch.
+///
+/// When the focused entity (or any ancestor) is `Display::None`, or
+/// the focused entity is `disabled`, focus moves to the previous
+/// focusable element in tab order via [`focus_backward`]. If
+/// `focus_backward` returns `None` (no prior focusable in scope),
+/// focus falls back to [`Entity::root`] so keystrokes route to the
+/// window rather than to an invisible view.
+fn invalidate_focus_on_hidden(cx: &mut Context) {
+    use crate::style::Display;
+    use crate::tree::focus_backward;
+
+    let focused = cx.focused;
+    if focused == Entity::null() || focused == Entity::root() {
+        return;
+    }
+
+    let hidden = std::iter::once(focused)
+        .chain(focused.parent_iter(&cx.tree))
+        .any(|entity| cx.style.display.get(entity).copied().unwrap_or_default() == Display::None);
+    let disabled = cx.style.disabled.get(focused).cloned().unwrap_or_default();
+
+    if !hidden && !disabled {
+        return;
+    }
+
+    // `lock_focus_to` matches the scope used by `focus_prev` / `focus_next`
+    // for keyboard navigation: respect any active modal-focus lock from
+    // `lock_focus_to_within`, otherwise scope to the entire tree.
+    let lock_focus_to = cx.focus_stack.last().copied().unwrap_or(Entity::root());
+    let new_target =
+        focus_backward(&cx.tree, &cx.style, focused, lock_focus_to).unwrap_or(Entity::root());
+
+    cx.with_current(new_target, |cx| cx.focus());
 }


### PR DESCRIPTION
## Summary (revised per @geom3trik's feedback)

Keyboard input dispatch routes `WindowEvent::KeyDown` directly to `cx.focused`, and nothing on the style-change side drops focus when the focused entity (or an ancestor) becomes `Display::None`. The existing cleanup in `Context::remove` only fires when an entity is *removed* from the tree, not when it merely gets hidden via a `.display(...)` modifier or a CSS rule.

## Symptom

Most visible in any toggle-able container (modal dialogs, collapsible panels). A `Textbox` inside a modal that gets hidden via `Display::None` continues to receive keystrokes. In a `vizia-plug`-based plug-in this means the host DAW keeps routing keys to the invisible textbox until the plug-in window is destroyed; the DAW's transport key (Space) and other shortcuts can't reach the host.

## Fix

Add `invalidate_focus_on_hidden` as a step at the end of `style_system`. When `cx.focused` (or any ancestor) is `Display::None`, or when the focused entity is `disabled`, move focus to the previous focusable element in tab order via the existing `focus_backward` helper. If `focus_backward` returns `None`, fall back to `Entity::root` so keystrokes route to the window rather than to an invisible view.

## Differences from the previous approach

Per @geom3trik's review feedback:

- **Location**: moved from `BackendContext::process_focus_invalidation` (a new backend-driven phase) into a step at the end of `style_system`. All backends pick this up automatically; no per-backend wiring needed.
- **Fallback target**: instead of always dropping focus to `Entity::root`, walk to the previous non-hidden focusable element via `focus_backward` (the same primitive vizia uses for Shift+Tab navigation). Falls back to `Entity::root` only when nothing focusable exists earlier in tab order.