### PR TITLE
Add ignore_clipping style for overlay clipping

### DIFF
--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -140,6 +140,10 @@ impl DrawContext<'_> {
         // If there is no cached value yet, walk ancestors to find an inherited clip.
         let mut current = self.current;
         while let Some(parent) = self.tree.get_parent(current) {
+            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
+                return None;
+            }
+
             if let Some(clip_path) = self.cache.clip_path.get(parent).cloned().flatten() {
                 return Some(clip_path);
             }

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -140,12 +140,13 @@ impl DrawContext<'_> {
         // If there is no cached value yet, walk ancestors to find an inherited clip.
         let mut current = self.current;
         while let Some(parent) = self.tree.get_parent(current) {
-            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
-                return None;
+            // A cached parent entry (including None) is authoritative.
+            if let Some(clip_path) = self.cache.clip_path.get(parent) {
+                return clip_path.clone();
             }
 
-            if let Some(clip_path) = self.cache.clip_path.get(parent).cloned().flatten() {
-                return Some(clip_path);
+            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
+                return None;
             }
             current = parent;
         }

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -128,17 +128,25 @@ impl DrawContext<'_> {
 
     /// Returns the clip path of the current view.
     pub fn clip_path(&self) -> Option<skia_safe::Path> {
-        // Get clip path or iterate up tree to get ancestor clip path
-        self.cache.clip_path.get(self.current).cloned().flatten().or_else(|| {
-            let mut current = self.current;
-            while let Some(parent) = self.tree.get_parent(current) {
-                if let Some(clip_path) = self.cache.clip_path.get(parent).cloned().flatten() {
-                    return Some(clip_path);
-                }
-                current = parent;
+        // A cached entry (including None) is authoritative for this entity.
+        if let Some(clip_path) = self.cache.clip_path.get(self.current) {
+            return clip_path.clone();
+        }
+
+        if self.style.ignore_clipping.get(self.current).copied().unwrap_or(false) {
+            return None;
+        }
+
+        // If there is no cached value yet, walk ancestors to find an inherited clip.
+        let mut current = self.current;
+        while let Some(parent) = self.tree.get_parent(current) {
+            if let Some(clip_path) = self.cache.clip_path.get(parent).cloned().flatten() {
+                return Some(clip_path);
             }
-            None
-        })
+            current = parent;
+        }
+
+        None
     }
 
     /// Returns the 2D transform of the current view.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -310,6 +310,10 @@ impl<'a> EventContext<'a> {
 
         let mut current = self.current;
         while let Some(parent) = self.tree.get_parent(current) {
+            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
+                return window_bounds;
+            }
+
             if let Some(clip_path) = self
                 .cache
                 .clip_path

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -310,19 +310,16 @@ impl<'a> EventContext<'a> {
 
         let mut current = self.current;
         while let Some(parent) = self.tree.get_parent(current) {
-            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
-                return window_bounds;
+            // A cached parent entry (including None) is authoritative.
+            if let Some(clip_path) = self.cache.clip_path.get(parent) {
+                return clip_path
+                    .clone()
+                    .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
+                    .unwrap_or(window_bounds);
             }
 
-            if let Some(clip_path) = self
-                .cache
-                .clip_path
-                .get(parent)
-                .cloned()
-                .flatten()
-                .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
-            {
-                return clip_path;
+            if self.style.ignore_clipping.get(parent).copied().unwrap_or(false) {
+                return window_bounds;
             }
 
             if parent == current_window {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -294,35 +294,41 @@ impl<'a> EventContext<'a> {
             self.tree.get_parent_window(self.current).unwrap_or(Entity::root())
         };
 
-        self.cache
-            .clip_path
-            .get(self.current)
-            .cloned()
-            .flatten()
-            .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
-            .or_else(|| {
-                let mut current = self.current;
-                while let Some(parent) = self.tree.get_parent(current) {
-                    if let Some(clip_path) = self
-                        .cache
-                        .clip_path
-                        .get(parent)
-                        .cloned()
-                        .flatten()
-                        .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
-                    {
-                        return Some(clip_path);
-                    }
+        let window_bounds = self.cache.get_bounds(current_window);
 
-                    if parent == current_window {
-                        break;
-                    }
+        // A cached entry (including None) is authoritative for this entity.
+        if let Some(clip_path) = self.cache.clip_path.get(self.current) {
+            return clip_path
+                .clone()
+                .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
+                .unwrap_or(window_bounds);
+        }
 
-                    current = parent;
-                }
-                None
-            })
-            .unwrap_or_else(|| self.cache.get_bounds(current_window))
+        if self.style.ignore_clipping.get(self.current).copied().unwrap_or(false) {
+            return window_bounds;
+        }
+
+        let mut current = self.current;
+        while let Some(parent) = self.tree.get_parent(current) {
+            if let Some(clip_path) = self
+                .cache
+                .clip_path
+                .get(parent)
+                .cloned()
+                .flatten()
+                .map(|clip_path| Into::<BoundingBox>::into(*clip_path.bounds()))
+            {
+                return clip_path;
+            }
+
+            if parent == current_window {
+                break;
+            }
+
+            current = parent;
+        }
+
+        window_bounds
     }
 
     /// Returns the 2D transform of the current view.

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -285,6 +285,15 @@ pub trait StyleModifiers: internal::Modifiable {
         self
     }
 
+    modifier!(
+        /// Sets whether the view should ignore ancestor clipping paths when drawing.
+        ///
+        /// This is useful for overlays such as popovers that need to escape overflow clipping.
+        ignore_clipping,
+        bool,
+        SystemFlags::RECLIP | SystemFlags::REDRAW
+    );
+
     /// Sets the clip path for the the view.
     fn clip_path<U: Into<ClipPath>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -239,6 +239,9 @@ pub struct Style {
     // Z Order
     pub(crate) z_index: StyleSet<i32>,
 
+    // Controls whether an entity should ignore ancestor clipping during drawing.
+    pub(crate) ignore_clipping: StyleSet<bool>,
+
     // Clipping
     pub(crate) clip_path: AnimatableSet<ClipPath>,
 
@@ -2447,6 +2450,7 @@ impl Style {
         self.opacity.remove(entity);
         // Z Order
         self.z_index.remove(entity);
+        self.ignore_clipping.remove(entity);
         // Clipping
         self.clip_path.remove(entity);
 

--- a/crates/vizia_core/src/systems/clipping.rs
+++ b/crates/vizia_core/src/systems/clipping.rs
@@ -21,10 +21,28 @@ pub(crate) fn clipping_system(cx: &mut Context) {
         }
 
         let bounds = cx.cache.bounds.get(entity).copied().unwrap();
+        let previous_clip_bounds = cx
+            .cache
+            .clip_path
+            .get(entity)
+            .and_then(|clip_path| clip_path.as_ref())
+            .map(|clip_path| *clip_path.bounds());
 
         if entity == Entity::root() {
             let clip_path = build_clip_path(cx, Entity::root(), bounds);
             cx.cache.clip_path.insert(entity, Some(clip_path));
+            let new_clip_bounds = cx
+                .cache
+                .clip_path
+                .get(entity)
+                .and_then(|clip_path| clip_path.as_ref())
+                .map(|clip_path| *clip_path.bounds());
+
+            if previous_clip_bounds != new_clip_bounds {
+                for descendant in LayoutTreeIterator::subtree(&cx.tree, entity).skip(1) {
+                    cx.cache.draw_bounds.remove(descendant);
+                }
+            }
             continue;
         }
 
@@ -99,20 +117,21 @@ pub(crate) fn clipping_system(cx: &mut Context) {
             cx.cache.clip_path.get(parent).cloned().flatten()
         };
 
-        match (clip_path, parent_clip_path) {
+        let effective_clip_path = match (clip_path, parent_clip_path) {
             (Some(clip_path), Some(parent_clip_path)) => {
-                let path_intersection =
-                    clip_path.op(&parent_clip_path, skia_safe::PathOp::Intersect);
-                cx.cache.clip_path.insert(entity, path_intersection);
+                clip_path.op(&parent_clip_path, skia_safe::PathOp::Intersect)
             }
-            (Some(clip_path), None) => {
-                cx.cache.clip_path.insert(entity, Some(clip_path));
-            }
-            (None, Some(parent_clip_path)) => {
-                cx.cache.clip_path.insert(entity, Some(parent_clip_path));
-            }
-            (None, None) => {
-                cx.cache.clip_path.insert(entity, None);
+            (Some(clip_path), None) => Some(clip_path),
+            (None, Some(parent_clip_path)) => Some(parent_clip_path),
+            (None, None) => None,
+        };
+
+        let new_clip_bounds = effective_clip_path.as_ref().map(|clip_path| *clip_path.bounds());
+        cx.cache.clip_path.insert(entity, effective_clip_path);
+
+        if previous_clip_bounds != new_clip_bounds {
+            for descendant in LayoutTreeIterator::subtree(&cx.tree, entity).skip(1) {
+                cx.cache.draw_bounds.remove(descendant);
             }
         }
     }

--- a/crates/vizia_core/src/systems/clipping.rs
+++ b/crates/vizia_core/src/systems/clipping.rs
@@ -91,7 +91,9 @@ pub(crate) fn clipping_system(cx: &mut Context) {
 
         let clip_path = clip_path.map(|clip_path| clip_path.make_transform(&transform));
 
-        let parent_clip_path = if cx.tree.is_window(entity) {
+        let ignore_clipping = cx.style.ignore_clipping.get(entity).copied().unwrap_or(false);
+
+        let parent_clip_path = if ignore_clipping || cx.tree.is_window(entity) {
             None
         } else {
             cx.cache.clip_path.get(parent).cloned().flatten()

--- a/crates/vizia_core/src/systems/clipping.rs
+++ b/crates/vizia_core/src/systems/clipping.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::f32::consts::SQRT_2;
 
 use skia_safe::{
@@ -5,7 +6,7 @@ use skia_safe::{
 };
 use vizia_storage::LayoutTreeIterator;
 
-use crate::prelude::*;
+use crate::{prelude::*, tree::minimal_layout_dirty_roots};
 
 /// Computes the clipping path for each entity in the layout tree.
 pub(crate) fn clipping_system(cx: &mut Context) {
@@ -13,130 +14,177 @@ pub(crate) fn clipping_system(cx: &mut Context) {
         return;
     }
 
-    let iter = LayoutTreeIterator::full(&cx.tree);
+    let dirty_subtree_roots = minimal_layout_dirty_roots(&cx.tree, &cx.style.reclip);
+    let mut invalidated_subtrees = HashSet::new();
 
-    for entity in iter {
-        if !cx.style.reclip.contains(&entity) {
-            continue;
-        }
+    for &root in &dirty_subtree_roots {
+        let iter = LayoutTreeIterator::subtree(&cx.tree, root);
+        for entity in iter {
+            if !cx.style.reclip.contains(&entity) {
+                continue;
+            }
 
-        let bounds = cx.cache.bounds.get(entity).copied().unwrap();
-        let previous_clip_bounds = cx
-            .cache
-            .clip_path
-            .get(entity)
-            .and_then(|clip_path| clip_path.as_ref())
-            .map(|clip_path| *clip_path.bounds());
+            let parent = cx.tree.get_layout_parent(entity).unwrap_or(Entity::root());
 
-        if entity == Entity::root() {
-            let clip_path = build_clip_path(cx, Entity::root(), bounds);
-            cx.cache.clip_path.insert(entity, Some(clip_path));
-            let new_clip_bounds = cx
+            let Some(bounds) = cx.cache.bounds.get(entity).copied() else { continue };
+            let previous_clip_bounds = cx
                 .cache
                 .clip_path
                 .get(entity)
                 .and_then(|clip_path| clip_path.as_ref())
                 .map(|clip_path| *clip_path.bounds());
 
-            if previous_clip_bounds != new_clip_bounds {
+            if entity == Entity::root() {
+                let clip_path = build_clip_path(cx, Entity::root(), bounds);
+                cx.cache.clip_path.insert(entity, Some(clip_path));
+                let new_clip_bounds = cx
+                    .cache
+                    .clip_path
+                    .get(entity)
+                    .and_then(|clip_path| clip_path.as_ref())
+                    .map(|clip_path| *clip_path.bounds());
+
+                let should_invalidate_subtree = should_invalidate_subtree(
+                    cx,
+                    entity,
+                    &dirty_subtree_roots,
+                    &invalidated_subtrees,
+                );
+
+                if previous_clip_bounds != new_clip_bounds && should_invalidate_subtree {
+                    for descendant in LayoutTreeIterator::subtree(&cx.tree, entity).skip(1) {
+                        cx.cache.draw_bounds.remove(descendant);
+                    }
+                    invalidated_subtrees.insert(entity);
+                }
+                continue;
+            }
+
+            let overflowx = cx.style.overflowx.get(entity).copied().unwrap_or_default();
+            let overflowy = cx.style.overflowy.get(entity).copied().unwrap_or_default();
+
+            let scale = cx.style.scale_factor();
+
+            let transform = cx
+                .cache
+                .transform
+                .get(entity)
+                .copied()
+                .unwrap_or(skia_safe::Matrix::new_identity());
+
+            let shape_clip_path = cx.style.clip_path.get(entity).and_then(|clip| match clip {
+                ClipPath::Auto => None,
+                ClipPath::Shape(rect) => {
+                    let clip_bounds = bounds.shrink_sides(
+                        rect.3.to_pixels(bounds.w, scale),
+                        rect.0.to_pixels(bounds.h, scale),
+                        rect.1.to_pixels(bounds.w, scale),
+                        rect.2.to_pixels(bounds.h, scale),
+                    );
+
+                    Some(build_clip_path(cx, entity, clip_bounds))
+                }
+            });
+
+            let window_entity = if cx.tree.is_window(entity) {
+                entity
+            } else {
+                cx.tree.get_parent_window(entity).unwrap_or(Entity::root())
+            };
+            let window_bounds = cx.cache.bounds.get(window_entity).copied().unwrap_or(bounds);
+
+            let overflow_clip_path = match (overflowx, overflowy) {
+                (Overflow::Visible, Overflow::Visible) => None,
+                (Overflow::Hidden, Overflow::Visible) => {
+                    let left = bounds.left();
+                    let right = bounds.right();
+                    let top = window_bounds.top();
+                    let bottom = window_bounds.bottom();
+                    let clip_bounds = BoundingBox::from_min_max(left, top, right, bottom);
+                    Some(build_clip_path(cx, entity, clip_bounds))
+                }
+                (Overflow::Visible, Overflow::Hidden) => {
+                    let left = window_bounds.left();
+                    let right = window_bounds.right();
+                    let top = bounds.top();
+                    let bottom = bounds.bottom();
+                    let clip_bounds = BoundingBox::from_min_max(left, top, right, bottom);
+                    Some(build_clip_path(cx, entity, clip_bounds))
+                }
+                (Overflow::Hidden, Overflow::Hidden) => Some(build_clip_path(cx, entity, bounds)),
+            };
+
+            let clip_path = match (overflow_clip_path, shape_clip_path) {
+                (Some(overflow_path), Some(shape_path)) => {
+                    overflow_path.op(&shape_path, skia_safe::PathOp::Intersect)
+                }
+                (Some(overflow_path), None) => Some(overflow_path),
+                (None, Some(shape_path)) => Some(shape_path),
+                (None, None) => None,
+            };
+
+            let clip_path = clip_path.map(|clip_path| clip_path.make_transform(&transform));
+
+            let ignore_clipping = cx.style.ignore_clipping.get(entity).copied().unwrap_or(false);
+
+            let parent_clip_path = if ignore_clipping || cx.tree.is_window(entity) {
+                None
+            } else {
+                cx.cache.clip_path.get(parent).cloned().flatten()
+            };
+
+            let effective_clip_path = match (clip_path, parent_clip_path) {
+                (Some(clip_path), Some(parent_clip_path)) => {
+                    clip_path.op(&parent_clip_path, skia_safe::PathOp::Intersect)
+                }
+                (Some(clip_path), None) => Some(clip_path),
+                (None, Some(parent_clip_path)) => Some(parent_clip_path),
+                (None, None) => None,
+            };
+
+            let new_clip_bounds = effective_clip_path.as_ref().map(|clip_path| *clip_path.bounds());
+            cx.cache.clip_path.insert(entity, effective_clip_path);
+            let should_invalidate_subtree =
+                should_invalidate_subtree(cx, entity, &dirty_subtree_roots, &invalidated_subtrees);
+
+            if previous_clip_bounds != new_clip_bounds && should_invalidate_subtree {
                 for descendant in LayoutTreeIterator::subtree(&cx.tree, entity).skip(1) {
                     cx.cache.draw_bounds.remove(descendant);
                 }
-            }
-            continue;
-        }
-
-        let parent = cx.tree.get_layout_parent(entity).unwrap_or(Entity::root());
-
-        let overflowx = cx.style.overflowx.get(entity).copied().unwrap_or_default();
-        let overflowy = cx.style.overflowy.get(entity).copied().unwrap_or_default();
-
-        let scale = cx.style.scale_factor();
-
-        let transform =
-            cx.cache.transform.get(entity).copied().unwrap_or(skia_safe::Matrix::new_identity());
-
-        let shape_clip_path = cx.style.clip_path.get(entity).and_then(|clip| match clip {
-            ClipPath::Auto => None,
-            ClipPath::Shape(rect) => {
-                let clip_bounds = bounds.shrink_sides(
-                    rect.3.to_pixels(bounds.w, scale),
-                    rect.0.to_pixels(bounds.h, scale),
-                    rect.1.to_pixels(bounds.w, scale),
-                    rect.2.to_pixels(bounds.h, scale),
-                );
-
-                Some(build_clip_path(cx, entity, clip_bounds))
-            }
-        });
-
-        let window_entity = if cx.tree.is_window(entity) {
-            entity
-        } else {
-            cx.tree.get_parent_window(entity).unwrap_or(Entity::root())
-        };
-        let window_bounds = cx.cache.bounds.get(window_entity).copied().unwrap_or(bounds);
-
-        let overflow_clip_path = match (overflowx, overflowy) {
-            (Overflow::Visible, Overflow::Visible) => None,
-            (Overflow::Hidden, Overflow::Visible) => {
-                let left = bounds.left();
-                let right = bounds.right();
-                let top = window_bounds.top();
-                let bottom = window_bounds.bottom();
-                let clip_bounds = BoundingBox::from_min_max(left, top, right, bottom);
-                Some(build_clip_path(cx, entity, clip_bounds))
-            }
-            (Overflow::Visible, Overflow::Hidden) => {
-                let left = window_bounds.left();
-                let right = window_bounds.right();
-                let top = bounds.top();
-                let bottom = bounds.bottom();
-                let clip_bounds = BoundingBox::from_min_max(left, top, right, bottom);
-                Some(build_clip_path(cx, entity, clip_bounds))
-            }
-            (Overflow::Hidden, Overflow::Hidden) => Some(build_clip_path(cx, entity, bounds)),
-        };
-
-        let clip_path = match (overflow_clip_path, shape_clip_path) {
-            (Some(overflow_path), Some(shape_path)) => {
-                overflow_path.op(&shape_path, skia_safe::PathOp::Intersect)
-            }
-            (Some(overflow_path), None) => Some(overflow_path),
-            (None, Some(shape_path)) => Some(shape_path),
-            (None, None) => None,
-        };
-
-        let clip_path = clip_path.map(|clip_path| clip_path.make_transform(&transform));
-
-        let ignore_clipping = cx.style.ignore_clipping.get(entity).copied().unwrap_or(false);
-
-        let parent_clip_path = if ignore_clipping || cx.tree.is_window(entity) {
-            None
-        } else {
-            cx.cache.clip_path.get(parent).cloned().flatten()
-        };
-
-        let effective_clip_path = match (clip_path, parent_clip_path) {
-            (Some(clip_path), Some(parent_clip_path)) => {
-                clip_path.op(&parent_clip_path, skia_safe::PathOp::Intersect)
-            }
-            (Some(clip_path), None) => Some(clip_path),
-            (None, Some(parent_clip_path)) => Some(parent_clip_path),
-            (None, None) => None,
-        };
-
-        let new_clip_bounds = effective_clip_path.as_ref().map(|clip_path| *clip_path.bounds());
-        cx.cache.clip_path.insert(entity, effective_clip_path);
-
-        if previous_clip_bounds != new_clip_bounds {
-            for descendant in LayoutTreeIterator::subtree(&cx.tree, entity).skip(1) {
-                cx.cache.draw_bounds.remove(descendant);
+                invalidated_subtrees.insert(entity);
             }
         }
     }
 
     cx.style.reclip.clear();
+}
+
+fn should_invalidate_subtree(
+    cx: &Context,
+    entity: Entity,
+    dirty_subtree_roots: &HashSet<Entity>,
+    invalidated_subtrees: &HashSet<Entity>,
+) -> bool {
+    dirty_subtree_roots.contains(&entity)
+        || !has_invalidated_layout_ancestor(cx, entity, invalidated_subtrees)
+}
+
+fn has_invalidated_layout_ancestor(
+    cx: &Context,
+    entity: Entity,
+    invalidated_subtrees: &HashSet<Entity>,
+) -> bool {
+    let mut ancestor = cx.tree.get_layout_parent(entity);
+
+    while let Some(current) = ancestor {
+        if invalidated_subtrees.contains(&current) {
+            return true;
+        }
+
+        ancestor = cx.tree.get_layout_parent(current);
+    }
+
+    false
 }
 
 fn build_clip_path(cx: &Context, entity: Entity, clip_bounds: BoundingBox) -> skia_safe::Path {

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -6,6 +6,10 @@ use std::collections::BinaryHeap;
 use vizia_storage::{DrawChildIterator, LayoutTreeIterator};
 use vizia_style::BlendMode;
 
+fn should_apply_entity_clip(style: &Style, entity: Entity) -> bool {
+    !style.ignore_clipping.get(entity).copied().unwrap_or(false)
+}
+
 pub(crate) fn draw_system(
     cx: &mut Context,
     window_entity: Entity,
@@ -253,7 +257,9 @@ fn draw_entity(
 
     canvas.save();
     if let Some(Some(clip_path)) = cx.cache.clip_path.get(current) {
-        canvas.clip_path(clip_path, ClipOp::Intersect, true);
+        if should_apply_entity_clip(cx.style, current) {
+            canvas.clip_path(clip_path, ClipOp::Intersect, true);
+        }
     }
 
     if let Some(transform) = cx.cache.transform.get(current) {

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -257,9 +257,7 @@ fn draw_entity(
 
     canvas.save();
     if let Some(Some(clip_path)) = cx.cache.clip_path.get(current) {
-        if should_apply_entity_clip(cx.style, current) {
-            canvas.clip_path(clip_path, ClipOp::Intersect, true);
-        }
+        canvas.clip_path(clip_path, ClipOp::Intersect, true);
     }
 
     if let Some(transform) = cx.cache.transform.get(current) {
@@ -402,6 +400,10 @@ pub(crate) fn draw_bounds(
     }
 
     if tree.is_window(entity) {
+        return dirty_bounds;
+    }
+
+    if !should_apply_entity_clip(style, entity) {
         return dirty_bounds;
     }
 

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -639,6 +639,11 @@ fn link_style_data(
         should_redraw = true;
     }
 
+    if style.ignore_clipping.link(entity, matched_rules) {
+        should_reclip = true;
+        should_redraw = true;
+    }
+
     if style.overflowx.link(entity, matched_rules) {
         should_reclip = true;
         should_redraw = true;

--- a/crates/vizia_core/src/tree/mod.rs
+++ b/crates/vizia_core/src/tree/mod.rs
@@ -1,5 +1,117 @@
 mod focus_iter;
 pub(crate) use focus_iter::*;
 
+use std::borrow::Borrow;
+use std::collections::HashSet;
+use std::hash::Hash;
+
+use vizia_id::GenerationalId;
+
 // Re-export tree
 pub use vizia_storage::{ChildIterator, ParentIterator, Tree, TreeExt};
+
+/// Returns the minimal set of dirty entities whose layout subtrees cover all dirty entities.
+///
+/// Any dirty entity with a dirty layout ancestor is excluded from the result.
+pub fn minimal_layout_dirty_roots<I, D, B>(tree: &Tree<I>, dirty: D) -> HashSet<I>
+where
+    I: GenerationalId + Eq + Hash,
+    D: IntoIterator<Item = B>,
+    B: Borrow<I>,
+{
+    let dirty: HashSet<I> = dirty.into_iter().map(|entity| *entity.borrow()).collect();
+
+    if dirty.contains(&I::root()) {
+        return HashSet::from([I::root()]);
+    }
+
+    let mut roots = HashSet::new();
+
+    for &entity in &dirty {
+        let mut has_dirty_layout_ancestor = false;
+        let mut parent = tree.get_layout_parent(entity);
+
+        while let Some(current) = parent {
+            if dirty.contains(&current) {
+                has_dirty_layout_ancestor = true;
+                break;
+            }
+
+            parent = tree.get_layout_parent(current);
+        }
+
+        if !has_dirty_layout_ancestor {
+            roots.insert(entity);
+        }
+    }
+
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vizia_id::{
+        GENERATIONAL_ID_GENERATION_MASK, GENERATIONAL_ID_INDEX_BITS, GENERATIONAL_ID_INDEX_MASK,
+        impl_generational_id,
+    };
+
+    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct TestEntity(u64);
+
+    impl_generational_id!(TestEntity);
+
+    #[test]
+    fn excludes_dirty_descendants_when_ancestor_is_dirty() {
+        let mut tree = Tree::new();
+        let root = TestEntity::root();
+        let a = TestEntity::new(1, 0);
+        let b = TestEntity::new(2, 0);
+        let c = TestEntity::new(3, 0);
+
+        tree.add(a, root).unwrap();
+        tree.add(b, a).unwrap();
+        tree.add(c, b).unwrap();
+
+        let dirty = HashSet::from([a, c]);
+        let roots = minimal_layout_dirty_roots(&tree, &dirty);
+
+        assert_eq!(roots, HashSet::from([a]));
+    }
+
+    #[test]
+    fn keeps_disjoint_dirty_nodes() {
+        let mut tree = Tree::new();
+        let root = TestEntity::root();
+        let a = TestEntity::new(1, 0);
+        let b = TestEntity::new(2, 0);
+        let c = TestEntity::new(3, 0);
+        let d = TestEntity::new(4, 0);
+
+        tree.add(a, root).unwrap();
+        tree.add(b, root).unwrap();
+        tree.add(c, a).unwrap();
+        tree.add(d, b).unwrap();
+
+        let dirty = HashSet::from([c, d]);
+        let roots = minimal_layout_dirty_roots(&tree, &dirty);
+
+        assert_eq!(roots, HashSet::from([c, d]));
+    }
+
+    #[test]
+    fn root_dirty_collapses_everything_to_root() {
+        let mut tree = Tree::new();
+        let root = TestEntity::root();
+        let a = TestEntity::new(1, 0);
+        let b = TestEntity::new(2, 0);
+
+        tree.add(a, root).unwrap();
+        tree.add(b, a).unwrap();
+
+        let dirty = HashSet::from([root, b]);
+        let roots = minimal_layout_dirty_roots(&tree, &dirty);
+
+        assert_eq!(roots, HashSet::from([root]));
+    }
+}

--- a/crates/vizia_core/src/views/popup.rs
+++ b/crates/vizia_core/src/views/popup.rs
@@ -76,6 +76,7 @@ impl Popover {
                 });
             })
             .position_type(PositionType::Absolute)
+            .ignore_clipping(true)
             .space(Pixels(0.0))
     }
 }

--- a/crates/vizia_core/src/views/tooltip.rs
+++ b/crates/vizia_core/src/views/tooltip.rs
@@ -70,6 +70,7 @@ impl Tooltip {
             })
             .role(Role::Tooltip)
             .z_index(110)
+            .ignore_clipping(true)
             .hoverable(false)
             .position_type(PositionType::Absolute)
             .space(Pixels(0.0))


### PR DESCRIPTION
Introduce an ignore_clipping style flag to let views opt out of ancestor clipping (useful for overlays/popovers). Adds a style modifier, stores the flag in Style, and removes it on entity cleanup. The clipping system now treats entities with ignore_clipping=true as having no parent clip, and the draw system skips applying clip paths for those entities. Also enable ignore_clipping on Popover so it can escape overflow clipping. Affects modifiers/style.rs, style/mod.rs, systems/clipping.rs, systems/draw.rs, and views/popup.rs.