### PR TITLE
Add headless app support and multiwindow fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,10 @@ name = "multiwindow"
 path = "examples/multiwindow.rs"
 
 [[example]]
+name = "multiwindow_headless"
+path = "examples/multiwindow_headless.rs"
+
+[[example]]
 name = "popup_window"
 path = "examples/popup_window.rs"
 

--- a/crates/vizia_baseview/src/window.rs
+++ b/crates/vizia_baseview/src/window.rs
@@ -109,7 +109,7 @@ impl ViziaWindow {
         let dpi_factor = window_scale_factor * win_desc.user_scale_factor;
 
         cx.add_main_window(Entity::root(), &win_desc, dpi_factor as f32);
-        cx.add_window(WindowView {});
+        cx.add_window(Entity::root(), WindowView {});
 
         cx.0.windows.insert(
             Entity::root(),

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -38,9 +38,19 @@ impl BackendContext {
         }
     }
 
-    /// Adds a root window view to the context.
-    pub fn add_window<W: View>(&mut self, window: W) {
-        self.0.views.insert(Entity::root(), Box::new(window));
+    /// Registers a window view for the given entity in the context.
+    pub fn add_window<W: View>(&mut self, window_entity: Entity, window: W) {
+        self.0.views.insert(window_entity, Box::new(window));
+    }
+
+    /// Creates a new entity as a child of the provided parent and inserts it into the tree.
+    pub fn create_child_entity(&mut self, parent: Entity) -> Entity {
+        let entity = self.0.entity_manager.create();
+        self.0.tree.add(entity, parent).expect("Failed to add entity to tree");
+        self.0.cache.add(entity);
+        self.0.style.add(entity);
+        self.0.needs_redraw(entity);
+        entity
     }
 
     /// Returns a mutable reference to the style data.
@@ -107,6 +117,9 @@ impl BackendContext {
         self.0.style.position_type.insert(window_entity, PositionType::Absolute);
 
         self.0.tree.set_window(window_entity, true);
+
+        // Every real window entity carries the accessibility Window role.
+        self.0.style.role.insert(window_entity, Role::Window);
 
         // let physical_x = window_description.position.unwrap_or_default().x as f32 * dpi_factor;
         // let physical_y = window_description.position.unwrap_or_default().y as f32 * dpi_factor;

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -476,7 +476,7 @@ impl Context {
                     // Fall back to the nearest enclosing window so focus is never
                     // stranded on the root sentinel.
                     let fallback = self.tree.get_parent_window(*entity).unwrap_or(Entity::root());
-                    self.focused = fallback;
+                    self.with_current(fallback, |cx| cx.focus());
                 }
             }
 

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -216,8 +216,6 @@ impl Context {
             drop_data: None,
         };
 
-        result.tree.set_window(Entity::root(), true);
-
         result.style.needs_restyle(Entity::root());
         result.style.needs_relayout();
         result.style.needs_retransform(Entity::root());
@@ -231,8 +229,6 @@ impl Context {
         Environment::new(&mut result).build(&mut result);
 
         result.entity_manager.create();
-
-        result.style.role.insert(Entity::root(), Role::Window);
 
         result
     }
@@ -257,7 +253,7 @@ impl Context {
         self.data::<Environment>()
     }
 
-    /// Returns the entity id of the  parent window to the current view.
+    /// Returns the entity id of the parent window of the current view.
     pub fn parent_window(&self) -> Entity {
         self.tree.get_parent_window(self.current).unwrap_or(Entity::root())
     }
@@ -477,7 +473,10 @@ impl Context {
                 if let Some(new_focus) = self.focus_stack.pop() {
                     self.with_current(new_focus, |cx| cx.focus());
                 } else {
-                    self.with_current(Entity::root(), |cx| cx.focus());
+                    // Fall back to the nearest enclosing window so focus is never
+                    // stranded on the root sentinel.
+                    let fallback = self.tree.get_parent_window(*entity).unwrap_or(Entity::root());
+                    self.focused = fallback;
                 }
             }
 
@@ -501,22 +500,28 @@ impl Context {
                 self.stop_timer(timer);
             }
 
-            let window_entity = self.tree.get_parent_window(*entity).unwrap_or(Entity::root());
+            let window_entity = if self.tree.is_window(*entity) {
+                // The entity being removed IS a window – its own WindowState is the target.
+                *entity
+            } else {
+                self.tree.get_parent_window(*entity).unwrap_or(Entity::root())
+            };
 
             if !self.tree.is_window(*entity) {
                 if let Some(draw_bounds) = self.cache.draw_bounds.get(*entity) {
-                    if let Some(dirty_rect) =
-                        &mut self.windows.get_mut(&window_entity).unwrap().dirty_rect
-                    {
-                        *dirty_rect = dirty_rect.union(draw_bounds);
-                    } else {
-                        self.windows.get_mut(&window_entity).unwrap().dirty_rect =
-                            Some(*draw_bounds);
+                    if let Some(ws) = self.windows.get_mut(&window_entity) {
+                        if let Some(dirty_rect) = &mut ws.dirty_rect {
+                            *dirty_rect = dirty_rect.union(draw_bounds);
+                        } else {
+                            ws.dirty_rect = Some(*draw_bounds);
+                        }
                     }
                 }
             }
 
-            self.windows.get_mut(&window_entity).unwrap().redraw_list.remove(entity);
+            if let Some(ws) = self.windows.get_mut(&window_entity) {
+                ws.redraw_list.remove(entity);
+            }
 
             if self.windows.contains_key(entity) {
                 self.windows.remove(entity);

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     model::ModelData,
 };
 
+use crate::environment::{apply_direction_class, apply_theme_class};
 use crate::{binding::BindingHandler, resource::StoredImage};
 use crate::{cache::CachedData, resource::ImageOrSvg};
 
@@ -637,11 +638,9 @@ impl Context {
             let environment = self.data::<Environment>();
             let theme_mode = environment.effective_theme();
             let direction = environment.direction.get();
-            self.with_current(Entity::root(), |cx| {
-                let cx = &mut EventContext::new(cx);
-                cx.toggle_class("dark", theme_mode == ThemeMode::DarkMode);
-                cx.toggle_class("rtl", direction == Direction::RightToLeft);
-            })
+            let cx = &mut EventContext::new(self);
+            apply_theme_class(cx, theme_mode == ThemeMode::DarkMode);
+            apply_direction_class(cx, direction);
         } else {
             // Add an empty stylesheet to ensure that the list of styles contains at least three entries.
             self.add_stylesheet("").unwrap();

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -45,9 +45,14 @@ fn direction_from_locale(locale: &LanguageIdentifier) -> Direction {
     }
 }
 
-fn apply_direction_class(cx: &mut EventContext, direction: Direction) {
+pub(crate) fn apply_direction_class(cx: &mut EventContext, direction: Direction) {
     let rtl = direction == Direction::RightToLeft;
-    let window_entities = cx.windows.keys().copied().collect::<Vec<_>>();
+    let window_entities = cx
+        .windows
+        .keys()
+        .copied()
+        .filter(|window_entity| cx.tree.get_parent(*window_entity) == Some(Entity::root()))
+        .collect::<Vec<_>>();
 
     cx.with_current(Entity::root(), |cx| {
         cx.toggle_class("rtl", rtl);
@@ -56,6 +61,25 @@ fn apply_direction_class(cx: &mut EventContext, direction: Direction) {
     for window_entity in window_entities {
         cx.with_current(window_entity, |cx| {
             cx.toggle_class("rtl", rtl);
+        });
+    }
+}
+
+pub(crate) fn apply_theme_class(cx: &mut EventContext, is_dark: bool) {
+    let window_entities = cx
+        .windows
+        .keys()
+        .copied()
+        .filter(|window_entity| cx.tree.get_parent(*window_entity) == Some(Entity::root()))
+        .collect::<Vec<_>>();
+
+    cx.with_current(Entity::root(), |cx| {
+        cx.toggle_class("dark", is_dark);
+    });
+
+    for window_entity in window_entities {
+        cx.with_current(window_entity, |cx| {
+            cx.toggle_class("dark", is_dark);
         });
     }
 }
@@ -142,9 +166,7 @@ impl Model for Environment {
             EnvironmentEvent::SetThemeMode(theme) => {
                 self.theme_mode = theme;
                 let is_dark = self.effective_theme() == ThemeMode::DarkMode;
-                cx.with_current(Entity::root(), |cx| {
-                    cx.toggle_class("dark", is_dark);
-                });
+                apply_theme_class(cx, is_dark);
                 cx.reload_styles().unwrap();
             }
 
@@ -168,9 +190,7 @@ impl Model for Environment {
                 self.theme_mode = theme_mode;
 
                 let is_dark = self.effective_theme() == ThemeMode::DarkMode;
-                cx.with_current(Entity::root(), |cx| {
-                    cx.toggle_class("dark", is_dark);
-                });
+                apply_theme_class(cx, is_dark);
 
                 cx.reload_styles().unwrap();
             }
@@ -189,9 +209,7 @@ impl Model for Environment {
                 self.system_theme_mode = *theme;
                 if self.theme_mode == ThemeMode::System {
                     let is_dark = self.system_theme_mode == ThemeMode::DarkMode;
-                    cx.with_current(Entity::root(), |cx| {
-                        cx.toggle_class("dark", is_dark);
-                    });
+                    apply_theme_class(cx, is_dark);
                     cx.reload_styles().unwrap();
                 }
             }

--- a/crates/vizia_core/src/systems/draw.rs
+++ b/crates/vizia_core/src/systems/draw.rs
@@ -155,8 +155,16 @@ pub(crate) fn draw_system(
 
     canvas.restore();
 
-    // surface.canvas().clear(Color::transparent());
-    dirty_surface.draw(surface.canvas(), (0, 0), SamplingOptions::default(), None);
+    // Composite dirty surface with Src blend so transparent pixels in dirty
+    // regions replace destination pixels instead of preserving stale content.
+    let mut composite_paint = Paint::default();
+    composite_paint.set_blend_mode(skia_safe::BlendMode::Src);
+    dirty_surface.draw(
+        surface.canvas(),
+        (0, 0),
+        SamplingOptions::default(),
+        Some(&composite_paint),
+    );
 
     // Debug draw dirty rect
     // if let Some(rect) = dirty_rect.map(Rect::from) {

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -95,8 +95,9 @@ impl Element for Node<'_, '_> {
     }
 
     fn is_root(&self) -> bool {
-        self.tree.is_window(self.entity)
-            && self.tree.get_parent(self.entity) == Some(Entity::root())
+        self.entity == Entity::root()
+            || (self.tree.is_window(self.entity)
+                && self.tree.get_parent(self.entity) == Some(Entity::root()))
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -95,7 +95,8 @@ impl Element for Node<'_, '_> {
     }
 
     fn is_root(&self) -> bool {
-        self.entity == Entity::root()
+        self.tree.is_window(self.entity)
+            && self.tree.get_parent(self.entity) == Some(Entity::root())
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -9,6 +9,7 @@ use crate::{
 use accesskit_winit::Adapter;
 use hashbrown::HashMap;
 use log::warn;
+use std::cell::RefCell;
 use std::{error::Error, fmt::Display, sync::Arc};
 use vizia_input::ImeState;
 
@@ -16,7 +17,6 @@ use vizia_input::ImeState;
 // use accesskit::{Action, NodeBuilder, NodeId, TreeUpdate};
 // #[cfg(feature = "accesskit")]
 // use accesskit_winit;
-// use std::cell::RefCell;
 use vizia_core::context::EventProxy;
 use vizia_core::prelude::*;
 use vizia_core::{backend::*, events::EventManager};
@@ -179,7 +179,37 @@ impl Application {
 
         cx.renegotiate_language();
         cx.0.add_built_in_styles();
-        (content)(cx.context());
+
+        if startup_mode == StartupMode::Compatibility {
+            let main_window_entity = cx.create_child_entity(Entity::root());
+            let content = RefCell::new(Some(content));
+
+            cx.add_window(
+                main_window_entity,
+                Window {
+                    window: None,
+                    on_close: None,
+                    on_create: None,
+                    should_close: false,
+                    custom_cursors: Default::default(),
+                },
+            );
+            cx.0.windows.insert(
+                main_window_entity,
+                WindowState {
+                    content: Some(Arc::new(move |cx| {
+                        if let Some(content) = content.borrow_mut().take() {
+                            content(cx);
+                        }
+                    })),
+                    window_description: WindowDescription::new(),
+                    ..Default::default()
+                },
+            );
+            cx.0.tree.set_window(main_window_entity, true);
+        } else {
+            (content)(cx.context());
+        }
 
         Self {
             cx,
@@ -438,8 +468,22 @@ impl ApplicationHandler<UserEvent> for Application {
             let mut implicit_window_entity = None;
 
             if self.startup_mode == StartupMode::Compatibility {
-                // Create the implicit primary window for compatibility mode as a child of root.
-                let main_window_entity = self.cx.create_child_entity(Entity::root());
+                // Reuse the implicit primary window entity allocated during build().
+                let main_window_entity = self
+                    .cx
+                    .0
+                    .windows
+                    .iter()
+                    .find_map(|(entity, window_state)| {
+                        if window_state.content.is_some()
+                            && self.cx.0.tree.get_parent(*entity) == Some(Entity::root())
+                        {
+                            Some(*entity)
+                        } else {
+                            None
+                        }
+                    })
+                    .expect("Compatibility mode missing implicit window entity");
 
                 let main_window: Arc<winit::window::Window> = self
                     .create_window(
@@ -465,14 +509,19 @@ impl ApplicationHandler<UserEvent> for Application {
                         custom_cursors: self.custom_cursors.clone(),
                     },
                 );
+                if let Some(window_state) = self.cx.0.windows.get_mut(&main_window_entity) {
+                    window_state.window_description = self.window_description.clone();
+                }
 
-                self.cx.0.windows.insert(
-                    main_window_entity,
-                    WindowState {
-                        window_description: self.window_description.clone(),
-                        ..Default::default()
-                    },
-                );
+                if let Some(content) = self
+                    .cx
+                    .0
+                    .windows
+                    .get(&main_window_entity)
+                    .and_then(|window_state| window_state.content.clone())
+                {
+                    self.cx.0.with_current(main_window_entity, |cx| (content)(cx));
+                }
 
                 implicit_window_entity = Some(main_window_entity);
 

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -9,6 +9,7 @@ use crate::{
 use accesskit_winit::Adapter;
 use hashbrown::HashMap;
 use log::warn;
+use std::cell::RefCell;
 use std::{error::Error, fmt::Display, sync::Arc};
 use vizia_input::ImeState;
 
@@ -67,6 +68,12 @@ impl From<vizia_core::events::Event> for UserEvent {
 
 type IdleCallback = Option<Box<dyn Fn(&mut Context)>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupMode {
+    Compatibility,
+    Headless,
+}
+
 #[derive(Debug)]
 pub enum ApplicationError {
     EventLoopError(EventLoopError),
@@ -106,6 +113,9 @@ pub struct Application {
     event_loop_proxy: EventLoopProxy<UserEvent>,
     windows: HashMap<WindowId, WinState>,
     window_ids: HashMap<Entity, WindowId>,
+    startup_mode: StartupMode,
+    exit_when_no_windows: bool,
+    had_windows: bool,
     #[cfg(feature = "accesskit")]
     accesskit_adapter: Option<accesskit_winit::Adapter>,
     #[cfg(feature = "accesskit")]
@@ -126,6 +136,23 @@ impl EventProxy for WinitEventProxy {
 
 impl Application {
     pub fn new<F>(content: F) -> Self
+    where
+        F: 'static + FnOnce(&mut Context),
+    {
+        Self::build(content, StartupMode::Compatibility)
+    }
+
+    /// Creates an application without an implicit primary window.
+    ///
+    /// Use this when you want explicit control over top-level window creation.
+    pub fn headless<F>(content: F) -> Self
+    where
+        F: 'static + FnOnce(&mut Context),
+    {
+        Self::build(content, StartupMode::Headless)
+    }
+
+    fn build<F>(content: F, startup_mode: StartupMode) -> Self
     where
         F: 'static + FnOnce(&mut Context),
     {
@@ -152,7 +179,37 @@ impl Application {
 
         cx.renegotiate_language();
         cx.0.add_built_in_styles();
-        (content)(cx.context());
+
+        if startup_mode == StartupMode::Compatibility {
+            let main_window_entity = cx.create_child_entity(Entity::root());
+            let content = RefCell::new(Some(content));
+
+            cx.add_window(
+                main_window_entity,
+                Window {
+                    window: None,
+                    on_close: None,
+                    on_create: None,
+                    should_close: false,
+                    custom_cursors: Default::default(),
+                },
+            );
+            cx.0.windows.insert(
+                main_window_entity,
+                WindowState {
+                    content: Some(Arc::new(move |cx| {
+                        if let Some(content) = content.borrow_mut().take() {
+                            content(cx);
+                        }
+                    })),
+                    window_description: WindowDescription::new(),
+                    ..Default::default()
+                },
+            );
+            cx.0.tree.set_window(main_window_entity, true);
+        } else {
+            (content)(cx.context());
+        }
 
         Self {
             cx,
@@ -164,6 +221,9 @@ impl Application {
             event_loop_proxy: proxy,
             windows: HashMap::new(),
             window_ids: HashMap::new(),
+            startup_mode,
+            exit_when_no_windows: true,
+            had_windows: false,
             #[cfg(feature = "accesskit")]
             accesskit_adapter: None,
             #[cfg(feature = "accesskit")]
@@ -292,6 +352,7 @@ impl Application {
         let window_id = window_state.window.id();
         self.windows.insert(window_id, window_state);
         self.window_ids.insert(window_entity, window_id);
+        self.had_windows = true;
         Ok(window)
     }
 
@@ -330,6 +391,17 @@ impl Application {
     pub fn on_idle<F: 'static + Fn(&mut Context)>(mut self, callback: F) -> Self {
         self.on_idle = Some(Box::new(callback));
 
+        self
+    }
+
+    /// Controls whether the application exits automatically when all windows are closed.
+    ///
+    /// Defaults to `true`. The exit only triggers once at least one window has been opened and
+    /// then all windows are closed — so headless apps that start with no windows are not affected
+    /// until their first window is created and subsequently closed.
+    /// Set to `false` to keep the event loop running as a daemon even after all windows close.
+    pub fn exit_when_no_windows(mut self, exit: bool) -> Self {
+        self.exit_when_no_windows = exit;
         self
     }
 
@@ -389,59 +461,11 @@ impl ApplicationHandler<UserEvent> for Application {
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.windows.is_empty() {
-            // Create the main window
-            let main_window: Arc<winit::window::Window> = self
-                .create_window(event_loop, Entity::root(), &self.window_description.clone(), None)
-                .expect("failed to create initial window");
             let custom_cursors = Arc::new(load_default_cursors(event_loop));
-            self.cx.add_main_window(
-                Entity::root(),
-                &self.window_description,
-                main_window.scale_factor() as f32,
-            );
-            self.cx.add_window(Window {
-                window: Some(main_window.clone()),
-                on_close: None,
-                on_create: None,
-                should_close: false,
-                custom_cursors: custom_cursors.clone(),
-            });
-
-            self.cx.0.windows.insert(
-                Entity::root(),
-                WindowState {
-                    window_description: self.window_description.clone(),
-                    ..Default::default()
-                },
-            );
-
-            #[cfg(feature = "accesskit")]
-            {
-                self.accesskit_adapter = Some(Adapter::with_event_loop_proxy(
-                    event_loop,
-                    &main_window,
-                    self.event_loop_proxy.clone(),
-                ));
-            }
-
-            main_window.set_visible(self.window_description.visible);
-
-            // set current system theme if available
-            if let Some(theme) = main_window.theme() {
-                let theme = match theme {
-                    winit::window::Theme::Light => ThemeMode::LightMode,
-                    winit::window::Theme::Dark => ThemeMode::DarkMode,
-                };
-                self.cx.emit_origin(WindowEvent::ThemeChanged(theme));
-            }
-
             self.cx.0.add_built_in_styles();
 
-            // Create any subwindows
+            // Create user-defined windows.
             for (window_entity, window_state) in self.cx.0.windows.clone().into_iter() {
-                if window_entity == Entity::root() {
-                    continue;
-                }
                 let owner = window_state.owner.and_then(|entity| {
                     self.window_ids
                         .get(&entity)
@@ -457,13 +481,35 @@ impl ApplicationHandler<UserEvent> for Application {
                     )
                     .expect("Failed to create window");
 
+                #[cfg(feature = "accesskit")]
+                if self.accesskit_adapter.is_none() {
+                    self.accesskit_adapter = Some(Adapter::with_event_loop_proxy(
+                        event_loop,
+                        &window,
+                        self.event_loop_proxy.clone(),
+                    ));
+                }
+
                 self.cx.add_main_window(
                     window_entity,
                     &window_state.window_description,
                     window.scale_factor() as f32,
                 );
-
                 window.set_visible(window_state.window_description.visible);
+
+                if self.startup_mode == StartupMode::Compatibility
+                    && window_entity.parent(&self.cx.0.tree) == Some(Entity::root())
+                    && self.window_description.visible == window_state.window_description.visible
+                    && window_state.owner.is_none()
+                {
+                    if let Some(theme) = window.theme() {
+                        let theme = match theme {
+                            winit::window::Theme::Light => ThemeMode::LightMode,
+                            winit::window::Theme::Dark => ThemeMode::DarkMode,
+                        };
+                        self.cx.emit_origin(WindowEvent::ThemeChanged(theme));
+                    }
+                }
 
                 self.cx.0.with_current(window_entity, |cx| {
                     if let Some(content) = &window_state.content {
@@ -750,11 +796,6 @@ impl ApplicationHandler<UserEvent> for Application {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        if self.windows.is_empty() {
-            event_loop.exit();
-            return;
-        }
-
         event_loop.set_control_flow(self.control_flow);
 
         Runtime::drain_pending_work();
@@ -824,10 +865,11 @@ impl ApplicationHandler<UserEvent> for Application {
             self.cx.0.remove(window_entity);
         }
 
-        // Sync window state with context
+        // Sync OS window state with the logical window map.
         self.windows.retain(|_, win| self.cx.0.windows.contains_key(&win.entity));
         self.window_ids.retain(|e, _| self.cx.0.windows.contains_key(e));
 
+        // Create any logical windows that don't yet have an OS window.
         if self.windows.len() != self.cx.0.windows.len() {
             for (window_entity, window_state) in self.cx.0.windows.clone().iter() {
                 if !self.window_ids.contains_key(window_entity) {
@@ -846,12 +888,20 @@ impl ApplicationHandler<UserEvent> for Application {
                         )
                         .expect("Failed to create window");
 
+                    #[cfg(feature = "accesskit")]
+                    if self.accesskit_adapter.is_none() {
+                        self.accesskit_adapter = Some(Adapter::with_event_loop_proxy(
+                            event_loop,
+                            &window,
+                            self.event_loop_proxy.clone(),
+                        ));
+                    }
+
                     self.cx.add_main_window(
                         *window_entity,
                         &window_state.window_description,
                         window.scale_factor() as f32,
                     );
-
                     window.set_visible(window_state.window_description.visible);
 
                     self.cx.0.with_current(*window_entity, |cx| {
@@ -873,7 +923,14 @@ impl ApplicationHandler<UserEvent> for Application {
             }
         }
 
-        if self.windows.is_empty() {
+        // Exit when all windows have been closed. The `had_windows` guard prevents
+        // premature exit at startup for headless apps that begin with no windows —
+        // the exit only fires after at least one window has been opened and closed.
+        if self.exit_when_no_windows
+            && self.had_windows
+            && self.windows.is_empty()
+            && self.cx.0.windows.is_empty()
+        {
             event_loop.exit();
         }
     }

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -114,6 +114,7 @@ pub struct Application {
     window_ids: HashMap<Entity, WindowId>,
     custom_cursors: Arc<HashMap<CursorIcon, CustomCursor>>,
     startup_mode: StartupMode,
+    implicit_primary_window: Option<Entity>,
     exit_when_no_windows: bool,
     had_windows: bool,
     #[cfg(feature = "accesskit")]
@@ -157,6 +158,7 @@ impl Application {
         F: 'static + FnOnce(&mut Context),
     {
         let context = Context::new();
+        let mut implicit_primary_window = None;
 
         let event_loop =
             EventLoop::<UserEvent>::with_user_event().build().expect("Failed to create event loop");
@@ -182,6 +184,7 @@ impl Application {
 
         if startup_mode == StartupMode::Compatibility {
             let main_window_entity = cx.create_child_entity(Entity::root());
+            implicit_primary_window = Some(main_window_entity);
             let content = RefCell::new(Some(content));
 
             cx.add_window(
@@ -223,6 +226,7 @@ impl Application {
             window_ids: HashMap::new(),
             custom_cursors: Arc::new(HashMap::new()),
             startup_mode,
+            implicit_primary_window,
             exit_when_no_windows: true,
             had_windows: false,
             #[cfg(feature = "accesskit")]
@@ -230,6 +234,10 @@ impl Application {
             #[cfg(feature = "accesskit")]
             adapter_initialized: false,
         }
+    }
+
+    fn app_window_modifier_target(&self) -> Entity {
+        self.implicit_primary_window.unwrap_or(Entity::root())
     }
 
     fn create_window(
@@ -1024,19 +1032,24 @@ impl ApplicationHandler<UserEvent> for Application {
 impl WindowModifiers for Application {
     fn title<T: ToStringLocalized>(mut self, title: impl Res<T> + Clone + 'static) -> Self {
         self.window_description.title = title.get_value(&self.cx.0).to_string_local(&self.cx.0);
+        let target = self.app_window_modifier_target();
 
         let getter_for_locale = title.clone();
 
         title.set_or_bind(&mut self.cx.0, move |cx, val| {
             let title_str = val.get_value(cx).to_string_local(cx);
 
-            cx.emit(WindowEvent::SetTitle(title_str));
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetTitle(title_str));
+            });
         });
 
         let locale = self.cx.0.environment().locale;
         locale.set_or_bind(&mut self.cx.0, move |cx, _| {
             let title = getter_for_locale.get_value(cx).to_string_local(cx);
-            cx.emit(WindowEvent::SetTitle(title));
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetTitle(title));
+            });
         });
 
         self
@@ -1044,9 +1057,12 @@ impl WindowModifiers for Application {
 
     fn inner_size<S: Into<WindowSize>>(mut self, size: impl Res<S>) -> Self {
         self.window_description.inner_size = size.get_value(&self.cx.0).into();
+        let target = self.app_window_modifier_target();
 
-        size.set_or_bind(&mut self.cx.0, |cx, size| {
-            cx.emit(WindowEvent::SetSize(size.get_value(cx).into()));
+        size.set_or_bind(&mut self.cx.0, move |cx, size| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetSize(size.get_value(cx).into()));
+            });
         });
 
         self
@@ -1054,9 +1070,12 @@ impl WindowModifiers for Application {
 
     fn min_inner_size<S: Into<WindowSize>>(mut self, size: impl Res<Option<S>>) -> Self {
         self.window_description.min_inner_size = size.get_value(&self.cx.0).map(|s| s.into());
+        let target = self.app_window_modifier_target();
 
-        size.set_or_bind(&mut self.cx.0, |cx, size| {
-            cx.emit(WindowEvent::SetMinSize(size.get_value(cx).map(|s| s.into())));
+        size.set_or_bind(&mut self.cx.0, move |cx, size| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetMinSize(size.get_value(cx).map(|s| s.into())));
+            });
         });
 
         self
@@ -1064,18 +1083,24 @@ impl WindowModifiers for Application {
 
     fn max_inner_size<S: Into<WindowSize>>(mut self, size: impl Res<Option<S>>) -> Self {
         self.window_description.max_inner_size = size.get_value(&self.cx.0).map(|s| s.into());
+        let target = self.app_window_modifier_target();
 
-        size.set_or_bind(&mut self.cx.0, |cx, size| {
-            cx.emit(WindowEvent::SetMaxSize(size.get_value(cx).map(|s| s.into())));
+        size.set_or_bind(&mut self.cx.0, move |cx, size| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetMaxSize(size.get_value(cx).map(|s| s.into())));
+            });
         });
         self
     }
 
     fn position<P: Into<WindowPosition>>(mut self, position: impl Res<P>) -> Self {
         self.window_description.position = Some(position.get_value(&self.cx.0).into());
+        let target = self.app_window_modifier_target();
 
-        position.set_or_bind(&mut self.cx.0, |cx, size| {
-            cx.emit(WindowEvent::SetPosition(size.get_value(cx).into()));
+        position.set_or_bind(&mut self.cx.0, move |cx, size| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetPosition(size.get_value(cx).into()));
+            });
         });
 
         self
@@ -1107,9 +1132,12 @@ impl WindowModifiers for Application {
 
     fn resizable(mut self, flag: impl Res<bool>) -> Self {
         self.window_description.resizable = flag.get_value(&self.cx.0);
+        let target = self.app_window_modifier_target();
 
-        flag.set_or_bind(&mut self.cx.0, |cx, flag| {
-            cx.emit(WindowEvent::SetResizable(flag.get_value(cx)));
+        flag.set_or_bind(&mut self.cx.0, move |cx, flag| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetResizable(flag.get_value(cx)));
+            });
         });
 
         self
@@ -1117,18 +1145,24 @@ impl WindowModifiers for Application {
 
     fn minimized(mut self, flag: impl Res<bool>) -> Self {
         self.window_description.minimized = flag.get_value(&self.cx.0);
+        let target = self.app_window_modifier_target();
 
-        flag.set_or_bind(&mut self.cx.0, |cx, flag| {
-            cx.emit(WindowEvent::SetMinimized(flag.get_value(cx)));
+        flag.set_or_bind(&mut self.cx.0, move |cx, flag| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetMinimized(flag.get_value(cx)));
+            });
         });
         self
     }
 
     fn maximized(mut self, flag: impl Res<bool>) -> Self {
         self.window_description.maximized = flag.get_value(&self.cx.0);
+        let target = self.app_window_modifier_target();
 
-        flag.set_or_bind(&mut self.cx.0, |cx, flag| {
-            cx.emit(WindowEvent::SetMaximized(flag.get_value(cx)));
+        flag.set_or_bind(&mut self.cx.0, move |cx, flag| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetMaximized(flag.get_value(cx)));
+            });
         });
 
         self
@@ -1136,9 +1170,12 @@ impl WindowModifiers for Application {
 
     fn visible(mut self, flag: impl Res<bool>) -> Self {
         self.window_description.visible = flag.get_value(&self.cx.0);
+        let target = self.app_window_modifier_target();
 
-        flag.set_or_bind(&mut self.cx.0, |cx, flag| {
-            cx.emit(WindowEvent::SetVisible(flag.get_value(cx)));
+        flag.set_or_bind(&mut self.cx.0, move |cx, flag| {
+            cx.with_current(target, |cx| {
+                cx.emit(WindowEvent::SetVisible(flag.get_value(cx)));
+            });
         });
 
         self

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -9,7 +9,6 @@ use crate::{
 use accesskit_winit::Adapter;
 use hashbrown::HashMap;
 use log::warn;
-use std::cell::RefCell;
 use std::{error::Error, fmt::Display, sync::Arc};
 use vizia_input::ImeState;
 
@@ -113,6 +112,7 @@ pub struct Application {
     event_loop_proxy: EventLoopProxy<UserEvent>,
     windows: HashMap<WindowId, WinState>,
     window_ids: HashMap<Entity, WindowId>,
+    custom_cursors: Arc<HashMap<CursorIcon, CustomCursor>>,
     startup_mode: StartupMode,
     exit_when_no_windows: bool,
     had_windows: bool,
@@ -179,37 +179,7 @@ impl Application {
 
         cx.renegotiate_language();
         cx.0.add_built_in_styles();
-
-        if startup_mode == StartupMode::Compatibility {
-            let main_window_entity = cx.create_child_entity(Entity::root());
-            let content = RefCell::new(Some(content));
-
-            cx.add_window(
-                main_window_entity,
-                Window {
-                    window: None,
-                    on_close: None,
-                    on_create: None,
-                    should_close: false,
-                    custom_cursors: Default::default(),
-                },
-            );
-            cx.0.windows.insert(
-                main_window_entity,
-                WindowState {
-                    content: Some(Arc::new(move |cx| {
-                        if let Some(content) = content.borrow_mut().take() {
-                            content(cx);
-                        }
-                    })),
-                    window_description: WindowDescription::new(),
-                    ..Default::default()
-                },
-            );
-            cx.0.tree.set_window(main_window_entity, true);
-        } else {
-            (content)(cx.context());
-        }
+        (content)(cx.context());
 
         Self {
             cx,
@@ -221,6 +191,7 @@ impl Application {
             event_loop_proxy: proxy,
             windows: HashMap::new(),
             window_ids: HashMap::new(),
+            custom_cursors: Arc::new(HashMap::new()),
             startup_mode,
             exit_when_no_windows: true,
             had_windows: false,
@@ -461,11 +432,78 @@ impl ApplicationHandler<UserEvent> for Application {
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.windows.is_empty() {
-            let custom_cursors = Arc::new(load_default_cursors(event_loop));
+            if self.custom_cursors.is_empty() {
+                self.custom_cursors = Arc::new(load_default_cursors(event_loop));
+            }
+            let mut implicit_window_entity = None;
+
+            if self.startup_mode == StartupMode::Compatibility {
+                // Create the implicit primary window for compatibility mode as a child of root.
+                let main_window_entity = self.cx.create_child_entity(Entity::root());
+
+                let main_window: Arc<winit::window::Window> = self
+                    .create_window(
+                        event_loop,
+                        main_window_entity,
+                        &self.window_description.clone(),
+                        None,
+                    )
+                    .expect("failed to create initial window");
+
+                self.cx.add_main_window(
+                    main_window_entity,
+                    &self.window_description,
+                    main_window.scale_factor() as f32,
+                );
+                self.cx.add_window(
+                    main_window_entity,
+                    Window {
+                        window: Some(main_window.clone()),
+                        on_close: None,
+                        on_create: None,
+                        should_close: false,
+                        custom_cursors: self.custom_cursors.clone(),
+                    },
+                );
+
+                self.cx.0.windows.insert(
+                    main_window_entity,
+                    WindowState {
+                        window_description: self.window_description.clone(),
+                        ..Default::default()
+                    },
+                );
+
+                implicit_window_entity = Some(main_window_entity);
+
+                #[cfg(feature = "accesskit")]
+                {
+                    self.accesskit_adapter = Some(Adapter::with_event_loop_proxy(
+                        event_loop,
+                        &main_window,
+                        self.event_loop_proxy.clone(),
+                    ));
+                }
+
+                main_window.set_visible(self.window_description.visible);
+
+                // Set current system theme if available.
+                if let Some(theme) = main_window.theme() {
+                    let theme = match theme {
+                        winit::window::Theme::Light => ThemeMode::LightMode,
+                        winit::window::Theme::Dark => ThemeMode::DarkMode,
+                    };
+                    self.cx.emit_origin(WindowEvent::ThemeChanged(theme));
+                }
+            }
+
             self.cx.0.add_built_in_styles();
 
             // Create user-defined windows.
             for (window_entity, window_state) in self.cx.0.windows.clone().into_iter() {
+                if Some(window_entity) == implicit_window_entity {
+                    continue;
+                }
                 let owner = window_state.owner.and_then(|entity| {
                     self.window_ids
                         .get(&entity)
@@ -497,20 +535,6 @@ impl ApplicationHandler<UserEvent> for Application {
                 );
                 window.set_visible(window_state.window_description.visible);
 
-                if self.startup_mode == StartupMode::Compatibility
-                    && window_entity.parent(&self.cx.0.tree) == Some(Entity::root())
-                    && self.window_description.visible == window_state.window_description.visible
-                    && window_state.owner.is_none()
-                {
-                    if let Some(theme) = window.theme() {
-                        let theme = match theme {
-                            winit::window::Theme::Light => ThemeMode::LightMode,
-                            winit::window::Theme::Dark => ThemeMode::DarkMode,
-                        };
-                        self.cx.emit_origin(WindowEvent::ThemeChanged(theme));
-                    }
-                }
-
                 self.cx.0.with_current(window_entity, |cx| {
                     if let Some(content) = &window_state.content {
                         (content)(cx)
@@ -518,7 +542,7 @@ impl ApplicationHandler<UserEvent> for Application {
                 });
                 self.cx.mutate_window(window_entity, |cx, win: &mut Window| {
                     win.window = Some(window.clone());
-                    win.custom_cursors = custom_cursors.clone();
+                    win.custom_cursors = self.custom_cursors.clone();
                     if let Some(callback) = &win.on_create {
                         (callback)(&mut EventContext::new_with_current(
                             cx.context(),
@@ -796,6 +820,10 @@ impl ApplicationHandler<UserEvent> for Application {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if self.custom_cursors.is_empty() {
+            self.custom_cursors = Arc::new(load_default_cursors(event_loop));
+        }
+
         event_loop.set_control_flow(self.control_flow);
 
         Runtime::drain_pending_work();
@@ -912,6 +940,7 @@ impl ApplicationHandler<UserEvent> for Application {
 
                     self.cx.mutate_window(*window_entity, |cx, win: &mut Window| {
                         win.window = Some(window.clone());
+                        win.custom_cursors = self.custom_cursors.clone();
                         if let Some(callback) = &win.on_create {
                             (callback)(&mut EventContext::new_with_current(
                                 cx.context(),

--- a/examples/multiwindow_headless.rs
+++ b/examples/multiwindow_headless.rs
@@ -1,0 +1,99 @@
+/// Demonstrates `Application::headless` – no implicit primary window, starting
+/// with zero windows.
+///
+/// The application starts with no OS windows at all. After a startup timer completes
+/// it sets a signal that causes a `Binding` to create the main window. A button
+/// inside that window then opens a second window the same way.
+pub use vizia::prelude::*;
+
+#[cfg(feature = "baseview")]
+fn main() {
+    panic!("This example is not supported on baseview");
+}
+
+#[cfg(all(feature = "winit", not(feature = "baseview")))]
+#[derive(Debug)]
+enum AppEvent {
+    /// Fired by the startup timer – triggers window creation via signal.
+    OpenMain,
+    ShowSecondary,
+    HideSecondary,
+}
+
+#[cfg(all(feature = "winit", not(feature = "baseview")))]
+struct AppData {
+    show_main: Signal<bool>,
+    show_secondary: Signal<bool>,
+}
+
+#[cfg(all(feature = "winit", not(feature = "baseview")))]
+impl Model for AppData {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
+        event.map(|e, _| match e {
+            AppEvent::OpenMain => {
+                if !self.show_main.get() {
+                    self.show_main.set(true)
+                }
+            }
+            AppEvent::ShowSecondary => self.show_secondary.set(true),
+            AppEvent::HideSecondary => self.show_secondary.set(false),
+        });
+    }
+}
+
+#[cfg(all(feature = "winit", not(feature = "baseview")))]
+fn main() -> Result<(), ApplicationError> {
+    Application::headless(|cx| {
+        // No windows created here – zero OS windows at startup.
+        let show_main = Signal::new(false);
+        let show_secondary = Signal::new(false);
+        AppData { show_main, show_secondary }.build(cx);
+
+        // When show_main becomes true, create the main window.
+        Binding::new(cx, show_main, move |cx| {
+            if show_main.get() {
+                Window::new(cx, move |cx| {
+                    VStack::new(cx, move |cx| {
+                        Label::new(cx, "Main window – opened by a timer event");
+                        Button::new(cx, |cx| Label::new(cx, "Open secondary window"))
+                            .on_press(|cx| cx.emit(AppEvent::ShowSecondary));
+                    })
+                    .padding(Pixels(20.0))
+                    .vertical_gap(Pixels(8.0));
+                })
+                .title("Main (spawned by timer)")
+                .inner_size((340, 180));
+            }
+        });
+
+        // Secondary window - created at root scope so it is a separate top-level window.
+        Binding::new(cx, show_secondary, move |cx| {
+            if show_secondary.get() {
+                Window::new(cx, |cx| {
+                    VStack::new(cx, |cx| {
+                        Label::new(cx, "Secondary window");
+                        Label::new(cx, "Independent top-level window.");
+                    })
+                    .padding(Pixels(20.0))
+                    .vertical_gap(Pixels(8.0));
+                })
+                .on_close(|cx| cx.emit(AppEvent::HideSecondary))
+                .title("Secondary")
+                .inner_size((280, 120));
+            }
+        });
+
+        // Start a bounded timer and create the main window when it stops.
+        let timer = cx.add_timer(
+            std::time::Duration::from_millis(100),
+            Some(std::time::Duration::from_millis(5000)),
+            |cx, action| {
+                if let TimerAction::Stop = action {
+                    cx.emit(AppEvent::OpenMain);
+                }
+            },
+        );
+        cx.start_timer(timer);
+    })
+    .run()
+}


### PR DESCRIPTION
Introduce Application::headless and a StartupMode to allow apps to start without an implicit primary window (headless startup) while preserving legacy behavior (compatibility). Change BackendContext::add_window to accept a window entity and add create_child_entity helper; mark real windows with the Window accessibility role. Fix contextual window handling and safety when removing entities (avoid unwrapping root windows, robust dirty rect/ redraw list updates) and improve focus fallback to the enclosing window. Update baseview call site to pass an entity, add exit_when_no_windows control and had_windows guard to avoid premature event-loop exit, and adjust window creation/accesskit/theme logic. Add a new example (examples/multiwindow_headless.rs) and register it in Cargo.toml to demonstrate headless multi-window usage.