### PR TITLE
Add public `Context::focused_element`

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -594,6 +594,17 @@ impl Context {
         );
     }
 
+    /// Returns the element name (e.g. `"textbox"`) of the currently focused
+    /// view, or `None` if the focused entity has no view or the view doesn't
+    /// declare an element name.
+    ///
+    /// Mirrors [`BackendContext::focused_element`] for use from contexts
+    /// (such as the `on_idle` application callback) that receive a
+    /// `&mut Context` directly.
+    pub fn focused_element(&self) -> Option<&'static str> {
+        self.views.get(&self.focused).and_then(|view| view.element())
+    }
+
     pub fn add_stylesheet(&mut self, style: impl IntoCssStr) -> Result<(), std::io::Error> {
         self.resource_manager.styles.push(Box::new(style));
 


### PR DESCRIPTION
## What

Adds `Context::focused_element()` as a `pub` method on the plain `Context`, mirroring the existing `BackendContext::focused_element()`. Twelve lines including the doc comment, read-only delegation to existing internals, no behavior change.

## Why

I'm working on a plug-in for an audio host that recently (2026-04-28) gained a host→plug-in virtual-key-event hook in `nih-plug` ([BillyDM/nih-plug commit `b59ce19b`](https://github.com/BillyDM/nih-plug/commit/b59ce19b31bdcc3ef36763b4030a283fd991b470)). The hook fires on the host UI thread, and the implementation needs to decide whether the focused vizia view is a text input it should route the key into, or whether to let the host's accelerator (e.g. REAPER's transport play/stop on the spacebar) fire normally.

The natural way to express that decision is `cx.focused_element() == Some("textbox")`, where `cx` is the `&mut Context` the host hands the callback. Today that's only available on `BackendContext`, which most user-facing callbacks don't expose.

I'd like to ship this hook for [vizia-plug](https://github.com/vizia/vizia-plug), but the impl can't compile against upstream `vizia/vizia:main` until `Context::focused_element` is reachable from a regular `&mut Context`.