### PR TITLE
Improve textbox focus, clipping, and styling + validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,6 +265,10 @@ name = "textbox"
 path = "examples/views/textbox.rs"
 
 [[example]]
+name = "login"
+path = "examples/views/login.rs"
+
+[[example]]
 name = "list"
 path = "examples/views/list.rs"
 

--- a/crates/vizia_core/resources/themes/default_layout.css
+++ b/crates/vizia_core/resources/themes/default_layout.css
@@ -922,7 +922,6 @@ tabbar scrollbar.horizontal {
 /* TEXTBOX */
 
 textbox {
-    overflow: hidden;
     width: auto;
     height: 32px;
     padding-left: 8px;

--- a/crates/vizia_core/resources/themes/default_theme.css
+++ b/crates/vizia_core/resources/themes/default_theme.css
@@ -1055,9 +1055,19 @@ textbox:disabled {
 }
 
 textbox:invalid {
-    border-color: var(--error);
-    transition: border-color 100ms;
-    border-width: 2px;
+    border-color: var(--destructive);
+    outline-width: 2px;
+    outline-color: var(--destructive);
+    outline-offset: 0px;
+    transition:
+        border-color 100ms,
+        outline-color 100ms;
+}
+
+textbox:invalid:focus-visible {
+    outline-width: 3px;
+    outline-color: var(--destructive);
+    outline-offset: 0px;
 }
 
 /* TOGGLE BUTTON */

--- a/crates/vizia_core/resources/themes/default_theme.css
+++ b/crates/vizia_core/resources/themes/default_theme.css
@@ -1030,8 +1030,10 @@ textbox {
     transition: background-color 100ms;
 }
 
-textbox:focus {
-    border-color: var(--ring);
+textbox:focus-visible {
+    outline-width: 3px;
+    outline-color: var(--ring);
+    outline-offset: 0px;
 }
 
 textbox:focus.caret {

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -9,7 +9,7 @@ use crate::text::{
 };
 use accesskit::{ActionData, ActionRequest, TextDirection, TextPosition, TextSelection};
 use skia_safe::textlayout::{RectHeightStyle, RectWidthStyle};
-use skia_safe::{Paint, PaintStyle, Rect};
+use skia_safe::{ClipOp, Paint, PaintStyle, Rect};
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Events for modifying a textbox.
@@ -1257,7 +1257,7 @@ where
 
                 if cx.is_over() {
                     if !cx.is_disabled() {
-                        cx.focus_with_visibility(false);
+                        cx.focus_with_visibility(true);
                         cx.capture();
                         cx.lock_cursor_icon();
 
@@ -1662,7 +1662,7 @@ where
             TextEvent::StartEdit => {
                 if !cx.is_disabled() && !self.edit {
                     self.edit = true;
-                    cx.focus_with_visibility(false);
+                    cx.focus_with_visibility(true);
                     cx.capture();
                     self.reset_caret_timer(cx);
                     self.reset_ime_position(cx);
@@ -1736,6 +1736,13 @@ where
             }
 
             TextEvent::Blur => {
+                // Clicking outside a textbox can end editing while retaining keyboard focus
+                // (for example when clicking non-focusable chrome). Keep focus but remove
+                // the visible focus indicator for pointer-driven blur.
+                if cx.focused() == cx.current() {
+                    cx.focus_with_visibility(false);
+                }
+
                 if let Some(callback) = &self.on_blur {
                     (callback)(cx);
                 } else {
@@ -1868,7 +1875,41 @@ where
         cx.draw_background(canvas);
         cx.draw_border(canvas);
         cx.draw_outline(canvas);
+
+        // Clip only the text content to the textbox shape so long text is contained
+        // without clipping outside effects such as outlines.
         canvas.save();
+        let path = cx.path();
+        canvas.clip_path(&path, ClipOp::Intersect, true);
+
+        let bounds = cx.bounds();
+        let padding_left = match cx.padding_left() {
+            Units::Pixels(val) => val,
+            _ => 0.0,
+        };
+        let padding_right = match cx.padding_right() {
+            Units::Pixels(val) => val,
+            _ => 0.0,
+        };
+        let padding_top = match cx.padding_top() {
+            Units::Pixels(val) => val,
+            _ => 0.0,
+        };
+        let padding_bottom = match cx.padding_bottom() {
+            Units::Pixels(val) => val,
+            _ => 0.0,
+        };
+
+        let content_left = bounds.x + padding_left;
+        let content_top = bounds.y + padding_top;
+        let content_right = (bounds.x + bounds.w - padding_right).max(content_left);
+        let content_bottom = (bounds.y + bounds.h - padding_bottom).max(content_top);
+        canvas.clip_rect(
+            Rect::new(content_left, content_top, content_right, content_bottom),
+            ClipOp::Intersect,
+            true,
+        );
+
         let transform = *self.transform.borrow();
         canvas.translate((transform.0, transform.1));
         cx.draw_text(canvas);

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -90,6 +90,8 @@ pub struct Textbox<R, T> {
     selection: Selection,
     preedit_backup: Option<PreeditBackup>,
     text_overflow: Option<TextOverflow>,
+    edited_since_focus: bool,
+    edited_once: bool,
 }
 
 // Determines whether the enter key submits the text or inserts a new line.
@@ -201,6 +203,8 @@ where
             selection: Selection::new(0, 0),
             preedit_backup: None,
             text_overflow: None,
+            edited_since_focus: false,
+            edited_once: false,
         }
         .build(cx, move |cx| {
             cx.add_listener(move |textbox: &mut Self, cx, event| {
@@ -742,6 +746,14 @@ where
         }
 
         self.real_text.clone()
+    }
+
+    fn is_text_valid(&self, text: &str) -> bool {
+        if let Ok(value) = text.parse::<T>() {
+            if let Some(validate) = &self.validate { validate(&value) } else { true }
+        } else {
+            false
+        }
     }
 
     fn reset_caret_timer(&mut self, cx: &mut EventContext) {
@@ -1586,6 +1598,9 @@ where
                     return;
                 }
 
+                self.edited_since_focus = true;
+                self.edited_once = true;
+
                 if self.show_placeholder.get() {
                     self.reset_text(cx);
                 }
@@ -1594,15 +1609,7 @@ where
 
                 let text = self.clone_text(cx);
 
-                if let Ok(value) = &text.parse::<T>() {
-                    if let Some(validate) = &self.validate {
-                        cx.set_valid(validate(value));
-                    } else {
-                        cx.set_valid(true);
-                    }
-                } else {
-                    cx.set_valid(false);
-                }
+                cx.set_valid(self.is_text_valid(&text));
 
                 if self.edit {
                     if let Some(callback) = &self.on_edit {
@@ -1628,19 +1635,13 @@ where
 
             TextEvent::DeleteText(movement) => {
                 if self.edit {
+                    self.edited_since_focus = true;
+                    self.edited_once = true;
                     self.delete_text(cx, *movement);
 
                     let text = self.clone_text(cx);
 
-                    if let Ok(value) = &text.parse::<T>() {
-                        if let Some(validate) = &self.validate {
-                            cx.set_valid(validate(value));
-                        } else {
-                            cx.set_valid(true);
-                        }
-                    } else {
-                        cx.set_valid(false);
-                    }
+                    cx.set_valid(self.is_text_valid(&text));
 
                     if let Some(callback) = &self.on_edit {
                         (callback)(cx, text);
@@ -1662,6 +1663,7 @@ where
             TextEvent::StartEdit => {
                 if !cx.is_disabled() && !self.edit {
                     self.edit = true;
+                    self.edited_since_focus = false;
                     cx.focus_with_visibility(true);
                     cx.capture();
                     self.reset_caret_timer(cx);
@@ -1683,14 +1685,12 @@ where
                         self.select_all(cx);
                     }
 
-                    if let Ok(value) = &text.parse::<T>() {
-                        if let Some(validate) = &self.validate {
-                            cx.set_valid(validate(value));
-                        } else {
-                            cx.set_valid(true);
-                        }
+                    // Keep textbox pristine only until first user edit; once edited,
+                    // preserve validation across blur/focus cycles.
+                    if self.edited_once || !text.is_empty() {
+                        cx.set_valid(self.is_text_valid(&text));
                     } else {
-                        cx.set_valid(false);
+                        cx.set_valid(true);
                     }
                 }
 
@@ -1714,14 +1714,8 @@ where
 
                 self.select_all(cx);
 
-                if let Ok(value) = &text.parse::<T>() {
-                    if let Some(validate) = &self.validate {
-                        cx.set_valid(validate(value));
-                    } else {
-                        cx.set_valid(true);
-                    }
-                } else {
-                    cx.set_valid(false);
+                if self.edited_since_focus {
+                    cx.set_valid(self.is_text_valid(&text));
                 }
 
                 // Reset transform to 0,0
@@ -1773,11 +1767,11 @@ where
 
             TextEvent::Submit(reason) => {
                 if let Some(callback) = &self.on_submit {
-                    if cx.is_valid() {
-                        let text = self.clone_text(cx);
-                        if let Ok(value) = text.parse::<T>() {
-                            (callback)(cx, value, *reason);
-                        }
+                    let text = self.clone_text(cx);
+                    let is_valid = self.is_text_valid(&text);
+                    cx.set_valid(is_valid);
+                    if is_valid && let Ok(value) = text.parse::<T>() {
+                        (callback)(cx, value, *reason);
                     }
                 }
             }
@@ -1839,21 +1833,15 @@ where
                 if self.edit {
                     if let Some(selected_text) = self.clone_selected(cx) {
                         if !selected_text.is_empty() {
+                            self.edited_since_focus = true;
+                            self.edited_once = true;
                             cx.set_clipboard(selected_text)
                                 .expect("Failed to add text to clipboard");
                             self.delete_text(cx, Movement::Grapheme(Direction::Upstream));
 
                             let text = self.clone_text(cx);
 
-                            if let Ok(value) = &text.parse::<T>() {
-                                if let Some(validate) = &self.validate {
-                                    cx.set_valid(validate(value));
-                                } else {
-                                    cx.set_valid(true);
-                                }
-                            } else {
-                                cx.set_valid(false);
-                            }
+                            cx.set_valid(self.is_text_valid(&text));
 
                             if let Some(callback) = &self.on_edit {
                                 (callback)(cx, text);

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -1085,6 +1085,37 @@ where
         })
     }
 
+    /// Sets whether masked text should be visible.
+    pub fn mask_visible<U: Into<bool> + Clone + 'static>(
+        self,
+        visible: impl Res<U> + 'static,
+    ) -> Self {
+        let visible = visible.to_signal(self.cx);
+        self.bind(visible, move |mut handle| {
+            let entity = handle.entity();
+            let new_visible = visible.get().into();
+            let mut display_text = String::new();
+            let mut changed = false;
+
+            handle = handle.modify(|textbox| {
+                if textbox.mask_visible != new_visible {
+                    let old_display = textbox.display_text_from_real();
+                    textbox.mask_visible = new_visible;
+                    let new_display = textbox.display_text_from_real();
+                    textbox.remap_selection_for_display_change(&old_display, &new_display);
+                    display_text = new_display;
+                    changed = true;
+                }
+            });
+
+            if changed {
+                handle = handle.text(display_text);
+                handle.context().style.needs_text_update(entity);
+                handle.context().needs_redraw(entity);
+            }
+        })
+    }
+
     /// Sets an optional maximum number of graphemes for textbox input.
     ///
     /// Use `Some(n)` to limit input length and `None` to remove the limit.

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -427,7 +427,8 @@ where
                 text.insert_str(start, &clamped_preedit);
 
                 if let Some((cursor_index, _)) = cursor {
-                    let new_caret = original_selection.min() + cursor_index.min(clamped_preedit.len());
+                    let new_caret =
+                        original_selection.min() + cursor_index.min(clamped_preedit.len());
                     new_caret_grapheme = Self::byte_to_grapheme_index(text, new_caret);
                 } else {
                     // If there is no valid cursor, the default behavior is to move to the end of the text.
@@ -435,10 +436,7 @@ where
                     new_caret_grapheme = Self::byte_to_grapheme_index(text, new_caret);
                 }
 
-                self.preedit_backup
-                    .as_mut()
-                    .unwrap()
-                    .set_prev_preedit(clamped_preedit);
+                self.preedit_backup.as_mut().unwrap().set_prev_preedit(clamped_preedit);
             }
 
             self.show_placeholder.set(self.real_text.is_empty());

--- a/crates/vizia_core/src/views/textbox.rs
+++ b/crates/vizia_core/src/views/textbox.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::ops::Range;
 use std::rc::Rc;
 
 use crate::prelude::*;
@@ -82,6 +83,7 @@ pub struct Textbox<R, T> {
     show_placeholder: Signal<bool>,
     show_caret: Signal<bool>,
     mask_char: Signal<Option<char>>,
+    max_length: Signal<Option<usize>>,
     can_copy: Signal<bool>,
     can_paste: Signal<bool>,
     mask_visible: bool,
@@ -176,6 +178,7 @@ where
         let initial_text = value.get_value(cx).to_string_local(cx);
         let show_caret = Signal::new(false);
         let mask_char = Signal::new(None);
+        let max_length = Signal::new(None);
         let can_copy = Signal::new(true);
         let can_paste = Signal::new(true);
         let placeholder = Signal::new(String::from(""));
@@ -195,6 +198,7 @@ where
             show_placeholder,
             show_caret,
             mask_char,
+            max_length,
             can_copy,
             can_paste,
             mask_visible: false,
@@ -331,13 +335,15 @@ where
             let real_selection =
                 Self::selection_display_to_real(&old_display, &self.real_text, self.selection);
 
-            text.edit(self.selection.range(), txt);
-            self.real_text.edit(real_selection.range(), txt);
+            let clamped = self.clamp_insert_text(txt, real_selection.range());
+
+            text.edit(self.selection.range(), &clamped);
+            self.real_text.edit(real_selection.range(), &clamped);
 
             // Track the caret in grapheme space so we can remap it safely after
             // display text is regenerated (for example when masking is enabled).
             let new_caret_grapheme =
-                Self::byte_to_grapheme_index(text, self.selection.min() + txt.len());
+                Self::byte_to_grapheme_index(text, self.selection.min() + clamped.len());
 
             self.show_placeholder.set(self.real_text.is_empty());
             self.sync_display_text(cx);
@@ -404,8 +410,6 @@ where
                     text.replace_range(start..end, "");
                 }
 
-                text.insert_str(start, preedit_txt);
-
                 let original_real_selection = Self::selection_display_to_real(
                     &old_display,
                     &self.real_text,
@@ -414,21 +418,27 @@ where
                 let real_start = original_real_selection.min();
                 let real_end =
                     real_start + prev_preedit_text.chars().map(|c| c.len_utf8()).sum::<usize>();
+                let clamped_preedit = self.clamp_insert_text(preedit_txt, real_start..real_end);
                 if real_end > real_start && real_end <= self.real_text.len() {
                     self.real_text.replace_range(real_start..real_end, "");
                 }
-                self.real_text.insert_str(real_start, preedit_txt);
+                self.real_text.insert_str(real_start, &clamped_preedit);
+
+                text.insert_str(start, &clamped_preedit);
 
                 if let Some((cursor_index, _)) = cursor {
-                    let new_caret = original_selection.min() + cursor_index;
+                    let new_caret = original_selection.min() + cursor_index.min(clamped_preedit.len());
                     new_caret_grapheme = Self::byte_to_grapheme_index(text, new_caret);
                 } else {
                     // If there is no valid cursor, the default behavior is to move to the end of the text.
-                    let new_caret = original_selection.min() + preedit_txt.chars().count();
+                    let new_caret = original_selection.min() + clamped_preedit.chars().count();
                     new_caret_grapheme = Self::byte_to_grapheme_index(text, new_caret);
                 }
 
-                self.preedit_backup.as_mut().unwrap().set_prev_preedit(preedit_txt.to_string());
+                self.preedit_backup
+                    .as_mut()
+                    .unwrap()
+                    .set_prev_preedit(clamped_preedit);
             }
 
             self.show_placeholder.set(self.real_text.is_empty());
@@ -748,6 +758,23 @@ where
         self.real_text.clone()
     }
 
+    fn clamp_insert_text(&self, txt: &str, replace_range: Range<usize>) -> String {
+        let Some(max_length) = self.max_length.get() else {
+            return txt.to_string();
+        };
+
+        let current_len = self.real_text.graphemes(true).count();
+        let replaced_len = self.real_text[replace_range].graphemes(true).count();
+        let preserved_len = current_len.saturating_sub(replaced_len);
+        let remaining = max_length.saturating_sub(preserved_len);
+
+        if remaining == 0 {
+            return String::new();
+        }
+
+        txt.graphemes(true).take(remaining).collect()
+    }
+
     fn is_text_valid(&self, text: &str) -> bool {
         if let Ok(value) = text.parse::<T>() {
             if let Some(validate) = &self.validate { validate(&value) } else { true }
@@ -1057,6 +1084,20 @@ where
             handle = handle.text(display_text);
             handle.context().style.needs_text_update(entity);
             handle.context().needs_redraw(entity);
+        })
+    }
+
+    /// Sets an optional maximum number of graphemes for textbox input.
+    ///
+    /// Use `Some(n)` to limit input length and `None` to remove the limit.
+    pub fn max_length<U: Into<Option<usize>> + Clone + 'static>(
+        self,
+        max_length: impl Res<U> + 'static,
+    ) -> Self {
+        let max_length = max_length.to_signal(self.cx);
+        self.bind(max_length, move |handle| {
+            let value = max_length.get().into();
+            handle.modify(|textbox| textbox.max_length.set_if_changed(value));
         })
     }
 

--- a/examples/views/login.rs
+++ b/examples/views/login.rs
@@ -1,5 +1,6 @@
 mod helpers;
 use helpers::*;
+use vizia::icons::{ICON_EYE, ICON_EYE_OFF};
 use vizia::prelude::*;
 
 const LOGIN_STYLES: &str = r#"
@@ -34,6 +35,7 @@ const LOGIN_STYLES: &str = r#"
 struct LoginData {
     username: Signal<String>,
     password: Signal<String>,
+    password_visible: Signal<bool>,
     username_error: Signal<String>,
     password_error: Signal<String>,
     can_submit: Signal<bool>,
@@ -45,6 +47,7 @@ impl LoginData {
         Self {
             username: Signal::new(String::new()),
             password: Signal::new(String::new()),
+            password_visible: Signal::new(false),
             username_error: Signal::new(String::new()),
             password_error: Signal::new(String::new()),
             can_submit: Signal::new(false),
@@ -95,6 +98,7 @@ impl LoginData {
 enum LoginEvent {
     SetUsername(String),
     SetPassword(String),
+    TogglePasswordVisible,
     Submit,
 }
 
@@ -113,6 +117,10 @@ impl Model for LoginData {
                 self.status.set(String::new());
             }
 
+            LoginEvent::TogglePasswordVisible => {
+                self.password_visible.update(|visible| *visible ^= true);
+            }
+
             LoginEvent::Submit => {
                 if self.can_submit.get() {
                     self.status.set("Login successful (demo)".to_string());
@@ -128,8 +136,15 @@ fn main() -> Result<(), ApplicationError> {
     Application::new(|cx| {
         cx.add_stylesheet(LOGIN_STYLES).expect("Failed to add login stylesheet");
 
-        let &LoginData { username, password, username_error, password_error, can_submit, status } =
-            LoginData::new().build(cx);
+        let &LoginData {
+            username,
+            password,
+            password_visible,
+            username_error,
+            password_error,
+            can_submit,
+            status,
+        } = LoginData::new().build(cx);
 
         ExamplePage::vertical(cx, |cx| {
             VStack::new(cx, |cx| {
@@ -148,12 +163,31 @@ fn main() -> Result<(), ApplicationError> {
                 .gap(Pixels(4.0));
                 VStack::new(cx, |cx| {
                     Label::new(cx, "Password").height(Auto).font_weight(FontWeightKeyword::Bold);
-                    Textbox::new(cx, password)
-                        .width(Stretch(1.0))
-                        .placeholder("Enter password")
-                        .mask_char(Some('*'))
-                        .validate(|value: &String| LoginData::password_error(value).is_none())
-                        .on_edit(|cx, text| cx.emit(LoginEvent::SetPassword(text)));
+                    ZStack::new(cx, |cx| {
+                        let password_entity = Textbox::new(cx, password)
+                            .width(Stretch(1.0))
+                            .placeholder("Enter password")
+                            .mask_char(Some('*'))
+                            .validate(|value: &String| LoginData::password_error(value).is_none())
+                            .on_edit(|cx, text| cx.emit(LoginEvent::SetPassword(text)))
+                            .padding_right(Pixels(50.0))
+                            .entity();
+
+                        ToggleButton::with_contents(
+                            cx,
+                            password_visible,
+                            |cx| Svg::new(cx, ICON_EYE),
+                            |cx| Svg::new(cx, ICON_EYE_OFF),
+                        )
+                        .on_toggle(move |cx| {
+                            cx.emit(LoginEvent::TogglePasswordVisible);
+                            cx.emit_to(password_entity, TextEvent::ToggleMaskVisible);
+                        });
+                    })
+                    .width(Stretch(1.0))
+                    .height(Auto)
+                    .alignment(Alignment::Right);
+
                     Label::new(cx, password_error).class("error-text");
                 })
                 .height(Auto)
@@ -161,7 +195,7 @@ fn main() -> Result<(), ApplicationError> {
                 Button::new(cx, |cx| Label::new(cx, "Login"))
                     .width(Stretch(1.0))
                     .on_press(|cx| cx.emit(LoginEvent::Submit))
-                    .disabled(can_submit.map(|ready| !*ready));
+                    .disabled(can_submit);
 
                 Label::new(cx, status).class("status-text");
             })

--- a/examples/views/login.rs
+++ b/examples/views/login.rs
@@ -164,14 +164,14 @@ fn main() -> Result<(), ApplicationError> {
                 VStack::new(cx, |cx| {
                     Label::new(cx, "Password").height(Auto).font_weight(FontWeightKeyword::Bold);
                     ZStack::new(cx, |cx| {
-                        let password_entity = Textbox::new(cx, password)
+                        Textbox::new(cx, password)
                             .width(Stretch(1.0))
                             .placeholder("Enter password")
                             .mask_char(Some('*'))
+                            .mask_visible(password_visible)
                             .validate(|value: &String| LoginData::password_error(value).is_none())
                             .on_edit(|cx, text| cx.emit(LoginEvent::SetPassword(text)))
-                            .padding_right(Pixels(50.0))
-                            .entity();
+                            .padding_right(Pixels(50.0));
 
                         ToggleButton::with_contents(
                             cx,
@@ -181,7 +181,6 @@ fn main() -> Result<(), ApplicationError> {
                         )
                         .on_toggle(move |cx| {
                             cx.emit(LoginEvent::TogglePasswordVisible);
-                            cx.emit_to(password_entity, TextEvent::ToggleMaskVisible);
                         });
                     })
                     .width(Stretch(1.0))

--- a/examples/views/login.rs
+++ b/examples/views/login.rs
@@ -1,0 +1,174 @@
+mod helpers;
+use helpers::*;
+use vizia::prelude::*;
+
+const LOGIN_STYLES: &str = r#"
+    .login-card {
+        width: 340px;
+        height: auto;
+        padding: 16px;
+        gap: 12px;
+        alignment: center;
+        border-width: 1px;
+        border-color: var(--border);
+        corner-radius: 8px;
+        background-color: var(--card);
+    }
+
+    .login-title {
+        font-size: 28px;
+        height: auto;
+    }
+
+    .error-text {
+        color: #b42318;
+        font-size: 12px;
+    }
+
+    .status-text {
+        font-size: 12px;
+    }
+"#;
+
+#[derive(Clone, Copy)]
+struct LoginData {
+    username: Signal<String>,
+    password: Signal<String>,
+    username_error: Signal<String>,
+    password_error: Signal<String>,
+    can_submit: Signal<bool>,
+    status: Signal<String>,
+}
+
+impl LoginData {
+    fn new() -> Self {
+        Self {
+            username: Signal::new(String::new()),
+            password: Signal::new(String::new()),
+            username_error: Signal::new(String::new()),
+            password_error: Signal::new(String::new()),
+            can_submit: Signal::new(false),
+            status: Signal::new(String::new()),
+        }
+    }
+
+    fn username_error(username: &str) -> Option<&'static str> {
+        if username.is_empty() {
+            Some("Username is required")
+        } else if username.chars().count() < 3 {
+            Some("Username must be at least 3 characters")
+        } else if !username.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
+            Some("Use letters, numbers, or _")
+        } else {
+            None
+        }
+    }
+
+    fn password_error(password: &str) -> Option<&'static str> {
+        let has_letter = password.chars().any(|ch| ch.is_ascii_alphabetic());
+        let has_number = password.chars().any(|ch| ch.is_ascii_digit());
+
+        if password.is_empty() {
+            Some("Password is required")
+        } else if password.chars().count() < 8 {
+            Some("Password must be at least 8 characters")
+        } else if !has_letter || !has_number {
+            Some("Password must include a letter and a number")
+        } else {
+            None
+        }
+    }
+
+    fn recompute_validation(&self) {
+        let username = self.username.get();
+        let password = self.password.get();
+
+        let username_error = Self::username_error(&username).unwrap_or_default().to_string();
+        let password_error = Self::password_error(&password).unwrap_or_default().to_string();
+
+        self.username_error.set(username_error.clone());
+        self.password_error.set(password_error.clone());
+        self.can_submit.set(username_error.is_empty() && password_error.is_empty());
+    }
+}
+
+enum LoginEvent {
+    SetUsername(String),
+    SetPassword(String),
+    Submit,
+}
+
+impl Model for LoginData {
+    fn event(&mut self, _: &mut EventContext, event: &mut Event) {
+        event.map(|login_event, _| match login_event {
+            LoginEvent::SetUsername(username) => {
+                self.username.set(username.clone());
+                self.recompute_validation();
+                self.status.set(String::new());
+            }
+
+            LoginEvent::SetPassword(password) => {
+                self.password.set(password.clone());
+                self.recompute_validation();
+                self.status.set(String::new());
+            }
+
+            LoginEvent::Submit => {
+                if self.can_submit.get() {
+                    self.status.set("Login successful (demo)".to_string());
+                } else {
+                    self.status.set("Please fix validation errors before logging in".to_string());
+                }
+            }
+        });
+    }
+}
+
+fn main() -> Result<(), ApplicationError> {
+    Application::new(|cx| {
+        cx.add_stylesheet(LOGIN_STYLES).expect("Failed to add login stylesheet");
+
+        let &LoginData { username, password, username_error, password_error, can_submit, status } =
+            LoginData::new().build(cx);
+
+        ExamplePage::vertical(cx, |cx| {
+            VStack::new(cx, |cx| {
+                Label::new(cx, "Welcome Back").class("login-title");
+
+                VStack::new(cx, |cx| {
+                    Label::new(cx, "Username").height(Auto).font_weight(FontWeightKeyword::Bold);
+                    Textbox::new(cx, username)
+                        .width(Stretch(1.0))
+                        .placeholder("Enter username")
+                        .validate(|value: &String| LoginData::username_error(value).is_none())
+                        .on_edit(|cx, text| cx.emit(LoginEvent::SetUsername(text)));
+                    Label::new(cx, username_error).class("error-text");
+                })
+                .height(Auto)
+                .gap(Pixels(4.0));
+                VStack::new(cx, |cx| {
+                    Label::new(cx, "Password").height(Auto).font_weight(FontWeightKeyword::Bold);
+                    Textbox::new(cx, password)
+                        .width(Stretch(1.0))
+                        .placeholder("Enter password")
+                        .mask_char(Some('*'))
+                        .validate(|value: &String| LoginData::password_error(value).is_none())
+                        .on_edit(|cx, text| cx.emit(LoginEvent::SetPassword(text)));
+                    Label::new(cx, password_error).class("error-text");
+                })
+                .height(Auto)
+                .gap(Pixels(4.0));
+                Button::new(cx, |cx| Label::new(cx, "Login"))
+                    .width(Stretch(1.0))
+                    .on_press(|cx| cx.emit(LoginEvent::Submit))
+                    .disabled(can_submit.map(|ready| !*ready));
+
+                Label::new(cx, status).class("status-text");
+            })
+            .class("login-card");
+        });
+    })
+    .title("Login Example")
+    .inner_size((700, 400))
+    .run()
+}

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), ApplicationError> {
                     .placeholder("Password")
                     .mask_char(Some('*'))
                     .on_edit(|cx, text| cx.emit(AppEvent::SetPasswordText(text)))
-                    .padding_right(Pixels(30.0))
+                    .padding_right(Pixels(50.0))
                     .entity();
 
                 ToggleButton::with_contents(

--- a/examples/views/textbox.rs
+++ b/examples/views/textbox.rs
@@ -61,13 +61,13 @@ fn main() -> Result<(), ApplicationError> {
                 .on_edit(|cx, text| cx.emit(AppEvent::SetEditableText(text)));
 
             ZStack::new(cx, |cx| {
-                let password_entity = Textbox::new(cx, password_text)
+                Textbox::new(cx, password_text)
                     .width(Stretch(1.0))
                     .placeholder("Password")
                     .mask_char(Some('*'))
+                    .mask_visible(password_visible)
                     .on_edit(|cx, text| cx.emit(AppEvent::SetPasswordText(text)))
-                    .padding_right(Pixels(50.0))
-                    .entity();
+                    .padding_right(Pixels(50.0));
 
                 ToggleButton::with_contents(
                     cx,
@@ -78,7 +78,6 @@ fn main() -> Result<(), ApplicationError> {
                 //.variant(ButtonVariant::Text)
                 .on_toggle(move |cx| {
                     cx.emit(AppEvent::TogglePasswordVisible);
-                    cx.emit_to(password_entity, TextEvent::ToggleMaskVisible);
                 });
             })
             .width(Pixels(300.0))


### PR DESCRIPTION
This pull request introduces several improvements and new features to the `textbox` view, focusing on enhanced input validation, better user experience, and new customization options. The most significant changes include the addition of a maximum input length for textboxes, improved validation logic, and more precise focus and visual feedback behaviors. There are also updates to the CSS to improve accessibility and visual cues for invalid or focused textboxes.

**Textbox functionality enhancements:**

* Added a `max_length` property to the `Textbox` widget, allowing developers to restrict the number of graphemes a user can input. Input is now clamped to this maximum length, including during preedit (IME) input. (`crates/vizia_core/src/views/textbox.rs`) [[1]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR86) [[2]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR181) [[3]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR201) [[4]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL330-R346) [[5]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR421-R439) [[6]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR759-R783) [[7]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR1088-R1132)
* Improved input validation logic by centralizing it in the new `is_text_valid` method, ensuring consistent validation after all relevant text events (insert, delete, paste, etc.), and tracking edit state for more accurate pristine/dirty handling. (`crates/vizia_core/src/views/textbox.rs`) [[1]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR95-R96) [[2]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR1671-R1673) [[3]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1597-R1682) [[4]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR1708-R1714) [[5]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1686-L1694) [[6]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1717-R1788) [[7]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1769-L1776) [[8]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR1906-R1914)
* Added `mask_visible` setter to the API for toggling password masking programmatically. (`crates/vizia_core/src/views/textbox.rs`)

**User experience and accessibility improvements:**

* Changed focus handling to always show the focus indicator on pointer interaction, and improved focus visibility logic for pointer-driven blur events. (`crates/vizia_core/src/views/textbox.rs`) [[1]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1260-R1342) [[2]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL1665-R1737) [[3]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cR1803-R1809)
* Updated CSS for `textbox` to use `:focus-visible` for more accessible focus outlines, and improved invalid state styling to use outlines and a new destructive color. (`crates/vizia_core/resources/themes/default_theme.css`) [[1]](diffhunk://#diff-00853898a9a8417c9ce7c093125cfe56cf2a8372dfee4474dbd3dbf9ffe6e9d2L1033-R1036) [[2]](diffhunk://#diff-00853898a9a8417c9ce7c093125cfe56cf2a8372dfee4474dbd3dbf9ffe6e9d2L1056-R1070)

**Examples and minor improvements:**

* Added a new `login` example to demonstrate textbox usage. (`Cargo.toml`)
* Minor code cleanups and dependency updates (e.g., import adjustments, removal of unused CSS rule). (`crates/vizia_core/src/views/textbox.rs`, `crates/vizia_core/resources/themes/default_layout.css`) [[1]](diffhunk://#diff-dbf186e96972cbf5d6256248feb1980793c30ecf10ba6fff74917637f7a9b49cL12-R13) [[2]](diffhunk://#diff-4453942aa09c2418ba800cfeb7cb047e6c9ae5f866f934fbab80f7bebec95d9fL925)