### PR TITLE
Only mark text layout when needed

### DIFF
--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -80,9 +80,11 @@ pub(crate) fn layout_system(cx: &mut Context) {
                 }
             }
 
-            cx.style.needs_text_layout(entity);
-
             if let Some(geo) = cx.cache.geo_changed.get(entity).copied() {
+                if !geo.is_empty() && cx.style.text.contains(entity) {
+                    cx.style.needs_text_layout(entity);
+                }
+
                 if !geo.is_empty()
                 // && cx.style.text.get(entity).is_some()
                 {


### PR DESCRIPTION
Call cx.style.needs_text_layout(entity) only when the entity's geometry change is non-empty and the entity actually has text. Previously the call ran unconditionally; this avoids setting unnecessary text layout work for empty geometry or non-text entities and reduces redundant layout work.