### PR TITLE
Avoid re-adding built-in styles

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -186,6 +186,7 @@ pub struct Context {
 
     pub ignore_default_theme: bool,
     built_in_translations_added: bool,
+    built_in_styles_added: bool,
     pub window_has_focus: bool,
     pub ime_state: ImeState,
 
@@ -266,6 +267,7 @@ impl Context {
 
             ignore_default_theme: false,
             built_in_translations_added: false,
+            built_in_styles_added: false,
             window_has_focus: true,
 
             ime_state: Default::default(),
@@ -675,18 +677,23 @@ impl Context {
     pub fn add_built_in_styles(&mut self) {
         self.add_built_in_translations();
 
-        let mut user_styles = Vec::new();
-        if self.resource_manager.styles.len() >= 3 {
-            user_styles = self.resource_manager.styles.drain(3..).collect::<Vec<_>>();
-        }
+        let user_styles = if self.built_in_styles_added {
+            if self.resource_manager.styles.len() >= 3 {
+                self.resource_manager.styles.drain(3..).collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            }
+        } else {
+            self.resource_manager.styles.drain(..).collect::<Vec<_>>()
+        };
 
         self.resource_manager.styles.clear();
 
-        self.add_stylesheet(DEFAULT_LAYOUT).unwrap();
-        self.add_stylesheet(MARKDOWN).unwrap();
+        self.resource_manager.styles.push(Box::new(DEFAULT_LAYOUT));
+        self.resource_manager.styles.push(Box::new(MARKDOWN));
 
         if !self.ignore_default_theme {
-            self.add_stylesheet(DEFAULT_THEME).unwrap();
+            self.resource_manager.styles.push(Box::new(DEFAULT_THEME));
             let environment = self.data::<Environment>();
             let theme_mode = environment.effective_theme();
             let direction = environment.direction.get();
@@ -697,10 +704,11 @@ impl Context {
             })
         } else {
             // Add an empty stylesheet to ensure that the list of styles contains at least three entries.
-            self.add_stylesheet("").unwrap();
+            self.resource_manager.styles.push(Box::new(""));
         }
 
         self.resource_manager.styles.extend(user_styles);
+        self.built_in_styles_added = true;
 
         EventContext::new(self).reload_styles().unwrap();
     }

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -176,7 +176,7 @@ impl Application {
         });
 
         cx.renegotiate_language();
-        cx.0.add_built_in_styles();
+        cx.0.add_built_in_translations();
         (content)(cx.context());
 
         Self {


### PR DESCRIPTION
Add a built_in_styles_added flag to Context and change add_built_in_styles to preserve user styles and avoid re-draining built-ins when called multiple times. Default styles (layout, markdown, theme or an empty placeholder) are now pushed directly into the resource manager and user styles are re-appended; built_in_styles_added is set to true and styles are reloaded. Also adjust application startup to call add_built_in_translations (not add_built_in_styles) to prevent duplicate style insertion on initialization.