### PR TITLE
Add Wayland clipboard support and provider selection

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -25,8 +25,22 @@ use std::{
 use vizia_id::IdManager;
 use vizia_window::WindowDescription;
 
+#[cfg(all(
+    feature = "clipboard",
+    not(all(
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "wayland",
+    ))
+))]
+use copypasta::ClipboardContext;
 #[cfg(feature = "clipboard")]
-use copypasta::{ClipboardContext, ClipboardProvider, nop_clipboard::NopClipboardContext};
+use copypasta::{ClipboardProvider, nop_clipboard::NopClipboardContext};
 use hashbrown::{HashMap, HashSet, hash_map::Entry};
 
 pub use access::*;
@@ -65,6 +79,41 @@ static NEXT_CONTEXT_ID: AtomicU64 = AtomicU64::new(1);
 pub(crate) struct SignalRebuild {
     pub(crate) context_id: u64,
     pub(crate) entity: Entity,
+}
+
+#[cfg(feature = "clipboard")]
+fn default_clipboard_provider() -> Box<dyn ClipboardProvider> {
+    #[cfg(all(
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "wayland"
+    ))]
+    {
+        Box::new(NopClipboardContext::new().unwrap())
+    }
+
+    #[cfg(not(all(
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        ),
+        feature = "wayland",
+    )))]
+    {
+        if let Ok(context) = ClipboardContext::new() {
+            Box::new(context)
+        } else {
+            Box::new(NopClipboardContext::new().unwrap())
+        }
+    }
 }
 
 thread_local! {
@@ -209,13 +258,7 @@ impl Context {
             event_proxy: None,
 
             #[cfg(feature = "clipboard")]
-            clipboard: {
-                if let Ok(context) = ClipboardContext::new() {
-                    Box::new(context)
-                } else {
-                    Box::new(NopClipboardContext::new().unwrap())
-                }
-            },
+            clipboard: default_clipboard_provider(),
             click_time: Instant::now(),
             clicks: 0,
             click_pos: (0.0, 0.0),

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -7,6 +7,18 @@ use crate::{
 };
 #[cfg(feature = "accesskit")]
 use accesskit_winit::Adapter;
+#[cfg(all(
+    feature = "clipboard",
+    feature = "wayland",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )
+))]
+use copypasta::wayland_clipboard::create_clipboards_from_external;
 use hashbrown::HashMap;
 use log::warn;
 use std::{error::Error, fmt::Display, sync::Arc};
@@ -30,6 +42,19 @@ use winit::{
     keyboard::{NativeKeyCode, PhysicalKey},
     window::{CursorIcon, CustomCursor, WindowAttributes, WindowId, WindowLevel},
 };
+
+#[cfg(all(
+    feature = "clipboard",
+    feature = "wayland",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )
+))]
+use winit::raw_window_handle::{HasDisplayHandle, RawDisplayHandle};
 
 // #[cfg(all(
 //     feature = "clipboard",
@@ -295,6 +320,31 @@ impl Application {
         Ok(window)
     }
 
+    #[cfg(all(
+        feature = "clipboard",
+        feature = "wayland",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
+    ))]
+    fn init_wayland_clipboard(&mut self, window: &winit::window::Window) {
+        let Ok(display_handle) = window.display_handle() else {
+            return;
+        };
+
+        if let RawDisplayHandle::Wayland(handle) = display_handle.as_raw() {
+            // SAFETY: The display handle comes from a live winit window and remains valid for
+            // at least as long as the window/application lifetime where the provider is used.
+            let (_, clipboard) =
+                unsafe { create_clipboards_from_external(handle.display.as_ptr()) };
+            self.cx.set_clipboard_provider(Box::new(clipboard));
+        }
+    }
+
     /// Sets the default built-in theming to be ignored.
     pub fn ignore_default_theme(mut self) -> Self {
         self.cx.context().ignore_default_theme = true;
@@ -393,6 +443,20 @@ impl ApplicationHandler<UserEvent> for Application {
             let main_window: Arc<winit::window::Window> = self
                 .create_window(event_loop, Entity::root(), &self.window_description.clone(), None)
                 .expect("failed to create initial window");
+
+            #[cfg(all(
+                feature = "clipboard",
+                feature = "wayland",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd"
+                )
+            ))]
+            self.init_wayland_clipboard(&main_window);
+
             let custom_cursors = Arc::new(load_default_cursors(event_loop));
             self.cx.add_main_window(
                 Entity::root(),


### PR DESCRIPTION
Introduce a platform-aware clipboard provider selection and Wayland initialization. Adds default_clipboard_provider() in vizia_core to choose a real ClipboardContext when available or fall back to NopClipboardContext; adjusts copypasta imports with cfgs. In vizia_winit, import copypasta's Wayland helper and winit raw display types under appropriate cfgs, add init_wayland_clipboard() to create clipboards from the window's Wayland display handle, and call it after creating the main window. These changes enable using an external Wayland clipboard when running on Wayland-only targets (with the clipboard feature) and ensure a safe fallback to a no-op clipboard when necessary.