### PR TITLE
fix(vizia_baseview): don't treat Cmd+Q as exit when parented

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -582,7 +582,10 @@ impl ApplicationRunner {
 /// forward it through, in which case the previous unconditional
 /// match would tear down the plug-in's GL surface and leave the
 /// host with an empty plug-in shell.
-pub fn requests_exit(event: &baseview::Event, is_parented: bool) -> bool {
+pub fn requests_exit(
+    event: &baseview::Event,
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] is_parented: bool,
+) -> bool {
     match event {
         baseview::Event::Window(baseview::WindowEvent::WillClose) => true,
         #[cfg(target_os = "macos")]

--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -179,9 +179,18 @@ pub(crate) struct ApplicationRunner {
     pub dirty_surface: skia_safe::Surface,
     window_description: WindowDescription,
     is_initialized: bool,
+    /// `true` when the underlying baseview window was opened via
+    /// [`Window::open_parented`] (i.e. the vizia application is embedded
+    /// inside a host such as a DAW). Gates lifecycle decisions that
+    /// should be left to the host: when parented, vizia_baseview must
+    /// not interpret Cmd+Q as a close request, because closing the
+    /// child window without the host's knowledge leaves the host with
+    /// an empty plug-in shell.
+    is_parented: bool,
 }
 
 impl ApplicationRunner {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         cx: BackendContext,
         gr_context: skia_safe::gpu::DirectContext,
@@ -190,6 +199,7 @@ impl ApplicationRunner {
         surface: skia_safe::Surface,
         dirty_surface: skia_safe::Surface,
         window_description: WindowDescription,
+        is_parented: bool,
     ) -> Self {
         ApplicationRunner {
             should_redraw: true,
@@ -204,6 +214,7 @@ impl ApplicationRunner {
             dirty_surface,
             window_description,
             is_initialized: false,
+            is_parented,
         }
     }
 
@@ -346,7 +357,7 @@ impl ApplicationRunner {
     }
 
     pub fn handle_event(&mut self, event: baseview::Event, should_quit: &mut bool) {
-        if requests_exit(&event) {
+        if requests_exit(&event, self.is_parented) {
             self.cx.send_event(Event::new(WindowEvent::WindowClose));
             *should_quit = true;
         }
@@ -555,11 +566,27 @@ impl ApplicationRunner {
 
 /// Returns true if the provided event should cause an [`Application`] to
 /// exit.
-pub fn requests_exit(event: &baseview::Event) -> bool {
+///
+/// `WindowEvent::WillClose` is honoured in both standalone and parented
+/// modes — it's a legitimate close signal from baseview / the host.
+///
+/// On macOS, Cmd+Q is recognized as a quit shortcut **only when the
+/// application is standalone** (`is_parented == false`). When
+/// vizia_baseview is embedded as a child window inside a host (the
+/// usual audio-plug-in setup), the host owns the application
+/// lifecycle: pressing Cmd+Q should quit the host, not close the
+/// plug-in's child window. Most hosts on macOS bind Cmd+Q to their
+/// own menu's "Quit" item, so AppKit's `performKeyEquivalent:`
+/// dispatch claims the key before the plug-in's NSView sees it.
+/// Hosts with looser key dispatch (Bitwig observed 2026-04-28) do
+/// forward it through, in which case the previous unconditional
+/// match would tear down the plug-in's GL surface and leave the
+/// host with an empty plug-in shell.
+pub fn requests_exit(event: &baseview::Event, is_parented: bool) -> bool {
     match event {
         baseview::Event::Window(baseview::WindowEvent::WillClose) => true,
         #[cfg(target_os = "macos")]
-        baseview::Event::Keyboard(event) => {
+        baseview::Event::Keyboard(event) if !is_parented => {
             if event.code == vizia_input::Code::KeyQ
                 && event.modifiers == vizia_input::KeyboardModifiers::META
                 && event.state == vizia_input::KeyState::Down

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -31,6 +31,7 @@ impl ViziaWindow {
         window: &mut baseview::Window,
         builder: Option<Box<dyn FnOnce(&mut Context) + Send>>,
         on_idle: Option<Box<dyn Fn(&mut Context) + Send>>,
+        is_parented: bool,
     ) -> ViziaWindow {
         // Reactive runtime setup — mirrors what `vizia_winit::Application::new` does.
         //
@@ -128,6 +129,7 @@ impl ViziaWindow {
             surface,
             dirty_surface,
             win_desc,
+            is_parented,
         );
         unsafe { context.make_not_current() };
 
@@ -175,7 +177,15 @@ impl ViziaWindow {
                 let mut cx = BackendContext::new(cx);
 
                 cx.set_event_proxy(Box::new(BaseviewProxy));
-                ViziaWindow::new(cx, win_desc, scale_policy, window, Some(Box::new(app)), on_idle)
+                ViziaWindow::new(
+                    cx,
+                    win_desc,
+                    scale_policy,
+                    window,
+                    Some(Box::new(app)),
+                    on_idle,
+                    true, // is_parented
+                )
             },
         )
     }
@@ -214,7 +224,15 @@ impl ViziaWindow {
                 let mut cx = BackendContext::new(cx);
 
                 cx.set_event_proxy(Box::new(BaseviewProxy));
-                ViziaWindow::new(cx, win_desc, scale_policy, window, Some(Box::new(app)), on_idle)
+                ViziaWindow::new(
+                    cx,
+                    win_desc,
+                    scale_policy,
+                    window,
+                    Some(Box::new(app)),
+                    on_idle,
+                    false, // is_parented
+                )
             },
         )
     }


### PR DESCRIPTION
## What

`vizia_baseview::requests_exit` unconditionally returns `true` for Cmd+Q on macOS, which is correct for standalone vizia_baseview applications but wrong when the application is embedded in a host as a child window (the usual audio-plug-in setup). The host owns the lifecycle: pressing Cmd+Q should quit the host, not close the plug-in's child window.

## Why I'm proposing this

Most hosts on macOS bind Cmd+Q to their own application menu's "Quit" item, so AppKit's `performKeyEquivalent:` claims the key before the plug-in's NSView sees it. The bug stays latent in those hosts.

Bitwig forwards Cmd+Q through to the plug-in (observed 2026-04-28 with a vizia-plug plug-in in Bitwig on macOS). The previous unconditional match in `requests_exit` then sets `should_quit = true`, `ViziaWindow::on_event` calls `window.close()`, the GL surface tears down, and Bitwig is left holding an empty plug-in shell while the user just meant to quit the DAW.

## Fix

Thread an `is_parented: bool` flag from `open_parented` / `open_blocking` through `ViziaWindow::new` into `ApplicationRunner`, and gate the macOS Cmd+Q match in `requests_exit` behind `!is_parented`. `WindowEvent::WillClose` is honoured in both modes (it remains a legitimate close signal from baseview / the host).

Standalone vizia_baseview consumers see no behaviour change; the auto-Cmd+Q-quit still fires for them.

Fixes #652.