### PR TITLE
Make mundy dependency Linux-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ indexmap = "2.13"
 keyboard-types = { version = "0.7", default-features = false }
 log = "0.4"
 morphorm = {git = "https://github.com/vizia/morphorm.git", rev = "f48333f042e346cff64a8a563b791a5b4c18163b"}
-mundy = "0.2.3"
 open = "5.3"
 parking_lot = "0.12"
 raw-window-handle = "0.5"

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -44,7 +44,9 @@ open = { workspace = true, optional = true }
 fxhash.workspace = true
 rayon = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
-mundy.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+mundy = "0.2.3"
 
 [lib]
 doctest = false

--- a/crates/vizia_core/src/environment.rs
+++ b/crates/vizia_core/src/environment.rs
@@ -1,7 +1,9 @@
 //! A model for system specific state which can be accessed by any model or view.
 use crate::prelude::*;
 
+#[cfg(target_os = "linux")]
 use mundy::Interest;
+#[cfg(target_os = "linux")]
 use mundy::Preferences;
 use unic_langid::CharacterDirection;
 use unic_langid::LanguageIdentifier;
@@ -63,13 +65,22 @@ fn apply_direction_class(cx: &mut EventContext, direction: Direction) {
 }
 
 fn detect_theme() -> ThemeMode {
-    let mundy_prefs = Preferences::once_blocking(Interest::ColorScheme, Duration::from_millis(500));
-
-    if let Some(preferences) = mundy_prefs
-        && preferences.color_scheme == mundy::ColorScheme::Dark
+    #[cfg(target_os = "linux")]
     {
-        ThemeMode::DarkMode
-    } else {
+        let mundy_prefs =
+            Preferences::once_blocking(Interest::ColorScheme, Duration::from_millis(100));
+
+        if let Some(preferences) = mundy_prefs
+            && preferences.color_scheme == mundy::ColorScheme::Dark
+        {
+            ThemeMode::DarkMode
+        } else {
+            ThemeMode::LightMode
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
         ThemeMode::LightMode
     }
 }


### PR DESCRIPTION
Remove the global mundy dependency and make it a Linux-only dependency for vizia_core. Add target-specific dependency stanza to crates/vizia_core/Cargo.toml and guard mundy imports/usages with #[cfg(target_os = "linux")]. In environment.rs detect_theme now only calls mundy::Preferences on Linux (with a reduced 100ms timeout) and non-Linux platforms fall back to LightMode. This prevents mundy from being built or referenced on non-Linux platforms and avoids related compile issues.