### PR TITLE
Add drag-and-drop support with new event handling and modifiers

### DIFF
--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -87,6 +87,7 @@ pub struct EventContext<'a> {
     clipboard: &'a mut Box<dyn ClipboardProvider>,
     pub(crate) event_proxy: &'a mut Option<Box<dyn crate::context::EventProxy>>,
     pub(crate) drop_data: &'a mut Option<DropData>,
+    pub(crate) active_drag_view: &'a mut Option<Entity>,
     pub windows: &'a mut HashMap<Entity, WindowState>,
 }
 
@@ -139,6 +140,7 @@ impl<'a> EventContext<'a> {
             clipboard: &mut cx.clipboard,
             event_proxy: &mut cx.event_proxy,
             drop_data: &mut cx.drop_data,
+            active_drag_view: &mut cx.active_drag_view,
             windows: &mut cx.windows,
         }
     }
@@ -172,6 +174,7 @@ impl<'a> EventContext<'a> {
             clipboard: &mut cx.clipboard,
             event_proxy: &mut cx.event_proxy,
             drop_data: &mut cx.drop_data,
+            active_drag_view: &mut cx.active_drag_view,
             windows: &mut cx.windows,
         }
     }
@@ -260,6 +263,21 @@ impl<'a> EventContext<'a> {
     /// Returns true if in a drop state.
     pub fn has_drop_data(&self) -> bool {
         self.drop_data.is_some()
+    }
+
+    /// Returns the current drop payload, if any.
+    pub fn drop_data(&self) -> Option<&DropData> {
+        self.drop_data.as_ref()
+    }
+
+    /// Returns the active drag preview view entity, if any.
+    pub fn active_drag_view(&self) -> Option<Entity> {
+        *self.active_drag_view
+    }
+
+    /// Sets the active drag preview view entity.
+    pub fn set_active_drag_view(&mut self, drag_view: Option<Entity>) {
+        *self.active_drag_view = drag_view;
     }
 
     /// Returns the bounds of the current view.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -657,6 +657,11 @@ impl<'a> EventContext<'a> {
         *self.drop_data = Some(data.into())
     }
 
+    /// Sets arbitrary typed drop data of the current view.
+    pub fn set_drop_data_any<T: Any + Send + Sync>(&mut self, data: T) {
+        *self.drop_data = Some(DropData::any(data));
+    }
+
     /// Get the contents of the system clipboard.
     ///
     /// This may fail for a variety of backend-specific reasons.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -657,11 +657,6 @@ impl<'a> EventContext<'a> {
         *self.drop_data = Some(data.into())
     }
 
-    /// Sets arbitrary typed drop data of the current view.
-    pub fn set_drop_data_any<T: Any + Send + Sync>(&mut self, data: T) {
-        *self.drop_data = Some(DropData::any(data));
-    }
-
     /// Get the contents of the system clipboard.
     ///
     /// This may fail for a variety of backend-specific reasons.

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -106,6 +106,7 @@ pub struct Context {
     pub(crate) captured: Entity,
     pub(crate) triggered: Entity,
     pub(crate) hovered: Entity,
+    pub(crate) drag_hovered: Entity,
     pub(crate) focused: Entity,
     pub(crate) focus_stack: Vec<Entity>,
     pub(crate) cursor_icon_locked: bool,
@@ -130,6 +131,7 @@ pub struct Context {
     pub ime_state: ImeState,
 
     pub(crate) drop_data: Option<DropData>,
+    pub(crate) active_drag_view: Option<Entity>,
 }
 
 impl Default for Context {
@@ -168,6 +170,7 @@ impl Context {
             captured: Entity::null(),
             triggered: Entity::null(),
             hovered: Entity::root(),
+            drag_hovered: Entity::null(),
             focused: Entity::root(),
             focus_stack: Vec::new(),
             cursor_icon_locked: false,
@@ -214,6 +217,7 @@ impl Context {
             ime_state: Default::default(),
 
             drop_data: None,
+            active_drag_view: None,
         };
 
         result.tree.set_window(Entity::root(), true);

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -36,6 +36,8 @@ pub struct Environment {
     pub system_theme_mode: ThemeMode,
     /// The timer used to blink the caret of a textbox.
     pub(crate) caret_timer: Timer,
+    /// The distance the mouse has to be dragged to start a drag operation.
+    pub drag_distance: Signal<u32>,
 }
 
 fn direction_from_locale(locale: &LanguageIdentifier) -> Direction {
@@ -90,6 +92,7 @@ impl Environment {
             theme_mode: ThemeMode::default(),
             system_theme_mode: detect_theme(),
             caret_timer,
+            drag_distance: Signal::new(4),
         }
     }
 
@@ -120,6 +123,8 @@ pub enum EnvironmentEvent {
     SetDoubleClickInterval(Duration),
     /// Set the delay before a tooltip fades in.
     SetTooltipDelay(Duration),
+    /// Set the distance the mouse has to be dragged to start a drag operation.
+    SetDragDistance(u32),
 }
 
 impl Model for Environment {
@@ -181,6 +186,10 @@ impl Model for Environment {
 
             EnvironmentEvent::SetTooltipDelay(delay) => {
                 self.tooltip_delay = delay;
+            }
+
+            EnvironmentEvent::SetDragDistance(distance) => {
+                self.drag_distance.set_if_changed(distance);
             }
         });
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -265,6 +265,16 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 cx.mouse.cursor_y = *y;
 
                 hover_system(cx, meta.origin);
+                dispatch_drag_events(cx, *x, *y);
+
+                if let Some(drag_view) = cx.active_drag_view {
+                    if cx.drop_data.is_some() {
+                        position_drag_view(cx, drag_view, *x, *y);
+                    } else {
+                        hide_drag_view(cx, drag_view);
+                        cx.active_drag_view = None;
+                    }
+                }
 
                 mutate_direct_or_up(meta, cx.captured, cx.hovered, false);
             }
@@ -311,6 +321,10 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
 
                     // Reset drag data
                     cx.drop_data = None;
+                    cx.drag_hovered = Entity::null();
+                    if let Some(drag_view) = cx.active_drag_view.take() {
+                        hide_drag_view(cx, drag_view);
+                    }
 
                     cx.with_current(if focusable { cx.hovered } else { cx.focused }, |cx| {
                         cx.focus_with_visibility(false)
@@ -368,6 +382,14 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
         }
         WindowEvent::MouseUp(button) => {
+            if let Some(drag_view) = cx.active_drag_view.take() {
+                hide_drag_view(cx, drag_view);
+            }
+
+            if matches!(button, MouseButton::Left) && cx.drop_data.is_some() {
+                cx.captured = Entity::null();
+            }
+
             match button {
                 MouseButton::Left => {
                     cx.mouse.left.pos_up = (cx.mouse.cursor_x, cx.mouse.cursor_y);
@@ -411,7 +433,13 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 cx.triggered = Entity::null();
             }
 
-            mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
+            if cx.drop_data.is_some() {
+                // During drag-and-drop, resolve drop handlers against the true hovered target
+                // instead of the captured source.
+                mutate_direct_or_up(meta, Entity::null(), cx.hovered, true);
+            } else {
+                mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
+            }
         }
         WindowEvent::MouseScroll(_, _) => {
             meta.target = cx.hovered;
@@ -737,6 +765,60 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
         }
 
         _ => {}
+    }
+}
+
+fn position_drag_view(cx: &mut Context, drag_view: Entity, x: f32, y: f32) {
+    if !cx.entity_manager.is_alive(drag_view) {
+        cx.active_drag_view = None;
+        return;
+    }
+
+    let left = cx.style.physical_to_logical(x);
+    let top = cx.style.physical_to_logical(y);
+
+    cx.with_current(drag_view, |cx| {
+        let mut ex = EventContext::new(cx);
+        ex.set_display(Display::Flex);
+        ex.set_left(Units::Pixels(left));
+        ex.set_top(Units::Pixels(top));
+    });
+}
+
+fn hide_drag_view(cx: &mut Context, drag_view: Entity) {
+    if !cx.entity_manager.is_alive(drag_view) {
+        return;
+    }
+
+    cx.with_current(drag_view, |cx| {
+        let mut ex = EventContext::new(cx);
+        ex.set_display(Display::None);
+    });
+}
+
+fn dispatch_drag_events(cx: &mut Context, x: f32, y: f32) {
+    if cx.drop_data.is_some() {
+        let hovered = cx.hovered;
+
+        if hovered != cx.drag_hovered {
+            if cx.drag_hovered != Entity::null() {
+                cx.event_queue
+                    .push_back(Event::new(WindowEvent::DragLeave).direct(cx.drag_hovered));
+            }
+
+            if hovered != Entity::null() {
+                cx.event_queue.push_back(Event::new(WindowEvent::DragEnter).direct(hovered));
+            }
+
+            cx.drag_hovered = hovered;
+        }
+
+        if hovered != Entity::null() {
+            cx.event_queue.push_back(Event::new(WindowEvent::DragMove(x, y)).target(hovered));
+        }
+    } else if cx.drag_hovered != Entity::null() {
+        cx.event_queue.push_back(Event::new(WindowEvent::DragLeave).direct(cx.drag_hovered));
+        cx.drag_hovered = Entity::null();
     }
 }
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -136,7 +136,7 @@ impl EventManager {
 
                 // Skip to next event if the current event was consumed.
                 if event.meta.consumed {
-                    clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
+                    clear_drop_state_for_drop_event(is_drop_event, &mut *cx.drop_data);
                     continue 'events;
                 }
 
@@ -157,7 +157,7 @@ impl EventManager {
 
                         // Skip to the next event if the current event was consumed.
                         if event.meta.consumed {
-                            clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
+                            clear_drop_state_for_drop_event(is_drop_event, &mut *cx.drop_data);
                             continue 'events;
                         }
                     }
@@ -179,7 +179,7 @@ impl EventManager {
 
                         // Skip to the next event if the current event was consumed.
                         if event.meta.consumed {
-                            clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
+                            clear_drop_state_for_drop_event(is_drop_event, &mut *cx.drop_data);
                             continue 'events;
                         }
                     }
@@ -189,7 +189,7 @@ impl EventManager {
                     (window_event_callback)(window_event);
                 });
 
-                clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
+                clear_drop_state_for_drop_event(is_drop_event, &mut *cx.drop_data);
             }
 
             binding_system(cx);
@@ -283,7 +283,9 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 cx.mouse.cursor_y = *y;
 
                 hover_system(cx, meta.origin);
-                dispatch_drag_events(cx, *x, *y);
+                if cx.drop_data.is_some() || cx.drag_hovered != Entity::null() {
+                    dispatch_drag_events(cx, *x, *y);
+                }
 
                 if let Some(drag_view) = cx.active_drag_view {
                     if cx.drop_data.is_some() {

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -408,10 +408,6 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 hide_drag_view(cx, drag_view);
             }
 
-            if matches!(button, MouseButton::Left) && had_drop_data {
-                cx.captured = Entity::null();
-            }
-
             match button {
                 MouseButton::Left => {
                     cx.mouse.left.pos_up = (cx.mouse.cursor_x, cx.mouse.cursor_y);
@@ -470,12 +466,12 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                         .push_back(Event::new(WindowEvent::DragLeave).target(cx.drag_hovered));
                 }
                 cx.drag_hovered = Entity::null();
-                // During drag-and-drop, resolve drop handlers against the true hovered target
-                // instead of the captured source.
-                mutate_direct_or_up(meta, Entity::null(), cx.hovered, true);
-            } else {
-                mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
             }
+            // Always route MouseUp through the captured entity (the drag source) so it
+            // receives the release and can reset its dragging state via DragModel::MouseUp.
+            // Capture is cleared by DragModel calling cx.release(). Drop and DragLeave are
+            // already queued to drag_hovered and will fire on the next event cycle.
+            mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
         }
         WindowEvent::MouseScroll(_, _) => {
             meta.target = cx.hovered;

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -179,6 +179,19 @@ impl EventManager {
                 event.map(|window_event: &WindowEvent, _| {
                     (window_event_callback)(window_event);
                 });
+
+                let mut clear_drop_state = false;
+                event.map(|window_event: &WindowEvent, _| {
+                    if matches!(window_event, WindowEvent::MouseUp(MouseButton::Left))
+                        && cx.drop_data.is_some()
+                    {
+                        clear_drop_state = true;
+                    }
+                });
+
+                if clear_drop_state {
+                    *cx.drop_data = None;
+                }
             }
 
             binding_system(cx);
@@ -803,11 +816,11 @@ fn dispatch_drag_events(cx: &mut Context, x: f32, y: f32) {
         if hovered != cx.drag_hovered {
             if cx.drag_hovered != Entity::null() {
                 cx.event_queue
-                    .push_back(Event::new(WindowEvent::DragLeave).direct(cx.drag_hovered));
+                    .push_back(Event::new(WindowEvent::DragLeave).target(cx.drag_hovered));
             }
 
             if hovered != Entity::null() {
-                cx.event_queue.push_back(Event::new(WindowEvent::DragEnter).direct(hovered));
+                cx.event_queue.push_back(Event::new(WindowEvent::DragEnter).target(hovered));
             }
 
             cx.drag_hovered = hovered;
@@ -817,7 +830,7 @@ fn dispatch_drag_events(cx: &mut Context, x: f32, y: f32) {
             cx.event_queue.push_back(Event::new(WindowEvent::DragMove(x, y)).target(hovered));
         }
     } else if cx.drag_hovered != Entity::null() {
-        cx.event_queue.push_back(Event::new(WindowEvent::DragLeave).direct(cx.drag_hovered));
+        cx.event_queue.push_back(Event::new(WindowEvent::DragLeave).target(cx.drag_hovered));
         cx.drag_hovered = Entity::null();
     }
 }

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -450,9 +450,8 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 // Dispatch Drop to the hovered drop target.
                 if cx.drag_hovered != Entity::null() {
                     if let Some(data) = cx.drop_data.clone() {
-                        cx.event_queue.push_back(
-                            Event::new(WindowEvent::Drop(data)).target(cx.drag_hovered),
-                        );
+                        cx.event_queue
+                            .push_back(Event::new(WindowEvent::Drop(data)).target(cx.drag_hovered));
                     }
                 }
                 cx.drag_hovered = Entity::null();

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -182,9 +182,7 @@ impl EventManager {
 
                 let mut clear_drop_state = false;
                 event.map(|window_event: &WindowEvent, _| {
-                    if matches!(window_event, WindowEvent::MouseUp(MouseButton::Left))
-                        && cx.drop_data.is_some()
-                    {
+                    if matches!(window_event, WindowEvent::Drop(_)) && cx.drop_data.is_some() {
                         clear_drop_state = true;
                     }
                 });
@@ -395,11 +393,13 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             mutate_direct_or_up(meta, cx.captured, cx.hovered, true);
         }
         WindowEvent::MouseUp(button) => {
+            let had_drop_data = cx.drop_data.is_some();
+
             if let Some(drag_view) = cx.active_drag_view.take() {
                 hide_drag_view(cx, drag_view);
             }
 
-            if matches!(button, MouseButton::Left) && cx.drop_data.is_some() {
+            if matches!(button, MouseButton::Left) && had_drop_data {
                 cx.captured = Entity::null();
             }
 
@@ -446,10 +446,12 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                 cx.triggered = Entity::null();
             }
 
-            if cx.drop_data.is_some() {
+            if had_drop_data {
+                let drop_data = cx.drop_data.take();
+
                 // Dispatch Drop to the hovered drop target.
                 if cx.drag_hovered != Entity::null() {
-                    if let Some(data) = cx.drop_data.clone() {
+                    if let Some(data) = drop_data {
                         cx.event_queue
                             .push_back(Event::new(WindowEvent::Drop(data)).target(cx.drag_hovered));
                     }

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -52,6 +52,10 @@ impl EventManager {
             // Loop over the events in the event queue.
             'events: for event in self.event_queue.iter_mut() {
                 let keyboard_lock_root = keyboard_event_lock_root(cx, event);
+                let mut is_drop_event = false;
+                event.map(|window_event: &WindowEvent, _| {
+                    is_drop_event = matches!(window_event, WindowEvent::Drop(_));
+                });
 
                 // Handle internal events.
                 event.take(|internal_event, _| match internal_event {
@@ -99,6 +103,7 @@ impl EventManager {
                     }
 
                     if event.meta.consumed {
+                        clear_drop_state_for_drop_event(is_drop_event, &mut cx.drop_data);
                         continue 'events;
                     }
                 }
@@ -112,6 +117,7 @@ impl EventManager {
 
                 // Skip to next event if the current event was consumed when handling internal state updates.
                 if event.meta.consumed {
+                    clear_drop_state_for_drop_event(is_drop_event, &mut cx.drop_data);
                     continue 'events;
                 }
 
@@ -130,6 +136,7 @@ impl EventManager {
 
                 // Skip to next event if the current event was consumed.
                 if event.meta.consumed {
+                    clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
                     continue 'events;
                 }
 
@@ -150,6 +157,7 @@ impl EventManager {
 
                         // Skip to the next event if the current event was consumed.
                         if event.meta.consumed {
+                            clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
                             continue 'events;
                         }
                     }
@@ -171,6 +179,7 @@ impl EventManager {
 
                         // Skip to the next event if the current event was consumed.
                         if event.meta.consumed {
+                            clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
                             continue 'events;
                         }
                     }
@@ -180,16 +189,7 @@ impl EventManager {
                     (window_event_callback)(window_event);
                 });
 
-                let mut clear_drop_state = false;
-                event.map(|window_event: &WindowEvent, _| {
-                    if matches!(window_event, WindowEvent::Drop(_)) && cx.drop_data.is_some() {
-                        clear_drop_state = true;
-                    }
-                });
-
-                if clear_drop_state {
-                    *cx.drop_data = None;
-                }
+                clear_drop_state_for_drop_event(is_drop_event, cx.drop_data);
             }
 
             binding_system(cx);
@@ -199,6 +199,13 @@ impl EventManager {
         } {}
     }
 }
+
+fn clear_drop_state_for_drop_event(is_drop_event: bool, drop_data: &mut Option<DropData>) {
+    if is_drop_event && drop_data.is_some() {
+        *drop_data = None;
+    }
+}
+
 fn is_keyboard_window_event(window_event: &WindowEvent) -> bool {
     matches!(
         window_event,
@@ -455,6 +462,10 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
                         cx.event_queue
                             .push_back(Event::new(WindowEvent::Drop(data)).target(cx.drag_hovered));
                     }
+
+                    // Drag is ending, so notify the last hovered drop target that the pointer left.
+                    cx.event_queue
+                        .push_back(Event::new(WindowEvent::DragLeave).target(cx.drag_hovered));
                 }
                 cx.drag_hovered = Entity::null();
                 // During drag-and-drop, resolve drop handlers against the true hovered target

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -447,6 +447,15 @@ fn internal_state_updates(cx: &mut Context, window_event: &WindowEvent, meta: &m
             }
 
             if cx.drop_data.is_some() {
+                // Dispatch Drop to the hovered drop target.
+                if cx.drag_hovered != Entity::null() {
+                    if let Some(data) = cx.drop_data.clone() {
+                        cx.event_queue.push_back(
+                            Event::new(WindowEvent::Drop(data)).target(cx.drag_hovered),
+                        );
+                    }
+                }
+                cx.drag_hovered = Entity::null();
                 // During drag-and-drop, resolve drop handlers against the true hovered target
                 // instead of the captured source.
                 mutate_direct_or_up(meta, Entity::null(), cx.hovered, true);

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -87,6 +87,7 @@ pub mod prelude {
     pub use super::localization::{Localized, ToStringLocalized, number_with_fraction, percentage};
     pub use super::modifiers::{
         AbilityModifiers, AccessibilityModifiers, ActionModifiers, ControlModifiers, ControlSize,
+        DragModifiers,
         LayoutModifiers, LinearGradientBuilder, ShadowBuilder, StyleModifiers, TextModifiers,
     };
     pub use super::resource::{ImageId, ImageRetentionPolicy};

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -87,8 +87,8 @@ pub mod prelude {
     pub use super::localization::{Localized, ToStringLocalized, number_with_fraction, percentage};
     pub use super::modifiers::{
         AbilityModifiers, AccessibilityModifiers, ActionModifiers, ControlModifiers, ControlSize,
-        DragModifiers,
-        LayoutModifiers, LinearGradientBuilder, ShadowBuilder, StyleModifiers, TextModifiers,
+        DragModifiers, LayoutModifiers, LinearGradientBuilder, ShadowBuilder, StyleModifiers,
+        TextModifiers,
     };
     pub use super::resource::{ImageId, ImageRetentionPolicy};
     pub use super::util::{CSS, IntoCssStr};

--- a/crates/vizia_core/src/modifiers/actions.rs
+++ b/crates/vizia_core/src/modifiers/actions.rs
@@ -77,8 +77,6 @@ pub(crate) struct ActionsModel {
     pub(crate) on_focus_in: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
     pub(crate) on_focus_out: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
     pub(crate) on_geo_changed: Option<Box<dyn Fn(&mut EventContext, GeoChanged) + Send + Sync>>,
-    pub(crate) on_drag_start: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
-    pub(crate) on_drop: Option<Box<dyn Fn(&mut EventContext, DropData) + Send + Sync>>,
 }
 
 impl ActionsModel {
@@ -97,8 +95,6 @@ impl ActionsModel {
             on_focus_in: None,
             on_focus_out: None,
             on_geo_changed: None,
-            on_drag_start: None,
-            on_drop: None,
         }
     }
 }
@@ -158,14 +154,6 @@ impl Model for ActionsModel {
                 self.on_geo_changed = Some(on_geo_changed);
                 cx.cache.set_bounds(cx.current, BoundingBox::default());
                 cx.needs_relayout();
-            }
-
-            ActionsEvent::OnDragStart(on_drag_start) => {
-                self.on_drag_start = Some(on_drag_start);
-            }
-
-            ActionsEvent::OnDrop(on_drop) => {
-                self.on_drop = Some(on_drop);
             }
         });
 
@@ -246,28 +234,12 @@ impl Model for ActionsModel {
                 if let Some(action) = &self.on_over_out {
                     (action)(cx);
                 }
-
-                if cx.mouse.left.state == MouseButtonState::Pressed
-                    && cx.mouse.left.pressed == cx.current()
-                    && cx.is_draggable()
-                {
-                    if let Some(action) = &self.on_drag_start {
-                        (action)(cx);
-                    }
-                }
                 // }
             }
 
             WindowEvent::MouseMove(x, y) => {
                 if let Some(action) = &self.on_mouse_move {
                     (action)(cx, *x, *y);
-                }
-                if cx.mouse.left.state == MouseButtonState::Released {
-                    if let Some(drop_data) = cx.drop_data.take() {
-                        if let Some(action) = &self.on_drop {
-                            (action)(cx, drop_data);
-                        }
-                    }
                 }
             }
 
@@ -280,11 +252,6 @@ impl Model for ActionsModel {
             WindowEvent::MouseUp(mouse_button) => {
                 if let Some(action) = &self.on_mouse_up {
                     (action)(cx, *mouse_button);
-                }
-                if let Some(drop_data) = cx.drop_data.take() {
-                    if let Some(action) = &self.on_drop {
-                        (action)(cx, drop_data);
-                    }
                 }
             }
 
@@ -327,8 +294,6 @@ pub(crate) enum ActionsEvent {
     OnFocusIn(Box<dyn Fn(&mut EventContext) + Send + Sync>),
     OnFocusOut(Box<dyn Fn(&mut EventContext) + Send + Sync>),
     OnGeoChanged(Box<dyn Fn(&mut EventContext, GeoChanged) + Send + Sync>),
-    OnDragStart(Box<dyn Fn(&mut EventContext) + Send + Sync>),
-    OnDrop(Box<dyn Fn(&mut EventContext, DropData) + Send + Sync>),
 }
 
 /// Modifiers which add an action callback to a view.
@@ -504,16 +469,6 @@ pub trait ActionModifiers<V> {
 
     /// Adds a popup menu to the view.
     fn menu<C: FnOnce(&mut Context) -> Handle<'_, T>, T: View>(self, content: C) -> Self;
-
-    /// Adds a callback which is performed when the view is dragged during a drag and drop operation.
-    fn on_drag<F>(self, action: F) -> Self
-    where
-        F: 'static + Fn(&mut EventContext) + Send + Sync;
-
-    /// Adds a callback which is performed when data is dropped on the view during a drag and drop operation.
-    fn on_drop<F>(self, action: F) -> Self
-    where
-        F: 'static + Fn(&mut EventContext, DropData) + Send + Sync;
 }
 
 // If the entity doesn't have an `ActionsModel` then add one to the entity
@@ -788,40 +743,6 @@ impl<V: View> ActionModifiers<V> for Handle<'_, V> {
 
         self.cx.emit_custom(
             Event::new(ActionsEvent::OnGeoChanged(Box::new(action)))
-                .target(self.entity)
-                .origin(self.entity),
-        );
-
-        self
-    }
-
-    fn on_drag<F>(self, action: F) -> Self
-    where
-        F: 'static + Fn(&mut EventContext) + Send + Sync,
-    {
-        build_action_model(self.cx, self.entity);
-
-        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
-            abilities.set(Abilities::DRAGGABLE, true);
-        }
-
-        self.cx.emit_custom(
-            Event::new(ActionsEvent::OnDragStart(Box::new(action)))
-                .target(self.entity)
-                .origin(self.entity),
-        );
-
-        self
-    }
-
-    fn on_drop<F>(self, action: F) -> Self
-    where
-        F: 'static + Fn(&mut EventContext, DropData) + Send + Sync,
-    {
-        build_action_model(self.cx, self.entity);
-
-        self.cx.emit_custom(
-            Event::new(ActionsEvent::OnDrop(Box::new(action)))
                 .target(self.entity)
                 .origin(self.entity),
         );

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -1,0 +1,310 @@
+use crate::prelude::*;
+use std::any::TypeId;
+
+pub(crate) struct DragModel {
+    pub(crate) on_drag_start: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
+    pub(crate) on_drag_enter: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
+    pub(crate) on_drag_leave: Option<Box<dyn Fn(&mut EventContext) + Send + Sync>>,
+    pub(crate) on_drag_move: Option<Box<dyn Fn(&mut EventContext, f32, f32) + Send + Sync>>,
+    pub(crate) on_drop: Option<Box<dyn Fn(&mut EventContext, DropData) + Send + Sync>>,
+    pub(crate) dragging: Signal<bool>,
+}
+
+impl DragModel {
+    pub(crate) fn new() -> Self {
+        Self {
+            on_drag_start: None,
+            on_drag_enter: None,
+            on_drag_leave: None,
+            on_drag_move: None,
+            on_drop: None,
+            dragging: Signal::new(false),
+        }
+    }
+}
+
+pub(crate) enum DragEvent {
+    OnDragStart(Box<dyn Fn(&mut EventContext) + Send + Sync>),
+    OnDragEnter(Box<dyn Fn(&mut EventContext) + Send + Sync>),
+    OnDragLeave(Box<dyn Fn(&mut EventContext) + Send + Sync>),
+    OnDragMove(Box<dyn Fn(&mut EventContext, f32, f32) + Send + Sync>),
+    OnDrop(Box<dyn Fn(&mut EventContext, DropData) + Send + Sync>),
+}
+
+fn reached_drag_distance_threshold(cx: &EventContext) -> bool {
+    let (press_x, press_y) = cx.mouse.left.pos_down;
+    let delta_x = cx.mouse.cursor_x - press_x;
+    let delta_y = cx.mouse.cursor_y - press_y;
+    let drag_distance = cx.environment().drag_distance.get() as f32;
+
+    delta_x * delta_x + delta_y * delta_y >= drag_distance * drag_distance
+}
+
+impl Model for DragModel {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.take(|drag_event, _| match drag_event {
+            DragEvent::OnDragStart(on_drag_start) => {
+                self.on_drag_start = Some(on_drag_start);
+            }
+
+            DragEvent::OnDragEnter(on_drag_enter) => {
+                self.on_drag_enter = Some(on_drag_enter);
+            }
+
+            DragEvent::OnDragLeave(on_drag_leave) => {
+                self.on_drag_leave = Some(on_drag_leave);
+            }
+
+            DragEvent::OnDragMove(on_drag_move) => {
+                self.on_drag_move = Some(on_drag_move);
+            }
+
+            DragEvent::OnDrop(on_drop) => {
+                self.on_drop = Some(on_drop);
+            }
+        });
+
+        event.map(|window_event, meta| match window_event {
+            WindowEvent::DragEnter => {
+                if meta.target == cx.current() {
+                    if let Some(action) = &self.on_drag_enter {
+                        (action)(cx);
+                    }
+                }
+            }
+
+            WindowEvent::DragLeave => {
+                if meta.target == cx.current() {
+                    if let Some(action) = &self.on_drag_leave {
+                        (action)(cx);
+                    }
+                }
+            }
+
+            WindowEvent::DragMove(x, y) => {
+                if let Some(action) = &self.on_drag_move {
+                    (action)(cx, *x, *y);
+                }
+            }
+
+            WindowEvent::MouseOut => {
+                if cx.mouse.left.state == MouseButtonState::Pressed
+                    && cx.mouse.left.pressed == cx.current()
+                    && cx.is_draggable()
+                    && reached_drag_distance_threshold(cx)
+                    && !cx.has_drop_data()
+                {
+                    if let Some(action) = &self.on_drag_start {
+                        (action)(cx);
+                    }
+
+                    if cx.has_drop_data() {
+                        cx.capture();
+
+                        self.dragging.set(true);
+                    }
+                }
+            }
+
+            WindowEvent::MouseMove(_, _) => {
+                if cx.mouse.left.state == MouseButtonState::Pressed
+                    && cx.mouse.left.pressed == cx.current()
+                    && cx.is_draggable()
+                    && reached_drag_distance_threshold(cx)
+                    && !cx.has_drop_data()
+                {
+                    if let Some(action) = &self.on_drag_start {
+                        (action)(cx);
+                    }
+
+                    if cx.has_drop_data() {
+                        cx.capture();
+
+                        self.dragging.set(true);
+                    }
+                }
+
+                if cx.mouse.left.state == MouseButtonState::Released {
+                    if let Some(action) = &self.on_drop {
+                        if let Some(drop_data) = cx.drop_data.take() {
+                            (action)(cx, drop_data);
+                        }
+                    }
+                    self.dragging.set(false);
+                }
+            }
+
+            WindowEvent::MouseUp(_) => {
+                self.dragging.set(false);
+                if let Some(action) = &self.on_drop {
+                    if let Some(drop_data) = cx.drop_data.take() {
+                        (action)(cx, drop_data);
+                    }
+                }
+            }
+
+            _ => {}
+        });
+    }
+}
+
+fn build_drag_model(cx: &mut Context, entity: Entity) {
+    if cx.models.get(&entity).and_then(|models| models.get(&TypeId::of::<DragModel>())).is_none() {
+        cx.with_current(entity, |cx| {
+            DragModel::new().build(cx);
+        });
+    }
+}
+
+/// Modifiers which add drag-and-drop callbacks to a view.
+pub trait DragModifiers<V> {
+    /// Adds a callback which is performed when the view begins to be dragged.
+    ///
+    /// The callback should call [`set_drop_data`](EventContext::set_drop_data) to supply the data
+    /// that will be delivered to the drop target.
+    fn on_drag<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync;
+
+    /// Adds a callback which is performed when the cursor enters this view while carrying drag data.
+    fn on_drag_enter<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync;
+
+    /// Adds a callback which is performed when the cursor leaves this view while carrying drag data.
+    fn on_drag_leave<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync;
+
+    /// Adds a callback which is performed when the cursor moves over this view while carrying drag data.
+    fn on_drag_move<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext, f32, f32) + Send + Sync;
+
+    /// Adds a callback which is performed when data is dropped on the view during a drag-and-drop operation.
+    fn on_drop<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext, DropData) + Send + Sync;
+
+    /// Adds a view that is rendered under the mouse cursor while this view is being dragged.
+    fn on_drag_view<C: Fn(&mut Context) -> Handle<'_, T> + 'static, T: View>(
+        self,
+        content: C,
+    ) -> Self;
+}
+
+impl<V: View> DragModifiers<V> for Handle<'_, V> {
+    fn on_drag<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync,
+    {
+        build_drag_model(self.cx, self.entity);
+
+        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
+            abilities.set(Abilities::DRAGGABLE, true);
+        }
+
+        self.cx.emit_custom(
+            Event::new(DragEvent::OnDragStart(Box::new(action)))
+                .target(self.entity)
+                .origin(self.entity),
+        );
+
+        self
+    }
+
+    fn on_drag_enter<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync,
+    {
+        build_drag_model(self.cx, self.entity);
+
+        self.cx.emit_custom(
+            Event::new(DragEvent::OnDragEnter(Box::new(action)))
+                .target(self.entity)
+                .origin(self.entity),
+        );
+
+        self
+    }
+
+    fn on_drag_leave<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext) + Send + Sync,
+    {
+        build_drag_model(self.cx, self.entity);
+
+        self.cx.emit_custom(
+            Event::new(DragEvent::OnDragLeave(Box::new(action)))
+                .target(self.entity)
+                .origin(self.entity),
+        );
+
+        self
+    }
+
+    fn on_drag_move<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext, f32, f32) + Send + Sync,
+    {
+        build_drag_model(self.cx, self.entity);
+
+        self.cx.emit_custom(
+            Event::new(DragEvent::OnDragMove(Box::new(action)))
+                .target(self.entity)
+                .origin(self.entity),
+        );
+
+        self
+    }
+
+    fn on_drop<F>(self, action: F) -> Self
+    where
+        F: 'static + Fn(&mut EventContext, DropData) + Send + Sync,
+    {
+        build_drag_model(self.cx, self.entity);
+
+        self.cx.emit_custom(
+            Event::new(DragEvent::OnDrop(Box::new(action))).target(self.entity).origin(self.entity),
+        );
+
+        self
+    }
+
+    fn on_drag_view<C: Fn(&mut Context) -> Handle<'_, T> + 'static, T: View>(
+        self,
+        content: C,
+    ) -> Self {
+        build_drag_model(self.cx, self.entity);
+
+        if let Some(abilities) = self.cx.style.abilities.get_mut(self.entity) {
+            abilities.set(Abilities::DRAGGABLE, true);
+        }
+
+        let source_entity = self.entity;
+
+        self.cx.with_current(source_entity, move |cx| {
+            let is_dragging = cx.data::<DragModel>().dragging;
+            Binding::new(cx, is_dragging, move |cx| {
+                if is_dragging.get() {
+                    let window_entity = cx.parent_window();
+                    let drag_entity = cx.with_current(window_entity, |cx| {
+                        (content)(cx)
+                            .position_type(PositionType::Absolute)
+                            .left(Pixels(0.0))
+                            .top(Pixels(0.0))
+                            .display(Display::None)
+                            .pointer_events(PointerEvents::None)
+                            .z_index(10_000)
+                            .entity()
+                    });
+
+                    let mut ex = EventContext::new(cx);
+                    ex.set_active_drag_view(Some(drag_entity));
+                }
+            });
+        });
+
+        self
+    }
+}

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -64,20 +64,16 @@ impl Model for DragModel {
             }
         });
 
-        event.map(|window_event, meta| match window_event {
+        event.map(|window_event, _meta| match window_event {
             WindowEvent::DragEnter => {
-                if meta.target == cx.current() {
-                    if let Some(action) = &self.on_drag_enter {
-                        (action)(cx);
-                    }
+                if let Some(action) = &self.on_drag_enter {
+                    (action)(cx);
                 }
             }
 
             WindowEvent::DragLeave => {
-                if meta.target == cx.current() {
-                    if let Some(action) = &self.on_drag_leave {
-                        (action)(cx);
-                    }
+                if let Some(action) = &self.on_drag_leave {
+                    (action)(cx);
                 }
             }
 
@@ -126,7 +122,7 @@ impl Model for DragModel {
 
                 if cx.mouse.left.state == MouseButtonState::Released {
                     if let Some(action) = &self.on_drop {
-                        if let Some(drop_data) = cx.drop_data.take() {
+                        if let Some(drop_data) = cx.drop_data.clone() {
                             (action)(cx, drop_data);
                         }
                     }
@@ -137,7 +133,7 @@ impl Model for DragModel {
             WindowEvent::MouseUp(_) => {
                 self.dragging.set(false);
                 if let Some(action) = &self.on_drop {
-                    if let Some(drop_data) = cx.drop_data.take() {
+                    if let Some(drop_data) = cx.drop_data.clone() {
                         (action)(cx, drop_data);
                     }
                 }

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -65,6 +65,12 @@ impl Model for DragModel {
         });
 
         event.map(|window_event, _meta| match window_event {
+            WindowEvent::Drop(drop_data) => {
+                if let Some(action) = &self.on_drop {
+                    (action)(cx, drop_data.clone());
+                }
+            }
+
             WindowEvent::DragEnter => {
                 if let Some(action) = &self.on_drag_enter {
                     (action)(cx);
@@ -121,22 +127,12 @@ impl Model for DragModel {
                 }
 
                 if cx.mouse.left.state == MouseButtonState::Released {
-                    if let Some(action) = &self.on_drop {
-                        if let Some(drop_data) = cx.drop_data.clone() {
-                            (action)(cx, drop_data);
-                        }
-                    }
                     self.dragging.set(false);
                 }
             }
 
             WindowEvent::MouseUp(_) => {
                 self.dragging.set(false);
-                if let Some(action) = &self.on_drop {
-                    if let Some(drop_data) = cx.drop_data.clone() {
-                        (action)(cx, drop_data);
-                    }
-                }
             }
 
             _ => {}

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -119,7 +119,10 @@ impl Model for DragModel {
                 }
             }
 
-            WindowEvent::MouseUp(_) => {
+            WindowEvent::MouseUp(MouseButton::Left) => {
+                // Dragging is initiated via the left button, so only left-button
+                // release should end the drag and release capture.
+                cx.release();
                 self.dragging.set(false);
             }
 

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -21,6 +21,24 @@ impl DragModel {
             dragging: Signal::new(false),
         }
     }
+
+    fn try_start_drag(&mut self, cx: &mut EventContext) {
+        if cx.mouse.left.state == MouseButtonState::Pressed
+            && cx.mouse.left.pressed == cx.current()
+            && cx.is_draggable()
+            && reached_drag_distance_threshold(cx)
+            && !cx.has_drop_data()
+        {
+            if let Some(action) = &self.on_drag_start {
+                (action)(cx);
+            }
+
+            if cx.has_drop_data() {
+                cx.capture();
+                self.dragging.set(true);
+            }
+        }
+    }
 }
 
 pub(crate) enum DragEvent {
@@ -90,41 +108,11 @@ impl Model for DragModel {
             }
 
             WindowEvent::MouseOut => {
-                if cx.mouse.left.state == MouseButtonState::Pressed
-                    && cx.mouse.left.pressed == cx.current()
-                    && cx.is_draggable()
-                    && reached_drag_distance_threshold(cx)
-                    && !cx.has_drop_data()
-                {
-                    if let Some(action) = &self.on_drag_start {
-                        (action)(cx);
-                    }
-
-                    if cx.has_drop_data() {
-                        cx.capture();
-
-                        self.dragging.set(true);
-                    }
-                }
+                self.try_start_drag(cx);
             }
 
             WindowEvent::MouseMove(_, _) => {
-                if cx.mouse.left.state == MouseButtonState::Pressed
-                    && cx.mouse.left.pressed == cx.current()
-                    && cx.is_draggable()
-                    && reached_drag_distance_threshold(cx)
-                    && !cx.has_drop_data()
-                {
-                    if let Some(action) = &self.on_drag_start {
-                        (action)(cx);
-                    }
-
-                    if cx.has_drop_data() {
-                        cx.capture();
-
-                        self.dragging.set(true);
-                    }
-                }
+                self.try_start_drag(cx);
 
                 if cx.mouse.left.state == MouseButtonState::Released {
                     self.dragging.set(false);

--- a/crates/vizia_core/src/modifiers/drag.rs
+++ b/crates/vizia_core/src/modifiers/drag.rs
@@ -281,8 +281,14 @@ impl<V: View> DragModifiers<V> for Handle<'_, V> {
 
         self.cx.with_current(source_entity, move |cx| {
             let is_dragging = cx.data::<DragModel>().dragging;
+            let preview_entity: Signal<Option<Entity>> = Signal::new(None);
             Binding::new(cx, is_dragging, move |cx| {
                 if is_dragging.get() {
+                    // Remove any leftover preview entity from a previous drag.
+                    if let Some(prev) = preview_entity.get() {
+                        cx.remove(prev);
+                    }
+
                     let window_entity = cx.parent_window();
                     let drag_entity = cx.with_current(window_entity, |cx| {
                         (content)(cx)
@@ -295,8 +301,19 @@ impl<V: View> DragModifiers<V> for Handle<'_, V> {
                             .entity()
                     });
 
+                    preview_entity.set(Some(drag_entity));
+
                     let mut ex = EventContext::new(cx);
                     ex.set_active_drag_view(Some(drag_entity));
+                } else {
+                    // Drag ended — remove the preview entity and clear the active drag view.
+                    if let Some(entity) = preview_entity.get() {
+                        cx.remove(entity);
+                        preview_entity.set(None);
+                    }
+
+                    let mut ex = EventContext::new(cx);
+                    ex.set_active_drag_view(None);
                 }
             });
         });

--- a/crates/vizia_core/src/modifiers/mod.rs
+++ b/crates/vizia_core/src/modifiers/mod.rs
@@ -91,6 +91,9 @@ pub use accessibility::*;
 mod actions;
 pub use actions::*;
 
+mod drag;
+pub use drag::*;
+
 mod layout;
 pub use layout::*;
 

--- a/crates/vizia_core/src/window/window_event.rs
+++ b/crates/vizia_core/src/window/window_event.rs
@@ -66,6 +66,12 @@ pub enum WindowEvent {
     MouseEnter,
     /// Emitted when the mouse cursor leaves an entity.
     MouseLeave,
+    /// Emitted when drag data enters the hovered entity.
+    DragEnter,
+    /// Emitted when drag data leaves the previously hovered entity.
+    DragLeave,
+    /// Emitted when drag data moves over the currently hovered entity.
+    DragMove(f32, f32),
     /// Emitted when an entity gains keyboard focus.
     FocusIn,
     /// Emitted when an entity loses keyboard focus.

--- a/crates/vizia_core/src/window/window_event.rs
+++ b/crates/vizia_core/src/window/window_event.rs
@@ -1,17 +1,44 @@
-use std::path::PathBuf;
+use std::{any::Any, fmt, path::PathBuf, sync::Arc};
 
 use crate::{entity::Entity, environment::ThemeMode, layout::cache::GeoChanged};
 use vizia_input::{Code, Key, MouseButton};
 use vizia_style::CursorIcon;
 use vizia_window::{WindowPosition, WindowSize};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 /// Data associated with a drop event.
 pub enum DropData {
     /// Path to a dropped file.
     File(PathBuf),
     ///  Entity ID of a dropped entity.
     Id(Entity),
+    /// Arbitrary user payload for app-defined drag/drop operations.
+    Any(Arc<dyn Any + Send + Sync>),
+}
+
+impl fmt::Debug for DropData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DropData::File(path) => f.debug_tuple("File").field(path).finish(),
+            DropData::Id(entity) => f.debug_tuple("Id").field(entity).finish(),
+            DropData::Any(_) => f.debug_tuple("Any").field(&"<opaque>").finish(),
+        }
+    }
+}
+
+impl DropData {
+    /// Creates a drop payload from arbitrary application-defined data.
+    pub fn any<T: Any + Send + Sync>(value: T) -> Self {
+        Self::Any(Arc::new(value))
+    }
+
+    /// Attempts to downcast arbitrary drop payload data by reference.
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        match self {
+            DropData::Any(value) => value.downcast_ref::<T>(),
+            _ => None,
+        }
+    }
 }
 
 impl From<Entity> for DropData {
@@ -23,6 +50,12 @@ impl From<Entity> for DropData {
 impl From<PathBuf> for DropData {
     fn from(value: PathBuf) -> Self {
         DropData::File(value)
+    }
+}
+
+impl From<Arc<dyn Any + Send + Sync>> for DropData {
+    fn from(value: Arc<dyn Any + Send + Sync>) -> Self {
+        DropData::Any(value)
     }
 }
 

--- a/examples/dragdrop.rs
+++ b/examples/dragdrop.rs
@@ -4,24 +4,92 @@ const STYLE: &str = r#"
     :root {
         alignment: center;
     }
+
+    .drop-zone {
+        border-width: 2px;
+        border-color: transparent;
+    }
+
+    .drop-zone.drag-over {
+        border-color: white;
+        cursor: copy;
+    }
+
+    .drag-preview {
+        size: 28px;
+        border-radius: 6px;
+        border-width: 1px;
+        border-color: #ffffff66;
+        background-color: #ffffff22;
+        backdrop-filter: blur(2px);
+    }
 "#;
+
+#[derive(Clone, Copy)]
+struct AppData {
+    drop_zone_color: Signal<Color>,
+}
+
+enum AppEvent {
+    SetDropZoneColor(Color),
+}
+
+impl Model for AppData {
+    fn event(&mut self, _cx: &mut EventContext, event: &mut Event) {
+        event.map(|app_event, _| match app_event {
+            AppEvent::SetDropZoneColor(color) => {
+                self.drop_zone_color.set(*color);
+            }
+        });
+    }
+}
 
 fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         cx.add_stylesheet(STYLE).expect("Failed to add stylesheet");
 
+        let drop_zone_color = Signal::new(Color::gray());
+        AppData { drop_zone_color }.build(cx);
+
         HStack::new(cx, |cx| {
-            Element::new(cx).size(Pixels(50.0)).background_color(Color::red()).on_drag(|ex| {
-                ex.set_drop_data(ex.current());
-            });
+            Element::new(cx)
+                .size(Pixels(50.0))
+                .background_color(Color::red())
+                .on_drag(|ex| {
+                    ex.set_drop_data(ex.current());
+                })
+                .on_drag_view(|cx| {
+                    Element::new(cx)
+                        .class("drag-preview")
+                        .size(Pixels(50.0))
+                        .background_color(Color::red())
+                });
 
-            Element::new(cx).size(Pixels(50.0)).background_color(Color::green()).on_drag(|ex| {
-                ex.set_drop_data(ex.current());
-            });
+            Element::new(cx)
+                .size(Pixels(50.0))
+                .background_color(Color::green())
+                .on_drag(|ex| {
+                    ex.set_drop_data(ex.current());
+                })
+                .on_drag_view(|cx| {
+                    Element::new(cx)
+                        .class("drag-preview")
+                        .size(Pixels(50.0))
+                        .background_color(Color::green())
+                });
 
-            Element::new(cx).size(Pixels(50.0)).background_color(Color::blue()).on_drag(|ex| {
-                ex.set_drop_data(ex.current());
-            });
+            Element::new(cx)
+                .size(Pixels(50.0))
+                .background_color(Color::blue())
+                .on_drag(|ex| {
+                    ex.set_drop_data(ex.current());
+                })
+                .on_drag_view(|cx| {
+                    Element::new(cx)
+                        .class("drag-preview")
+                        .size(Pixels(50.0))
+                        .background_color(Color::blue())
+                });
         })
         .height(Pixels(100.0))
         .width(Auto)
@@ -30,22 +98,27 @@ fn main() -> Result<(), ApplicationError> {
 
         Element::new(cx)
             .size(Pixels(100.0))
-            .background_color(Color::gray())
+            .background_color(drop_zone_color)
+            .class("drop-zone")
+            .on_drag_enter(|ex| {
+                println!("Drag entered drop zone");
+                ex.toggle_class("drag-over", true);
+            })
+            .on_drag_leave(|ex| {
+                println!("Drag left drop zone");
+                ex.toggle_class("drag-over", false);
+            })
+            .on_drag_move(|_ex, x, y| {
+                println!("Drag move over drop zone: ({x}, {y})");
+            })
             .on_drop(|ex, data| {
+                ex.toggle_class("drag-over", false);
                 if let DropData::Id(id) = data {
                     let bg = ex.with_current(id, |ex| ex.background_color());
-                    ex.set_background_color(bg);
-                    ex.emit(WindowEvent::SetCursor(CursorIcon::Default));
+                    ex.emit(AppEvent::SetDropZoneColor(bg));
                 }
                 if let DropData::File(file) = data {
                     println!("Dropped File: {:?}", file);
-                }
-            })
-            .on_hover(|ex| {
-                if ex.has_drop_data() {
-                    ex.emit(WindowEvent::SetCursor(CursorIcon::Copy));
-                } else {
-                    ex.emit(WindowEvent::SetCursor(CursorIcon::Default));
                 }
             });
     })


### PR DESCRIPTION
Introduce a drag-and-drop system: add a new DragModel and DragModifiers (crates/vizia_core/src/modifiers/drag.rs) and export DragModifiers in modifiers mod. Extend WindowEvent with DragEnter/DragLeave/DragMove and add Context fields (active_drag_view, drag_hovered) plus EventContext accessors for drop_data and active drag view. Add environment drag_distance signal and event to configure when dragging starts. Update the event manager to dispatch drag events, manage a drag preview view (position/hide), and adjust mouse handling during drag operations. Remove deprecated drag/drop callbacks from ActionsModel and update the dragdrop example to demonstrate previews and enter/leave/move handlers.