### PR TITLE
Refactor scroll handling with transforms and update scrollbar logic

### DIFF
--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -290,16 +290,28 @@ impl<'a> EventContext<'a> {
         let bounds = self.cache.get_bounds(entity);
 
         if let Some(transform) = self.cache.transform.get(entity).copied() {
+            // The cache stores identity matrices for all entities by default, so skip map/rounding
+            // work when no effective transform is present.
+            if transform == Matrix::new_identity() {
+                return bounds;
+            }
+
             let (rect, _) = transform.map_rect(Rect::from(bounds));
-            BoundingBox::from_min_max(
-                rect.left().floor(),
-                rect.top().floor(),
-                rect.right().ceil(),
-                rect.bottom().ceil(),
-            )
+            rect.into()
         } else {
             bounds
         }
+    }
+
+    /// Returns transformed bounds expanded to pixel-snapped extents.
+    pub fn transformed_bounds_snapped(&self, entity: Entity) -> BoundingBox {
+        let bounds = self.transformed_bounds(entity);
+        BoundingBox::from_min_max(
+            bounds.left().floor(),
+            bounds.top().floor(),
+            bounds.right().ceil(),
+            bounds.bottom().ceil(),
+        )
     }
 
     /// Returns the transformed bounds of the current view's parent.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -16,7 +16,7 @@ use crate::resource::{ImageOrSvg, ResourceManager, StoredImage};
 use crate::tree::{focus_backward, focus_forward, is_navigatable};
 use vizia_input::MouseState;
 
-use skia_safe::Matrix;
+use skia_safe::{Matrix, Rect};
 
 use crate::text::TextContext;
 #[cfg(feature = "clipboard")]
@@ -283,6 +283,28 @@ impl<'a> EventContext<'a> {
     /// Returns the bounds of the current view.
     pub fn bounds(&self) -> BoundingBox {
         self.cache.get_bounds(self.current)
+    }
+
+    /// Returns the transformed bounds of an entity in window coordinates.
+    pub fn transformed_bounds(&self, entity: Entity) -> BoundingBox {
+        let bounds = self.cache.get_bounds(entity);
+
+        if let Some(transform) = self.cache.transform.get(entity).copied() {
+            let (rect, _) = transform.map_rect(Rect::from(bounds));
+            BoundingBox::from_min_max(
+                rect.left().floor(),
+                rect.top().floor(),
+                rect.right().ceil(),
+                rect.bottom().ceil(),
+            )
+        } else {
+            bounds
+        }
+    }
+
+    /// Returns the transformed bounds of the current view's parent.
+    pub fn parent_transformed_bounds(&self) -> BoundingBox {
+        self.transformed_bounds(self.parent())
     }
 
     // pub fn set_bounds(&mut self, bounds: BoundingBox) {

--- a/crates/vizia_core/src/layout/node.rs
+++ b/crates/vizia_core/src/layout/node.rs
@@ -369,12 +369,16 @@ impl Node for Entity {
         store.wrap.get(*self).copied()
     }
 
-    fn vertical_scroll(&self, store: &Self::Store) -> Option<f32> {
-        store.vertical_scroll.get(*self).cloned().map(|val| store.logical_to_physical(val))
+    fn vertical_scroll(&self, _store: &Self::Store) -> Option<f32> {
+        // Scroll offset is applied via transform on ScrollContent, not through morphorm.
+        // Return None so morphorm takes its non-scroll code path.
+        None
     }
 
-    fn horizontal_scroll(&self, store: &Self::Store) -> Option<f32> {
-        store.horizontal_scroll.get(*self).cloned().map(|val| store.logical_to_physical(val))
+    fn horizontal_scroll(&self, _store: &Self::Store) -> Option<f32> {
+        // Scroll offset is applied via transform on ScrollContent, not through morphorm.
+        // Return None so morphorm takes its non-scroll code path.
+        None
     }
 
     fn min_vertical_gap(&self, store: &Self::Store) -> Option<Units> {

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -303,14 +303,14 @@ pub trait LayoutModifiers: internal::Modifiable {
         /// Set the vertical scroll position of the view.
         vertical_scroll,
         f32,
-        SystemFlags::RELAYOUT
+        SystemFlags::REDRAW | SystemFlags::RECLIP
     );
 
     modifier!(
         /// Set the horizontal scroll position of the view.
         horizontal_scroll,
         f32,
-        SystemFlags::RELAYOUT
+        SystemFlags::REDRAW | SystemFlags::RECLIP
     );
 
     modifier!(

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -300,20 +300,6 @@ pub trait LayoutModifiers: internal::Modifiable {
     }
 
     modifier!(
-        /// Set the vertical scroll position of the view.
-        vertical_scroll,
-        f32,
-        SystemFlags::REDRAW | SystemFlags::RECLIP
-    );
-
-    modifier!(
-        /// Set the horizontal scroll position of the view.
-        horizontal_scroll,
-        f32,
-        SystemFlags::REDRAW | SystemFlags::RECLIP
-    );
-
-    modifier!(
         /// Sets the minimum width of the view.
         min_width,
         Units,

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -365,10 +365,6 @@ pub struct Style {
     pub(crate) vertical_gap: AnimatableVarSet<Units>,
     pub(crate) horizontal_gap: AnimatableVarSet<Units>,
 
-    // Scrolling
-    pub(crate) vertical_scroll: AnimatableSet<f32>,
-    pub(crate) horizontal_scroll: AnimatableSet<f32>,
-
     // Size
     pub(crate) width: AnimatableVarSet<Units>,
     pub(crate) height: AnimatableVarSet<Units>,
@@ -2712,10 +2708,6 @@ impl Style {
         self.vertical_gap.remove(entity);
         self.horizontal_gap.remove(entity);
 
-        // Scrolling
-        self.vertical_scroll.remove(entity);
-        self.horizontal_scroll.remove(entity);
-
         // Size
         self.width.remove(entity);
         self.height.remove(entity);
@@ -2902,10 +2894,6 @@ impl Style {
         self.padding_bottom.clear_rules();
         self.horizontal_gap.clear_rules();
         self.vertical_gap.clear_rules();
-
-        // Scrolling
-        self.horizontal_scroll.clear_rules();
-        self.vertical_scroll.clear_rules();
 
         // Text and Font
         self.text_wrap.clear_rules();

--- a/crates/vizia_core/src/systems/transform.rs
+++ b/crates/vizia_core/src/systems/transform.rs
@@ -86,6 +86,12 @@ pub(crate) fn transform_system(cx: &mut Context) {
                     let iter = LayoutTreeIterator::subtree(&cx.tree, entity);
                     for descendant in iter {
                         cx.style.needs_reclip(descendant);
+                        // Cached draw bounds include transformed and clipped extents.
+                        // Invalidate them when ancestor transforms change so dirty/intersection
+                        // checks don't cull newly visible descendants.
+                        if descendant != entity {
+                            cx.cache.draw_bounds.remove(descendant);
+                        }
                     }
                 }
 

--- a/crates/vizia_core/src/views/popup.rs
+++ b/crates/vizia_core/src/views/popup.rs
@@ -90,8 +90,7 @@ impl View for Popover {
         event.map(|window_event, _| match window_event {
             // Reposition popup if there isn't enough room for it.
             WindowEvent::GeometryChanged(_) => {
-                let parent = cx.parent();
-                let parent_bounds = cx.cache.get_bounds(parent);
+                let parent_bounds = cx.parent_transformed_bounds();
                 let bounds = cx.bounds();
                 let window_bounds = cx.cache.get_bounds(cx.parent_window());
                 let scale = cx.scale_factor();

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -35,6 +35,7 @@ impl Scrollbar {
     {
         let value = value.to_signal(cx);
         let ratio = ratio.to_signal(cx);
+        let translate_state: Memo<(f32, f32)> = Memo::new(move |_| (value.get(), ratio.get()));
 
         Self {
             value,
@@ -48,10 +49,9 @@ impl Scrollbar {
             Element::new(cx)
                 .class("thumb")
                 .focusable(true)
-                .bind(value, move |handle| {
-                    let value = value.get();
-
-                    let ratio = ratio.get().clamp(0.0001, 1.0);
+                .bind(translate_state, move |handle| {
+                    let (value, ratio) = translate_state.get();
+                    let ratio = ratio.clamp(0.0001, 1.0);
                     let offset =
                         if ratio >= 1.0 { 0.0 } else { (value * (1.0 - ratio) / ratio) * 100.0 };
 

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -1,5 +1,6 @@
 use crate::context::TreeProps;
 use crate::prelude::*;
+use skia_safe::Rect;
 
 /// A view which represents a bar that can be dragged to manipulate a scrollview.
 pub struct Scrollbar {
@@ -19,11 +20,6 @@ enum ScrollBarEvent {
 }
 
 impl Scrollbar {
-    fn is_horizontal_rtl(&self, cx: &EventContext) -> bool {
-        self.orientation == Orientation::Horizontal
-            && cx.environment().direction.get() == Direction::RightToLeft
-    }
-
     /// Create a new [Scrollbar] view.
     pub fn new<F, V, R>(
         cx: &mut Context,
@@ -54,13 +50,20 @@ impl Scrollbar {
                 .focusable(true)
                 .bind(value, move |handle| {
                     let value = value.get();
+
+                    let ratio = ratio.get().clamp(0.0001, 1.0);
+                    let offset =
+                        if ratio >= 1.0 { 0.0 } else { (value * (1.0 - ratio) / ratio) * 100.0 };
+
                     match orientation {
-                        Orientation::Horizontal => {
-                            handle.left(Units::Stretch(value)).right(Units::Stretch(1.0 - value))
-                        }
-                        Orientation::Vertical => {
-                            handle.top(Units::Stretch(value)).bottom(Units::Stretch(1.0 - value))
-                        }
+                        Orientation::Horizontal => handle.translate(Translate {
+                            x: LengthOrPercentage::Percentage(offset),
+                            y: LengthOrPercentage::Length(Length::px(0.0)),
+                        }),
+                        Orientation::Vertical => handle.translate(Translate {
+                            x: LengthOrPercentage::Length(Length::px(0.0)),
+                            y: LengthOrPercentage::Percentage(offset),
+                        }),
                     };
                 })
                 .bind(ratio, move |handle| {
@@ -88,8 +91,19 @@ impl Scrollbar {
 
     fn thumb_bounds(&self, cx: &mut EventContext) -> BoundingBox {
         let child = cx.first_child();
+        let bounds = cx.with_current(child, |cx| cx.bounds());
 
-        cx.with_current(child, |cx| cx.bounds())
+        if let Some(transform) = cx.cache.transform.get(child).copied() {
+            let (rect, _) = transform.map_rect(Rect::from(bounds));
+            BoundingBox::from_min_max(
+                rect.left().floor(),
+                rect.top().floor(),
+                rect.right().ceil(),
+                rect.bottom().ceil(),
+            )
+        } else {
+            bounds
+        }
     }
 
     fn compute_new_value(&self, cx: &mut EventContext, physical_delta: f32, value_ref: f32) -> f32 {
@@ -100,8 +114,6 @@ impl Scrollbar {
             value_ref
         } else {
             // what percentage of negative space have we crossed?
-            let physical_delta =
-                if self.is_horizontal_rtl(cx) { -physical_delta } else { physical_delta };
             let logical_delta = physical_delta / negative_space;
             value_ref + logical_delta
         }
@@ -155,10 +167,7 @@ impl View for Scrollbar {
                         match self.orientation {
                             Orientation::Horizontal => {
                                 let px = cx.mouse.cursor_x - cx.bounds().x - thumb_bounds.w / 2.0;
-                                let mut x = (px / sx).clamp(0.0, 1.0);
-                                if self.is_horizontal_rtl(cx) {
-                                    x = 1.0 - x;
-                                }
+                                let x = (px / sx).clamp(0.0, 1.0);
                                 if let Some(callback) = &self.on_changing {
                                     (callback)(cx, x);
                                 }
@@ -227,10 +236,7 @@ impl View for Scrollbar {
                                 Orientation::Horizontal => {
                                     let px =
                                         cx.mouse.cursor_x - cx.bounds().x - thumb_bounds.w / 2.0;
-                                    let mut x = (px / sx).clamp(0.0, 1.0);
-                                    if self.is_horizontal_rtl(cx) {
-                                        x = 1.0 - x;
-                                    }
+                                    let x = (px / sx).clamp(0.0, 1.0);
                                     if let Some(callback) = &self.on_changing {
                                         (callback)(cx, x);
                                     }

--- a/crates/vizia_core/src/views/scrollbar.rs
+++ b/crates/vizia_core/src/views/scrollbar.rs
@@ -1,6 +1,5 @@
 use crate::context::TreeProps;
 use crate::prelude::*;
-use skia_safe::Rect;
 
 /// A view which represents a bar that can be dragged to manipulate a scrollview.
 pub struct Scrollbar {
@@ -91,19 +90,7 @@ impl Scrollbar {
 
     fn thumb_bounds(&self, cx: &mut EventContext) -> BoundingBox {
         let child = cx.first_child();
-        let bounds = cx.with_current(child, |cx| cx.bounds());
-
-        if let Some(transform) = cx.cache.transform.get(child).copied() {
-            let (rect, _) = transform.map_rect(Rect::from(bounds));
-            BoundingBox::from_min_max(
-                rect.left().floor(),
-                rect.top().floor(),
-                rect.right().ceil(),
-                rect.bottom().ceil(),
-            )
-        } else {
-            bounds
-        }
+        cx.transformed_bounds(child)
     }
 
     fn compute_new_value(&self, cx: &mut EventContext, physical_delta: f32, value_ref: f32) -> f32 {

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -89,7 +89,9 @@ impl ScrollView {
         let has_h_scroll = Memo::new(move |_| container_width.get() < inner_width.get());
         let has_v_scroll = Memo::new(move |_| container_height.get() < inner_height.get());
 
-        let horizontal_scrollbar_value: Memo<f32> = Memo::new(move |_| scroll_x.get());
+        let horizontal_scrollbar_value: Memo<f32> = Memo::new(move |_| {
+            ScrollView::map_scroll_x_to_physical(scroll_x.get(), direction.get())
+        });
 
         let scroll_state = Memo::new(move |_| {
             (
@@ -117,7 +119,34 @@ impl ScrollView {
             show_vertical_scrollbar,
         }
         .build(cx, move |cx| {
-            ScrollContent::new(cx, content);
+            // Apply scroll offset as a translation transform on scroll_content.
+            ScrollContent::new(cx, content).bind(scroll_state, move |mut handle| {
+                let (
+                    scroll_x,
+                    scroll_y,
+                    inner_width,
+                    inner_height,
+                    container_width,
+                    container_height,
+                    direction,
+                ) = scroll_state_signal.get();
+                let scale_factor = handle.context().scale_factor();
+                let y_overflow = (inner_height - container_height).max(0.0);
+                let top = (y_overflow * scroll_y).round() / scale_factor;
+                let x_overflow = (inner_width - container_width).max(0.0);
+                let left = (x_overflow * scroll_x).round() / scale_factor;
+                println!(
+                    "scroll_x: {}, left: {}, top: {}, x_overflow: {}",
+                    scroll_x, left, top, x_overflow
+                );
+
+                let tx = if direction == Direction::RightToLeft { left } else { -left };
+
+                handle.transform(vec![Transform::Translate((
+                    LengthOrPercentage::Length(Length::px(tx)),
+                    LengthOrPercentage::Length(Length::px(-top)),
+                ))]);
+            });
 
             Binding::new(cx, show_vertical_scrollbar, move |cx| {
                 if show_vertical_scrollbar.get() {
@@ -143,29 +172,17 @@ impl ScrollView {
                         horizontal_ratio,
                         Orientation::Horizontal,
                         |cx, value| {
-                            cx.emit(ScrollEvent::SetX(value));
+                            let logical = ScrollView::map_scroll_x_from_physical(
+                                value,
+                                cx.environment().direction.get(),
+                            );
+                            cx.emit(ScrollEvent::SetX(logical));
                         },
                     )
                     .position_type(PositionType::Absolute)
                     .scroll_to_cursor(scroll_to_cursor);
                 }
             });
-        })
-        .bind(scroll_state, move |mut handle| {
-            let (
-                scroll_x,
-                scroll_y,
-                inner_width,
-                inner_height,
-                container_width,
-                container_height,
-                direction,
-            ) = scroll_state_signal.get();
-            let scale_factor = handle.context().scale_factor();
-            let top = ((inner_height - container_height) * scroll_y).round() / scale_factor;
-            let physical_scroll_x = ScrollView::map_scroll_x_to_physical(scroll_x, direction);
-            let left = ((inner_width - container_width) * physical_scroll_x).round() / scale_factor;
-            handle.horizontal_scroll(-left.abs()).vertical_scroll(-top.abs());
         })
         .toggle_class("h-scroll", has_h_scroll)
         .toggle_class("v-scroll", has_v_scroll)
@@ -191,12 +208,7 @@ impl View for ScrollView {
         event.map(|scroll_update, meta| {
             match scroll_update {
                 ScrollEvent::ScrollX(f) => {
-                    let delta = if cx.environment().direction.get() == Direction::RightToLeft {
-                        -*f
-                    } else {
-                        *f
-                    };
-                    self.scroll_x.set((self.scroll_x.get() + delta).clamp(0.0, 1.0));
+                    self.scroll_x.set((self.scroll_x.get() + *f).clamp(0.0, 1.0));
 
                     if let Some(callback) = &self.on_scroll {
                         (callback)(cx, self.scroll_x.get(), self.scroll_y.get());
@@ -250,7 +262,7 @@ impl View for ScrollView {
                         inner_width = *w;
                         inner_height = *h;
 
-                        if inner_width != container_width {
+                        if inner_width > container_width {
                             let physical_scroll_x = ((left * scale_factor)
                                 / (inner_width - container_width))
                                 .clamp(0.0, 1.0);
@@ -262,7 +274,7 @@ impl View for ScrollView {
                             scroll_x = 0.0;
                         }
 
-                        if inner_height != container_height {
+                        if inner_height > container_height {
                             scroll_y = ((top * scale_factor) / (inner_height - container_height))
                                 .clamp(0.0, 1.0);
                         } else {
@@ -370,7 +382,7 @@ impl View for ScrollView {
                         container_width = bounds.width();
                         container_height = bounds.height();
 
-                        if inner_width != container_width {
+                        if inner_width > container_width {
                             let physical_scroll_x = ((left * scale_factor)
                                 / (inner_width - container_width))
                                 .clamp(0.0, 1.0);
@@ -382,7 +394,7 @@ impl View for ScrollView {
                             scroll_x = 0.0;
                         }
 
-                        if inner_height != container_height {
+                        if inner_height > container_height {
                             scroll_y = ((top * scale_factor) / (inner_height - container_height))
                                 .clamp(0.0, 1.0);
                         } else {

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -135,17 +135,13 @@ impl ScrollView {
                 let top = (y_overflow * scroll_y).round() / scale_factor;
                 let x_overflow = (inner_width - container_width).max(0.0);
                 let left = (x_overflow * scroll_x).round() / scale_factor;
-                println!(
-                    "scroll_x: {}, left: {}, top: {}, x_overflow: {}",
-                    scroll_x, left, top, x_overflow
-                );
 
                 let tx = if direction == Direction::RightToLeft { left } else { -left };
 
-                handle.transform(vec![Transform::Translate((
-                    LengthOrPercentage::Length(Length::px(tx)),
-                    LengthOrPercentage::Length(Length::px(-top)),
-                ))]);
+                handle.translate(Translate {
+                    x: LengthOrPercentage::Length(Length::px(tx)),
+                    y: LengthOrPercentage::Length(Length::px(-top)),
+                });
             });
 
             Binding::new(cx, show_vertical_scrollbar, move |cx| {

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::prelude::*;
-use skia_safe::Rect;
 
 pub(crate) const SCROLL_SENSITIVITY: f32 = 20.0;
 
@@ -194,22 +193,6 @@ impl ScrollView {
             self.scroll_y.set(0.0);
         }
     }
-
-    fn transformed_bounds(cx: &EventContext, entity: Entity) -> BoundingBox {
-        let bounds = cx.cache.get_bounds(entity);
-
-        if let Some(transform) = cx.cache.transform.get(entity).copied() {
-            let (rect, _) = transform.map_rect(Rect::from(bounds));
-            BoundingBox::from_min_max(
-                rect.left().floor(),
-                rect.top().floor(),
-                rect.right().ceil(),
-                rect.bottom().ceil(),
-            )
-        } else {
-            bounds
-        }
-    }
 }
 
 impl View for ScrollView {
@@ -314,8 +297,8 @@ impl View for ScrollView {
                 }
 
                 ScrollEvent::ScrollToView(entity) => {
-                    let view_bounds = ScrollView::transformed_bounds(cx, *entity);
-                    let content_bounds = ScrollView::transformed_bounds(cx, cx.current());
+                    let view_bounds = cx.transformed_bounds(*entity);
+                    let content_bounds = cx.transformed_bounds(cx.current());
 
                     let direction = cx.environment().direction.get();
                     let mut physical_scroll_x =

--- a/crates/vizia_core/src/views/scrollview.rs
+++ b/crates/vizia_core/src/views/scrollview.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::prelude::*;
+use skia_safe::Rect;
 
 pub(crate) const SCROLL_SENSITIVITY: f32 = 20.0;
 
@@ -193,6 +194,22 @@ impl ScrollView {
             self.scroll_y.set(0.0);
         }
     }
+
+    fn transformed_bounds(cx: &EventContext, entity: Entity) -> BoundingBox {
+        let bounds = cx.cache.get_bounds(entity);
+
+        if let Some(transform) = cx.cache.transform.get(entity).copied() {
+            let (rect, _) = transform.map_rect(Rect::from(bounds));
+            BoundingBox::from_min_max(
+                rect.left().floor(),
+                rect.top().floor(),
+                rect.right().ceil(),
+                rect.bottom().ceil(),
+            )
+        } else {
+            bounds
+        }
+    }
 }
 
 impl View for ScrollView {
@@ -297,9 +314,8 @@ impl View for ScrollView {
                 }
 
                 ScrollEvent::ScrollToView(entity) => {
-                    let view_bounds = cx.cache.get_bounds(*entity);
-
-                    let content_bounds = cx.bounds();
+                    let view_bounds = ScrollView::transformed_bounds(cx, *entity);
+                    let content_bounds = ScrollView::transformed_bounds(cx, cx.current());
 
                     let direction = cx.environment().direction.get();
                     let mut physical_scroll_x =

--- a/crates/vizia_core/src/views/slider.rs
+++ b/crates/vizia_core/src/views/slider.rs
@@ -283,19 +283,16 @@ where
                     });
 
                     let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                    let current = cx.current();
+                    let bounds = cx.transformed_bounds(current);
+                    let thumb_bounds = cx.transformed_bounds(thumb);
                     let thumb_size = match self.orientation.get() {
-                        Orientation::Horizontal => cx.cache.get_width(thumb),
-                        Orientation::Vertical => cx.cache.get_height(thumb),
+                        Orientation::Horizontal => thumb_bounds.width(),
+                        Orientation::Vertical => thumb_bounds.height(),
                     };
                     let min = self.range.get().start;
                     let max = self.range.get().end;
                     let step = self.step.get();
-
-                    let current = cx.current();
-                    let width = cx.cache.get_width(current);
-                    let height = cx.cache.get_height(current);
-                    let posx = cx.cache.get_posx(current);
-                    let posy = cx.cache.get_posy(current);
 
                     let is_rtl = matches!(
                         cx.style.direction.get(current).copied(),
@@ -304,14 +301,19 @@ where
 
                     let mut dx = match self.orientation.get() {
                         Orientation::Horizontal => {
-                            let raw_dx = (cx.mouse.left.pos_down.0 - posx - thumb_size / 2.0)
-                                / (width - thumb_size);
+                            let span = (bounds.width() - thumb_size).max(f32::EPSILON);
+                            let raw_dx =
+                                (cx.mouse.left.pos_down.0 - bounds.left() - thumb_size / 2.0)
+                                    / span;
                             if is_rtl { 1.0 - raw_dx } else { raw_dx }
                         }
 
                         Orientation::Vertical => {
-                            (height - (cx.mouse.left.pos_down.1 - posy) - thumb_size / 2.0)
-                                / (height - thumb_size)
+                            let span = (bounds.height() - thumb_size).max(f32::EPSILON);
+                            (bounds.height()
+                                - (cx.mouse.left.pos_down.1 - bounds.top())
+                                - thumb_size / 2.0)
+                                / span
                         }
                     };
 
@@ -342,20 +344,17 @@ where
             WindowEvent::MouseMove(x, y) => {
                 if self.is_dragging {
                     let thumb = cx.get_entities_by_class("thumb").first().copied().unwrap();
+                    let current = cx.current();
+                    let bounds = cx.transformed_bounds(current);
+                    let thumb_bounds = cx.transformed_bounds(thumb);
                     let thumb_size = match self.orientation.get() {
-                        Orientation::Horizontal => cx.cache.get_width(thumb),
-                        Orientation::Vertical => cx.cache.get_height(thumb),
+                        Orientation::Horizontal => thumb_bounds.width(),
+                        Orientation::Vertical => thumb_bounds.height(),
                     };
 
                     let min = self.range.get().start;
                     let max = self.range.get().end;
                     let step = self.step.get();
-
-                    let current = cx.current();
-                    let width = cx.cache.get_width(current);
-                    let height = cx.cache.get_height(current);
-                    let posx = cx.cache.get_posx(current);
-                    let posy = cx.cache.get_posy(current);
 
                     let is_rtl = matches!(
                         cx.style.direction.get(current).copied(),
@@ -364,12 +363,14 @@ where
 
                     let mut dx = match self.orientation.get() {
                         Orientation::Horizontal => {
-                            let raw_dx = (*x - posx - thumb_size / 2.0) / (width - thumb_size);
+                            let span = (bounds.width() - thumb_size).max(f32::EPSILON);
+                            let raw_dx = (*x - bounds.left() - thumb_size / 2.0) / span;
                             if is_rtl { 1.0 - raw_dx } else { raw_dx }
                         }
 
                         Orientation::Vertical => {
-                            (height - (*y - posy) - thumb_size / 2.0) / (height - thumb_size)
+                            let span = (bounds.height() - thumb_size).max(f32::EPSILON);
+                            (bounds.height() - (*y - bounds.top()) - thumb_size / 2.0) / span
                         }
                     };
 

--- a/crates/vizia_core/src/views/tooltip.rs
+++ b/crates/vizia_core/src/views/tooltip.rs
@@ -81,8 +81,7 @@ impl Tooltip {
                             if tooltip.placement == Placement::Cursor && !x.is_nan() && !y.is_nan()
                             {
                                 let scale = ex.scale_factor();
-                                let parent = ex.parent();
-                                let parent_bounds = ex.cache.get_bounds(parent);
+                                let parent_bounds = ex.parent_transformed_bounds();
                                 if parent_bounds.contains_point(*x, *y) {
                                     ex.set_left(Pixels(
                                         ((*x - parent_bounds.x) - ex.bounds().width() / 2.0)
@@ -109,8 +108,7 @@ impl View for Tooltip {
         event.map(|window_event, _| match window_event {
             // Reposition popup if there isn't enough room for it.
             WindowEvent::GeometryChanged(_) => {
-                let parent = cx.parent();
-                let parent_bounds = cx.cache.get_bounds(parent);
+                let parent_bounds = cx.parent_transformed_bounds();
                 let bounds = cx.bounds();
                 let window_bounds = cx.cache.get_bounds(cx.parent_window());
 

--- a/crates/vizia_core/src/views/xypad.rs
+++ b/crates/vizia_core/src/views/xypad.rs
@@ -8,6 +8,17 @@ pub struct XYPad {
 }
 
 impl XYPad {
+    fn normalized_from_cursor(cx: &EventContext, current: Entity, x: f32, y: f32) -> (f32, f32) {
+        let bounds = cx.transformed_bounds(current);
+        let width = bounds.width().max(f32::EPSILON);
+        let height = bounds.height().max(f32::EPSILON);
+
+        let dx = ((x - bounds.left()) / width).clamp(0.0, 1.0);
+        let dy = ((y - bounds.top()) / height).clamp(0.0, 1.0);
+
+        (dx, dy)
+    }
+
     /// creates a new [XYPad] view.
     pub fn new<R: Res<(f32, f32)> + 'static>(cx: &mut Context, value: R) -> Handle<Self> {
         let value_state = value.to_signal(cx);
@@ -49,16 +60,10 @@ impl View for XYPad {
                     return;
                 }
                 let current = cx.current();
-                cx.capture();
-                let mouse = cx.mouse();
-                if meta.target == current {
-                    let mut dx = (mouse.left.pos_down.0 - cx.cache.get_posx(current))
-                        / cx.cache.get_width(current);
-                    let mut dy = (mouse.left.pos_down.1 - cx.cache.get_posy(current))
-                        / cx.cache.get_height(current);
-
-                    dx = dx.clamp(0.0, 1.0);
-                    dy = dy.clamp(0.0, 1.0);
+                let (mouse_x, mouse_y) = cx.mouse.left.pos_down;
+                if meta.target == current || meta.target.is_descendant_of(cx.tree, current) {
+                    cx.capture();
+                    let (dx, dy) = Self::normalized_from_cursor(cx, current, mouse_x, mouse_y);
 
                     self.is_dragging = true;
 
@@ -72,19 +77,12 @@ impl View for XYPad {
                 cx.set_active(false);
                 cx.release();
                 self.is_dragging = false;
-                if meta.target == cx.current() {
-                    cx.release();
-                }
             }
 
             WindowEvent::MouseMove(x, y) => {
                 if self.is_dragging {
                     let current = cx.current();
-                    let mut dx = (*x - cx.cache.get_posx(current)) / cx.cache.get_width(current);
-                    let mut dy = (*y - cx.cache.get_posy(current)) / cx.cache.get_height(current);
-
-                    dx = dx.clamp(0.0, 1.0);
-                    dy = dy.clamp(0.0, 1.0);
+                    let (dx, dy) = Self::normalized_from_cursor(cx, current, *x, *y);
 
                     if let Some(callback) = &self.on_change {
                         (callback)(cx, dx, 1.0 - dy);


### PR DESCRIPTION
This pull request significantly refactors how scrolling is handled in the layout and rendering systems, shifting from using morphorm's scroll offsets to applying scroll via transform on the scroll content. It also updates the scrollbar and scrollview logic to align with this new approach, removes unnecessary RTL-specific code, and fixes several edge cases related to scroll bounds and invalidation.