### PR TITLE
Introduce async Task API with Tokio integration and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ selectors = "0.38"
 serde = { version = "1.0", features = ["derive"] }
 skia-safe = { version = "0.97", features = ["gl", "textlayout", "svg"] }
 sys-locale = "0.3"
-tokio = { version = "1.52.3", features = ["rt-multi-thread"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "time"] }
 unic-langid = { version = "0.9.6", features = ["macros"] }
 unicode-segmentation = "1.12"
 unicode-bidi = "0.3"
@@ -368,3 +368,7 @@ path = "examples/views/virtual_table.rs"
 [[example]]
 name = "table"
 path = "examples/views/table.rs"
+
+[[example]]
+name = "task_download"
+path = "examples/task_download.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 exclude = ["assets/", "examples/"]
 
 [features]
-default = ["winit", "clipboard", "x11", "wayland", "markdown", "accesskit"]
+default = ["winit", "clipboard", "x11", "wayland", "markdown", "accesskit", "tokio"]
 clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
 winit = ["vizia_winit"]
 baseview = ["vizia_baseview"]
@@ -21,6 +21,7 @@ accesskit = ["vizia_winit?/accesskit"]
 markdown = ["vizia_core/markdown"]
 rayon = ["vizia_core/rayon"]
 serde = ["vizia_core/serde"]
+tokio = ["vizia_core/tokio"]
 
 [dependencies]
 vizia_core.workspace = true
@@ -45,7 +46,7 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 vizia = { version = "0.4.0", path = "." }
-vizia_core = { version = "0.4.0", path = "crates/vizia_core" }
+vizia_core = { version = "0.4.0", path = "crates/vizia_core", default-features = false }
 vizia_winit = { version = "0.4.0", path = "crates/vizia_winit", default-features = false }
 vizia_baseview = { version = "0.4.0", path = "crates/vizia_baseview" }
 vizia_id = { version = "0.4.0", path = "crates/vizia_id" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ accesskit = ["vizia_winit?/accesskit"]
 markdown = ["vizia_core/markdown"]
 rayon = ["vizia_core/rayon"]
 serde = ["vizia_core/serde"]
-tokio = ["vizia_core/tokio"]
+tokio = ["vizia_core/tokio", "dep:tokio"]
 
 [dependencies]
 vizia_core.workspace = true
 vizia_winit = { workspace = true, optional = true, default-features = false}
 vizia_baseview = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 chrono.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 exclude = ["assets/", "examples/"]
 
 [features]
-default = ["winit", "clipboard", "x11", "wayland", "markdown", "accesskit", "tokio"]
+default = ["winit", "clipboard", "x11", "wayland", "markdown", "accesskit"]
 clipboard = ["vizia_core/clipboard", "vizia_winit?/clipboard"]
 winit = ["vizia_winit"]
 baseview = ["vizia_baseview"]
@@ -373,3 +373,4 @@ path = "examples/views/table.rs"
 [[example]]
 name = "task_download"
 path = "examples/task_download.rs"
+required-features = ["tokio"]

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -9,12 +9,14 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
+default = ["tokio"]
 clipboard = ["copypasta"]
 x11 = ["copypasta?/x11"]
 wayland = ["copypasta?/wayland"]
 markdown = ["comrak", "dep:open"]
 rayon = ["dep:rayon", "dep:dashmap", "hashbrown/rayon"]
 serde = ["vizia_reactive/serde"]
+tokio = ["dep:tokio"]
 
 [dependencies]
 vizia_storage.workspace = true
@@ -44,7 +46,7 @@ open = { workspace = true, optional = true }
 fxhash.workspace = true
 rayon = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
-tokio.workspace = true
+tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mundy = "0.2.3"

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -44,6 +44,7 @@ open = { workspace = true, optional = true }
 fxhash.workspace = true
 rayon = { workspace = true, optional = true }
 dashmap = { workspace = true, optional = true }
+tokio.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mundy = "0.2.3"

--- a/crates/vizia_core/Cargo.toml
+++ b/crates/vizia_core/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["tokio"]
+default = []
 clipboard = ["copypasta"]
 x11 = ["copypasta?/x11"]
 wayland = ["copypasta?/wayland"]

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -825,13 +825,34 @@ impl<'a> EventContext<'a> {
         }
     }
 
-    /// Submits a built task pipeline to run asynchronously.
+    /// Submits a configured [`TaskBuilder`] for asynchronous execution.
+    ///
+    /// Tasks run on Vizia's shared Tokio runtime and complete through the
+    /// `on_result(...)` callback attached to the builder, when one is provided.
+    ///
+    /// Returns a [`TaskHandle`] that can be used to request cancellation.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # #[cfg(feature = "tokio")]
+    /// # fn trigger(cx: &EventContext) {
+    /// // Fire-and-forget:
+    /// cx.add_task(Task::new(|_| async move { Ok::<(), &'static str>(()) }));
+    ///
+    /// // With completion handling:
+    /// cx.add_task(
+    ///     Task::new(|_| async move { Ok::<_, &'static str>(()) })
+    ///         .name("refresh")
+    ///         .on_result(|_, _| {}),
+    /// );
+    /// # }
+    /// ```
     #[cfg(feature = "tokio")]
-    pub fn add_task<T, E, Map>(&self, task: TaskBuilder<T, E, Map>) -> TaskHandle
+    pub fn add_task<T, E>(&self, task: TaskBuilder<T, E>) -> TaskHandle
     where
         T: Send + 'static,
         E: Send + 'static,
-        Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
     {
         task.add_to_event_context(self)
     }

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -60,7 +60,6 @@ type Models = HashMap<Entity, HashMap<TypeId, Box<dyn ModelData>>>;
 /// }
 /// ```
 pub struct EventContext<'a> {
-    pub(crate) context_id: u64,
     pub(crate) current: Entity,
     pub(crate) captured: &'a mut Entity,
     pub(crate) focused: &'a mut Entity,
@@ -76,7 +75,10 @@ pub struct EventContext<'a> {
         &'a mut HashMap<Entity, Box<dyn Fn(&mut dyn ViewHandler, &mut EventContext, &mut Event)>>,
     pub(crate) resource_manager: &'a mut ResourceManager,
     pub(crate) text_context: &'a mut TextContext,
+    #[cfg(feature = "tokio")]
     pub(crate) task_runtime: &'a super::TaskRuntime,
+    #[cfg(feature = "tokio")]
+    pub(crate) named_tasks: &'a super::NamedTaskMap,
     pub(crate) modifiers: &'a Modifiers,
     pub(crate) mouse: &'a MouseState<Entity>,
     pub(crate) event_queue: &'a mut VecDeque<Event>,
@@ -116,7 +118,6 @@ impl<'a> EventContext<'a> {
     /// Creates a new [EventContext].
     pub fn new(cx: &'a mut Context) -> Self {
         Self {
-            context_id: cx.context_id,
             current: cx.current,
             captured: &mut cx.captured,
             focused: &mut cx.focused,
@@ -131,7 +132,10 @@ impl<'a> EventContext<'a> {
             listeners: &mut cx.listeners,
             resource_manager: &mut cx.resource_manager,
             text_context: &mut cx.text_context,
+            #[cfg(feature = "tokio")]
             task_runtime: &cx.task_runtime,
+            #[cfg(feature = "tokio")]
+            named_tasks: &cx.named_tasks,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
             event_queue: &mut cx.event_queue,
@@ -152,7 +156,6 @@ impl<'a> EventContext<'a> {
     /// Creates a new [EventContext] with the given current [Entity].
     pub fn new_with_current(cx: &'a mut Context, current: Entity) -> Self {
         Self {
-            context_id: cx.context_id,
             current,
             captured: &mut cx.captured,
             focused: &mut cx.focused,
@@ -167,7 +170,10 @@ impl<'a> EventContext<'a> {
             listeners: &mut cx.listeners,
             resource_manager: &mut cx.resource_manager,
             text_context: &mut cx.text_context,
+            #[cfg(feature = "tokio")]
             task_runtime: &cx.task_runtime,
+            #[cfg(feature = "tokio")]
+            named_tasks: &cx.named_tasks,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
             event_queue: &mut cx.event_queue,
@@ -821,8 +827,13 @@ impl<'a> EventContext<'a> {
 
     /// Submits a built task pipeline to run asynchronously.
     #[cfg(feature = "tokio")]
-    pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
-        task.add_to(self)
+    pub fn add_task<T, E, Map>(&self, task: TaskBuilder<T, E, Map>) -> TaskHandle
+    where
+        T: Send + 'static,
+        E: Send + 'static,
+        Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
+    {
+        task.add_to_event_context(self)
     }
 
     pub fn modify<V: View>(&mut self, f: impl FnOnce(&mut V)) {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -3,6 +3,7 @@ use std::collections::{BinaryHeap, VecDeque};
 #[cfg(feature = "clipboard")]
 use std::error::Error;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
@@ -60,6 +61,7 @@ type Models = HashMap<Entity, HashMap<TypeId, Box<dyn ModelData>>>;
 /// }
 /// ```
 pub struct EventContext<'a> {
+    pub(crate) context_id: u64,
     pub(crate) current: Entity,
     pub(crate) captured: &'a mut Entity,
     pub(crate) focused: &'a mut Entity,
@@ -75,6 +77,7 @@ pub struct EventContext<'a> {
         &'a mut HashMap<Entity, Box<dyn Fn(&mut dyn ViewHandler, &mut EventContext, &mut Event)>>,
     pub(crate) resource_manager: &'a mut ResourceManager,
     pub(crate) text_context: &'a mut TextContext,
+    pub(crate) task_runtime: &'a Arc<tokio::runtime::Runtime>,
     pub(crate) modifiers: &'a Modifiers,
     pub(crate) mouse: &'a MouseState<Entity>,
     pub(crate) event_queue: &'a mut VecDeque<Event>,
@@ -114,6 +117,7 @@ impl<'a> EventContext<'a> {
     /// Creates a new [EventContext].
     pub fn new(cx: &'a mut Context) -> Self {
         Self {
+            context_id: cx.context_id,
             current: cx.current,
             captured: &mut cx.captured,
             focused: &mut cx.focused,
@@ -128,6 +132,7 @@ impl<'a> EventContext<'a> {
             listeners: &mut cx.listeners,
             resource_manager: &mut cx.resource_manager,
             text_context: &mut cx.text_context,
+            task_runtime: &cx.task_runtime,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
             event_queue: &mut cx.event_queue,
@@ -148,6 +153,7 @@ impl<'a> EventContext<'a> {
     /// Creates a new [EventContext] with the given current [Entity].
     pub fn new_with_current(cx: &'a mut Context, current: Entity) -> Self {
         Self {
+            context_id: cx.context_id,
             current,
             captured: &mut cx.captured,
             focused: &mut cx.focused,
@@ -162,6 +168,7 @@ impl<'a> EventContext<'a> {
             listeners: &mut cx.listeners,
             resource_manager: &mut cx.resource_manager,
             text_context: &mut cx.text_context,
+            task_runtime: &cx.task_runtime,
             modifiers: &cx.modifiers,
             mouse: &cx.mouse,
             event_queue: &mut cx.event_queue,
@@ -811,6 +818,11 @@ impl<'a> EventContext<'a> {
             current: self.current,
             event_proxy: self.event_proxy.as_ref().map(|p| p.make_clone()),
         }
+    }
+
+    /// Submits a built task pipeline to run asynchronously.
+    pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
+        task.add_to(self)
     }
 
     pub fn modify<V: View>(&mut self, f: impl FnOnce(&mut V)) {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -3,7 +3,6 @@ use std::collections::{BinaryHeap, VecDeque};
 #[cfg(feature = "clipboard")]
 use std::error::Error;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use hashbrown::hash_map::Entry;
 use hashbrown::{HashMap, HashSet};
@@ -77,7 +76,7 @@ pub struct EventContext<'a> {
         &'a mut HashMap<Entity, Box<dyn Fn(&mut dyn ViewHandler, &mut EventContext, &mut Event)>>,
     pub(crate) resource_manager: &'a mut ResourceManager,
     pub(crate) text_context: &'a mut TextContext,
-    pub(crate) task_runtime: &'a Arc<tokio::runtime::Runtime>,
+    pub(crate) task_runtime: &'a super::TaskRuntime,
     pub(crate) modifiers: &'a Modifiers,
     pub(crate) mouse: &'a MouseState<Entity>,
     pub(crate) event_queue: &'a mut VecDeque<Event>,
@@ -821,6 +820,7 @@ impl<'a> EventContext<'a> {
     }
 
     /// Submits a built task pipeline to run asynchronously.
+    #[cfg(feature = "tokio")]
     pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
         task.add_to(self)
     }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -7,6 +7,7 @@ mod draw;
 mod event;
 mod proxy;
 mod resource;
+#[cfg(feature = "tokio")]
 mod task;
 
 use log::debug;
@@ -49,6 +50,7 @@ pub use draw::*;
 pub use event::*;
 pub use proxy::*;
 pub use resource::*;
+#[cfg(feature = "tokio")]
 pub use task::*;
 
 use crate::{
@@ -64,6 +66,11 @@ use crate::resource::ResourceManager;
 use crate::text::TextContext;
 use vizia_input::{ImeState, MouseState};
 use vizia_storage::{ChildIterator, LayoutTreeIterator};
+
+#[cfg(feature = "tokio")]
+pub(crate) type TaskRuntime = Arc<tokio::runtime::Runtime>;
+#[cfg(not(feature = "tokio"))]
+pub(crate) type TaskRuntime = ();
 
 static DEFAULT_LAYOUT: &str = include_str!("../../resources/themes/default_layout.css");
 static DEFAULT_THEME: &str = include_str!("../../resources/themes/default_theme.css");
@@ -176,7 +183,7 @@ pub struct Context {
 
     pub text_context: TextContext,
 
-    pub(crate) task_runtime: Arc<tokio::runtime::Runtime>,
+    pub(crate) task_runtime: TaskRuntime,
 
     pub(crate) event_proxy: Option<Box<dyn EventProxy>>,
 
@@ -260,12 +267,7 @@ impl Context {
                 }
             },
 
-            task_runtime: Arc::new(
-                tokio::runtime::Builder::new_multi_thread()
-                    .enable_all()
-                    .build()
-                    .expect("failed to build context task runtime"),
-            ),
+            task_runtime: Self::new_task_runtime(),
 
             event_proxy: None,
 
@@ -306,6 +308,21 @@ impl Context {
         result.style.role.insert(Entity::root(), Role::Window);
 
         result
+    }
+
+    #[cfg(feature = "tokio")]
+    fn new_task_runtime() -> TaskRuntime {
+        Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("failed to build context task runtime"),
+        )
+    }
+
+    #[cfg(not(feature = "tokio"))]
+    fn new_task_runtime() -> TaskRuntime {
+        ()
     }
 
     /// The "current" entity, generally the entity which is currently being built or the entity
@@ -997,6 +1014,7 @@ impl Context {
         }
     }
 
+    #[cfg(feature = "tokio")]
     /// Submits a built task pipeline to run asynchronously.
     pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
         task.add_to(self)

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -69,8 +69,6 @@ use vizia_storage::{ChildIterator, LayoutTreeIterator};
 
 #[cfg(feature = "tokio")]
 pub(crate) type TaskRuntime = Arc<tokio::runtime::Runtime>;
-#[cfg(not(feature = "tokio"))]
-pub(crate) type TaskRuntime = ();
 
 static DEFAULT_LAYOUT: &str = include_str!("../../resources/themes/default_layout.css");
 static DEFAULT_THEME: &str = include_str!("../../resources/themes/default_theme.css");
@@ -183,7 +181,10 @@ pub struct Context {
 
     pub text_context: TextContext,
 
+    #[cfg(feature = "tokio")]
     pub(crate) task_runtime: TaskRuntime,
+    #[cfg(feature = "tokio")]
+    pub(crate) named_tasks: NamedTaskMap,
 
     pub(crate) event_proxy: Option<Box<dyn EventProxy>>,
 
@@ -266,8 +267,10 @@ impl Context {
                     text_paragraphs: Default::default(),
                 }
             },
-
+            #[cfg(feature = "tokio")]
             task_runtime: Self::new_task_runtime(),
+            #[cfg(feature = "tokio")]
+            named_tasks: new_named_task_map(),
 
             event_proxy: None,
 
@@ -318,11 +321,6 @@ impl Context {
                 .build()
                 .expect("failed to build context task runtime"),
         )
-    }
-
-    #[cfg(not(feature = "tokio"))]
-    fn new_task_runtime() -> TaskRuntime {
-        ()
     }
 
     /// The "current" entity, generally the entity which is currently being built or the entity
@@ -1016,8 +1014,13 @@ impl Context {
 
     #[cfg(feature = "tokio")]
     /// Submits a built task pipeline to run asynchronously.
-    pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
-        task.add_to(self)
+    pub fn add_task<T, E, Map>(&self, task: TaskBuilder<T, E, Map>) -> TaskHandle
+    where
+        T: Send + 'static,
+        E: Send + 'static,
+        Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
+    {
+        task.add_to_context(self)
     }
 
     /// Finds the entity that identifier identifies

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -1013,12 +1013,37 @@ impl Context {
     }
 
     #[cfg(feature = "tokio")]
-    /// Submits a built task pipeline to run asynchronously.
-    pub fn add_task<T, E, Map>(&self, task: TaskBuilder<T, E, Map>) -> TaskHandle
+    /// Submits a configured [`TaskBuilder`] for asynchronous execution.
+    ///
+    /// Tasks run on Vizia's shared Tokio runtime and complete through the
+    /// `on_result(...)` callback attached to the builder, when one is provided.
+    ///
+    /// Returns a [`TaskHandle`] that can be used to request cancellation.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// // Fire-and-forget:
+    /// cx.add_task(Task::new(|_| async move { Ok::<(), &'static str>(()) }));
+    ///
+    /// // With completion handling:
+    /// cx.add_task(
+    ///     Task::new(|_| async move { Ok::<_, &'static str>("loaded") })
+    ///         .on_result(|result, proxy| {
+    ///             if let TaskResult::Completed(message) = result {
+    ///                 let _ = proxy.emit(message);
+    ///             }
+    ///         }),
+    /// );
+    /// # }
+    /// ```
+    pub fn add_task<T, E>(&self, task: TaskBuilder<T, E>) -> TaskHandle
     where
         T: Send + 'static,
         E: Send + 'static,
-        Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
     {
         task.add_to_context(self)
     }

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -7,6 +7,7 @@ mod draw;
 mod event;
 mod proxy;
 mod resource;
+mod task;
 
 use log::debug;
 use skia_safe::{
@@ -48,6 +49,7 @@ pub use draw::*;
 pub use event::*;
 pub use proxy::*;
 pub use resource::*;
+pub use task::*;
 
 use crate::{
     events::{TimedEvent, TimedEventHandle, TimerState, ViewHandler},
@@ -174,6 +176,8 @@ pub struct Context {
 
     pub text_context: TextContext,
 
+    pub(crate) task_runtime: Arc<tokio::runtime::Runtime>,
+
     pub(crate) event_proxy: Option<Box<dyn EventProxy>>,
 
     #[cfg(feature = "clipboard")]
@@ -255,6 +259,13 @@ impl Context {
                     text_paragraphs: Default::default(),
                 }
             },
+
+            task_runtime: Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build context task runtime"),
+            ),
 
             event_proxy: None,
 
@@ -984,6 +995,11 @@ impl Context {
             current: self.current,
             event_proxy: self.event_proxy.as_ref().map(|p| p.make_clone()),
         }
+    }
+
+    /// Submits a built task pipeline to run asynchronously.
+    pub fn add_task<T: AddTask>(&self, task: T) -> TaskHandle {
+        task.add_to(self)
     }
 
     /// Finds the entity that identifier identifies

--- a/crates/vizia_core/src/context/proxy.rs
+++ b/crates/vizia_core/src/context/proxy.rs
@@ -42,16 +42,16 @@ impl std::fmt::Display for ProxyEmitError {
 impl std::error::Error for ProxyEmitError {}
 
 impl ContextProxy {
-    pub fn emit<M: Any + Send>(&mut self, message: M) -> Result<(), ProxyEmitError> {
+    pub fn emit<M: Any + Send>(&mut self, message: M) {
         if let Some(proxy) = &self.event_proxy {
             let event = Event::new(message)
                 .target(self.current)
                 .origin(self.current)
                 .propagate(Propagation::Up);
 
-            proxy.send(event).map_err(|_| ProxyEmitError::EventLoopClosed)
+            proxy.send(event).expect("Sending an event to an event loop which has been closed");
         } else {
-            Err(ProxyEmitError::Unsupported)
+            panic!("The current runtime does not support proxying events");
         }
     }
 
@@ -73,7 +73,8 @@ impl ContextProxy {
     }
 
     pub fn redraw(&mut self) -> Result<(), ProxyEmitError> {
-        self.emit(InternalEvent::Redraw)
+        self.emit(InternalEvent::Redraw);
+        Ok(())
     }
 
     pub fn load_image(
@@ -83,7 +84,7 @@ impl ContextProxy {
         policy: ImageRetentionPolicy,
     ) -> Result<(), ProxyEmitError> {
         if let Some(image) = skia_safe::Image::from_encoded(skia_safe::Data::new_copy(data)) {
-            self.emit(InternalEvent::LoadImage { path, image: Mutex::new(Some(image)), policy })?
+            self.emit(InternalEvent::LoadImage { path, image: Mutex::new(Some(image)), policy });
         }
 
         Ok(())

--- a/crates/vizia_core/src/context/proxy.rs
+++ b/crates/vizia_core/src/context/proxy.rs
@@ -42,16 +42,16 @@ impl std::fmt::Display for ProxyEmitError {
 impl std::error::Error for ProxyEmitError {}
 
 impl ContextProxy {
-    pub fn emit<M: Any + Send>(&mut self, message: M) {
+    pub fn emit<M: Any + Send>(&mut self, message: M) -> Result<(), ProxyEmitError> {
         if let Some(proxy) = &self.event_proxy {
             let event = Event::new(message)
                 .target(self.current)
                 .origin(self.current)
                 .propagate(Propagation::Up);
 
-            proxy.send(event).expect("Sending an event to an event loop which has been closed");
+            proxy.send(event).map_err(|_| ProxyEmitError::EventLoopClosed)
         } else {
-            panic!("The current runtime does not support proxying events");
+            Err(ProxyEmitError::Unsupported)
         }
     }
 
@@ -73,8 +73,7 @@ impl ContextProxy {
     }
 
     pub fn redraw(&mut self) -> Result<(), ProxyEmitError> {
-        self.emit(InternalEvent::Redraw);
-        Ok(())
+        self.emit(InternalEvent::Redraw)
     }
 
     pub fn load_image(
@@ -84,7 +83,7 @@ impl ContextProxy {
         policy: ImageRetentionPolicy,
     ) -> Result<(), ProxyEmitError> {
         if let Some(image) = skia_safe::Image::from_encoded(skia_safe::Data::new_copy(data)) {
-            self.emit(InternalEvent::LoadImage { path, image: Mutex::new(Some(image)), policy });
+            self.emit(InternalEvent::LoadImage { path, image: Mutex::new(Some(image)), policy })?
         }
 
         Ok(())

--- a/crates/vizia_core/src/context/task.rs
+++ b/crates/vizia_core/src/context/task.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::collections::HashMap;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
@@ -18,6 +19,13 @@ pub(crate) fn new_named_task_map() -> NamedTaskMap {
 }
 
 /// Entry point for constructing async task pipelines.
+///
+/// A task pipeline is built with [`Task::new`], configured through [`TaskBuilder`],
+/// and submitted with [`Context::add_task`](crate::context::Context::add_task) or
+/// [`EventContext::add_task`](crate::context::EventContext::add_task).
+///
+/// Tasks run on Vizia's Tokio runtime (enabled with the `tokio` feature) and
+/// report completion through [`TaskResult`].
 pub struct Task;
 
 impl Task {
@@ -25,8 +33,35 @@ impl Task {
     ///
     /// The provided token is shared with [`TaskHandle::cancel`] and named-task replacement.
     ///
+    /// The factory is called once per attempt, so retries get a fresh future.
+    ///
     /// Ignore the token for one-shot tasks, for example
     /// `Task::new(|_| async move { Ok::<_, MyError>(value) })`.
+    ///
+    /// # Examples
+    ///
+    /// Fire-and-forget task (no completion callback):
+    /// ```rust
+    /// # use vizia_core::prelude::*;
+    /// # let cx = Context::default();
+    /// cx.add_task(Task::new(|_| async move { Ok::<(), &'static str>(()) }));
+    /// ```
+    ///
+    /// Task with completion handling:
+    /// ```rust
+    /// # use vizia_core::prelude::*;
+    /// # use std::time::Duration;
+    /// # let cx = Context::default();
+    /// cx.add_task(
+    ///     Task::new(|_| async move { Ok::<usize, &'static str>(42) })
+    ///         .timeout(Duration::from_secs(2))
+    ///         .on_result(|result, proxy| {
+    ///             if let TaskResult::Completed(value) = result {
+    ///                 let _ = proxy.emit(value);
+    ///             }
+    ///         }),
+    /// );
+    /// ```
     pub fn new<Factory, Fut, T, E>(mut factory: Factory) -> TaskBuilder<T, E>
     where
         Factory: FnMut(TaskCancellation) -> Fut + Send + 'static,
@@ -43,6 +78,9 @@ impl Task {
 }
 
 /// Cooperative cancellation token passed to every [`Task::new`] attempt.
+///
+/// Check [`TaskCancellation::is_cancelled`] at appropriate points inside long
+/// operations or loops and return early when cancellation is requested.
 #[derive(Debug, Clone)]
 pub struct TaskCancellation {
     cancelled: Arc<AtomicBool>,
@@ -54,12 +92,34 @@ impl TaskCancellation {
     }
 
     /// Returns `true` if cancellation has been requested for the task.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # use std::time::Duration;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// let _handle = cx.add_task(
+    ///     Task::new(|cancellation| async move {
+    ///         while !cancellation.is_cancelled() {
+    ///             tokio::time::sleep(Duration::from_millis(16)).await;
+    ///         }
+    ///         Err::<(), _>("cancelled")
+    ///     })
+    ///     .on_result(|_, _| {}),
+    /// );
+    /// # }
+    /// ```
     pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::Acquire)
     }
 }
 
 /// Handle for observing and cancelling an asynchronous task.
+///
+/// Keep this handle if you need to cancel in-flight work manually, or to query
+/// whether it has been cancelled or completed.
 #[derive(Debug, Clone)]
 pub struct TaskHandle {
     cancelled: Arc<AtomicBool>,
@@ -90,6 +150,21 @@ impl TaskHandle {
     /// Returns `true` if this call requested cancellation for an in-flight task.
     ///
     /// Returns `false` if cancellation was already requested or the task already finished.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// let handle = cx.add_task(
+    ///     Task::new(|_| async move { Ok::<_, &'static str>(()) })
+    ///         .on_result(|_, _| {}),
+    /// );
+    ///
+    /// let _requested = handle.cancel();
+    /// # }
+    /// ```
     pub fn cancel(&self) -> bool {
         if self.is_finished() {
             return false;
@@ -112,12 +187,29 @@ impl TaskHandle {
 /// Final completion state delivered to `TaskBuilder::on_result(...)`.
 #[derive(Debug)]
 pub enum TaskResult<T, E> {
+    /// The task produced a successful value.
     Completed(T),
+    /// The task returned an `Err(E)` on its final attempt.
     Error(E),
+    /// The task timed out on its final attempt.
     Timeout,
+    /// Cancellation was requested before successful completion.
     Cancelled,
     /// The worker task panicked or was aborted before producing a completion result.
-    Disconnected,
+    ///
+    /// `panic` contains a message when the worker unwound with a `String` or `&'static str`
+    /// payload, and `None` when the worker was aborted or used a non-string panic payload.
+    Disconnected { panic: Option<String> },
+}
+
+fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => match payload.downcast::<&'static str>() {
+            Ok(message) => (*message).to_string(),
+            Err(_) => "non-string panic payload".to_string(),
+        },
+    }
 }
 
 #[derive(Default)]
@@ -141,72 +233,191 @@ fn hash_task_name<K: Hash>(key: &K) -> u64 {
 }
 
 /// Builder for configuring asynchronous task execution before completion handling.
-pub struct TaskBuilder<T, E, Map = NoCompletion> {
+///
+/// Typical flow:
+/// 1. Build with [`Task::new`]
+/// 2. Configure options such as [`TaskBuilder::timeout`], [`TaskBuilder::retry`],
+///    and [`TaskBuilder::name`]
+/// 3. Optionally attach completion handling with [`TaskBuilder::on_result`]
+/// 4. Submit via `add_task(...)`
+pub struct TaskBuilder<T, E> {
     source: TaskSourceFn<T, E>,
     options: TaskSpawnOptions,
-    completion_handler: Map,
+    completion_handler:
+        Option<Box<dyn FnMut(TaskResult<T, E>, &mut ContextProxy) + Send + 'static>>,
 }
 
-pub struct NoCompletion;
-
-impl<T, E> TaskBuilder<T, E, NoCompletion>
+impl<T, E> TaskBuilder<T, E>
 where
     T: Send + 'static,
     E: Send + 'static,
 {
     fn new(source: TaskSourceFn<T, E>) -> Self {
-        Self { source, options: TaskSpawnOptions::default(), completion_handler: NoCompletion }
+        Self { source, options: TaskSpawnOptions::default(), completion_handler: None }
     }
 
     /// Handle task completion with direct access to the context proxy.
     ///
     /// Use this to emit one or many messages by calling `proxy.emit(...)` and/or
     /// `proxy.emit_to(...)` yourself.
-    pub fn on_result<Map>(self, completion_handler: Map) -> TaskBuilder<T, E, Map>
+    ///
+    /// This callback is invoked for every terminal result, including timeout,
+    /// cancellation, and worker disconnection.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// cx.add_task(
+    ///     Task::new(|_| async move { Ok::<usize, &'static str>(7) })
+    ///         .on_result(|result, proxy| {
+    ///             match result {
+    ///                 TaskResult::Completed(value) => {
+    ///                     let _ = proxy.emit(value);
+    ///                 }
+    ///                 TaskResult::Error(err) => {
+    ///                     let _ = proxy.emit(err.to_string());
+    ///                 }
+    ///                 TaskResult::Timeout | TaskResult::Cancelled => {}
+    ///                 TaskResult::Disconnected { panic } => {
+    ///                     if let Some(message) = panic {
+    ///                         eprintln!("task worker panicked: {message}");
+    ///                     }
+    ///                 }
+    ///             }
+    ///         }),
+    /// );
+    /// # }
+    /// ```
+    pub fn on_result<Map>(self, completion_handler: Map) -> Self
     where
         Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
     {
-        TaskBuilder { source: self.source, options: self.options, completion_handler }
+        let mut completion_handler = Some(completion_handler);
+        let completion_handler =
+            Box::new(move |result: TaskResult<T, E>, proxy: &mut ContextProxy| {
+                if let Some(handler) = completion_handler.take() {
+                    handler(result, proxy);
+                }
+            });
+
+        TaskBuilder {
+            source: self.source,
+            options: self.options,
+            completion_handler: Some(completion_handler),
+        }
     }
 }
 
-impl<T, E, Map> TaskBuilder<T, E, Map> {
+impl<T, E> TaskBuilder<T, E> {
     fn map_options(mut self, f: impl FnOnce(&mut TaskSpawnOptions)) -> Self {
         f(&mut self.options);
         self
     }
 
-    /// Set a timeout for completion waiting.
+    /// Set a timeout for each attempt.
     ///
-    /// If the timeout elapses, completion yields `TaskResult::Timeout`.
+    /// If an attempt exceeds this timeout, it is treated as timed out.
+    ///
+    /// When retries are enabled, a timed-out attempt can be retried. The final
+    /// completion state is [`TaskResult::Timeout`] only if all attempts time out.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # use std::time::Duration;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// cx.add_task(
+    ///     Task::new(|_| async move {
+    ///         tokio::time::sleep(Duration::from_secs(3)).await;
+    ///         Ok::<_, &'static str>(())
+    ///     })
+    ///     .timeout(Duration::from_millis(500))
+    ///     .on_result(|_, _| {}),
+    /// );
+    /// # }
+    /// ```
     pub fn timeout(self, timeout: Duration) -> Self {
         self.map_options(|options| options.timeout = Some(timeout))
     }
 
     /// Name this task and automatically cancel the previous in-flight task with the same key
     /// for this context/entity.
+    ///
+    /// This is useful for "latest wins" workflows such as search-as-you-type.
+    ///
+    /// The key is hashed and scoped to the submitting entity, so identical names
+    /// on different entities do not cancel each other.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// // A newer "search" task replaces and cancels the previous in-flight one.
+    /// cx.add_task(
+    ///     Task::new(|_| async move { Ok::<_, &'static str>(()) })
+    ///         .name("search")
+    ///         .on_result(|_, _| {}),
+    /// );
+    /// # }
+    /// ```
     pub fn name<K: Hash>(self, key: K) -> Self {
         self.map_options(|options| options.task_name_hash = Some(hash_task_name(&key)))
     }
 
-    /// Retry `Err(_)` or timed out attempts up to `retries` times.
+    /// Retry failed attempts up to `retries` times.
     ///
-    /// Total attempts = 1 + retries.
+    /// Retries apply to `Err(_)` and timed-out attempts.
+    ///
+    /// Total attempts = `1 + retries`.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use vizia_core::prelude::*;
+    /// # use std::time::Duration;
+    /// # #[cfg(feature = "tokio")]
+    /// # {
+    /// # let cx = Context::default();
+    /// let mut attempt = 0usize;
+    /// cx.add_task(
+    ///     Task::new(move |_| {
+    ///         attempt += 1;
+    ///         async move {
+    ///             if attempt < 3 {
+    ///                 Err::<(), _>("temporary error")
+    ///             } else {
+    ///                 Ok::<(), &'static str>(())
+    ///             }
+    ///         }
+    ///     })
+    ///     .retry(2)
+    ///     .retry_delay(Duration::from_millis(50))
+    ///     .on_result(|_, _| {}),
+    /// );
+    /// # }
+    /// ```
     pub fn retry(self, retries: usize) -> Self {
         self.map_options(|options| options.retries = retries)
     }
 
     /// Delay between retry attempts.
+    ///
+    /// This delay is only used when a retry is actually scheduled.
     pub fn retry_delay(self, delay: Duration) -> Self {
         self.map_options(|options| options.retry_delay = Some(delay))
     }
 }
 
-impl<T, E, Map> TaskBuilder<T, E, Map>
+impl<T, E> TaskBuilder<T, E>
 where
     T: Send + 'static,
     E: Send + 'static,
-    Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
 {
     pub(crate) fn add_to_context(self, cx: &Context) -> TaskHandle {
         execute_task_with_source(
@@ -233,19 +444,20 @@ where
     }
 }
 
-fn execute_task_with_source<T, E, Map>(
+fn execute_task_with_source<T, E>(
     mut proxy: ContextProxy,
     runtime: Arc<tokio::runtime::Runtime>,
     named_tasks: NamedTaskMap,
     task_entity: Option<Entity>,
     options: TaskSpawnOptions,
     mut source: TaskSourceFn<T, E>,
-    completion_handler: Map,
+    completion_handler: Option<
+        Box<dyn FnMut(TaskResult<T, E>, &mut ContextProxy) + Send + 'static>,
+    >,
 ) -> TaskHandle
 where
     T: Send + 'static,
     E: Send + 'static,
-    Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
 {
     let handle = TaskHandle::new();
     let cancelled = handle.cancelled_flag();
@@ -323,13 +535,19 @@ where
 
         let completion_result = match worker.await {
             Ok(result) => result,
-            Err(_) => TaskResult::Disconnected,
+            Err(join_error) => {
+                let panic =
+                    join_error.is_panic().then(|| panic_payload_to_string(join_error.into_panic()));
+                TaskResult::Disconnected { panic }
+            }
         };
 
         clear_named_task(&named_tasks, named_task_key, &cancelled);
         finished.store(true, Ordering::Release);
 
-        completion_handler(completion_result, &mut proxy);
+        if let Some(mut completion_handler) = completion_handler {
+            completion_handler(completion_result, &mut proxy);
+        }
     });
 
     handle
@@ -532,8 +750,10 @@ mod tests {
         );
 
         match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
-            TaskResult::Disconnected => {}
-            other => panic!("expected disconnected result, got {other:?}"),
+            TaskResult::Disconnected { panic: Some(message) } => {
+                assert!(message.contains("boom"));
+            }
+            other => panic!("expected disconnected panic result, got {other:?}"),
         }
     }
 

--- a/crates/vizia_core/src/context/task.rs
+++ b/crates/vizia_core/src/context/task.rs
@@ -1,0 +1,576 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
+
+use crate::context::{Context, ContextProxy, EventContext};
+use crate::entity::Entity;
+
+static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
+static NAMED_TASKS: LazyLock<Mutex<HashMap<NamedTaskKey, Arc<AtomicBool>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct NamedTaskKey {
+    scope: u64,
+    entity: Entity,
+    name_hash: u64,
+}
+
+/// Policy controlling when an async task attempt times out.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum TaskTimeoutPolicy {
+    /// No timeout is applied.
+    #[default]
+    None,
+    /// Cancel completion delivery if an attempt does not finish before the duration.
+    CancelAfter(Duration),
+}
+
+/// Policy controlling retry behavior for factory-based tasks.
+#[derive(Clone, Copy, Debug, Default)]
+pub enum TaskRetryPolicy {
+    /// Run exactly one attempt.
+    #[default]
+    None,
+    /// Retry failed attempts.
+    ///
+    /// Total attempts = 1 + retries.
+    Attempts { retries: usize, delay: Option<Duration> },
+}
+
+impl TaskRetryPolicy {
+    fn retries(self) -> usize {
+        match self {
+            TaskRetryPolicy::None => 0,
+            TaskRetryPolicy::Attempts { retries, .. } => retries,
+        }
+    }
+
+    fn delay(self) -> Option<Duration> {
+        match self {
+            TaskRetryPolicy::None => None,
+            TaskRetryPolicy::Attempts { delay, .. } => delay,
+        }
+    }
+}
+
+/// Opaque identifier for an asynchronous task submitted via `add_task(...)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TaskId(pub(crate) u64);
+
+/// Entry point for constructing async task pipelines.
+pub struct Task;
+
+impl Task {
+    /// Creates a task builder from a future factory source.
+    ///
+    /// Use a zero-arg closure for one-shot tasks, for example
+    /// `Task::new(|| async move { ... })`.
+    pub fn new<Factory, Fut>(factory: Factory) -> TaskBuilder<FactoryTask<Factory>>
+    where
+        Factory: FnMut() -> Fut + Send + 'static,
+        Fut: Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        TaskBuilder::new(FactoryTask::new(factory))
+    }
+}
+
+/// Handle for observing and cancelling an asynchronous task.
+#[derive(Debug, Clone)]
+pub struct TaskHandle {
+    id: TaskId,
+    cancelled: Arc<AtomicBool>,
+    finished: Arc<AtomicBool>,
+}
+
+impl TaskHandle {
+    pub(crate) fn new() -> Self {
+        Self {
+            id: TaskId(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            finished: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn cancelled_flag(&self) -> Arc<AtomicBool> {
+        self.cancelled.clone()
+    }
+
+    pub(crate) fn finished_flag(&self) -> Arc<AtomicBool> {
+        self.finished.clone()
+    }
+
+    /// Returns the task identifier.
+    pub fn id(&self) -> TaskId {
+        self.id
+    }
+
+    /// Requests cooperative cancellation.
+    ///
+    /// Returns `true` if this call changed the task into a cancelled state.
+    pub fn cancel(&self) -> bool {
+        !self.cancelled.swap(true, Ordering::AcqRel)
+    }
+
+    /// Returns `true` if cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Returns `true` when the task closure has completed.
+    pub fn is_finished(&self) -> bool {
+        self.finished.load(Ordering::Acquire)
+    }
+}
+
+/// Final completion state delivered to `TaskBuilder::on_result(...)`.
+#[derive(Debug)]
+pub enum TaskResult<T, E = Infallible> {
+    Completed(T),
+    Error(E),
+    Timeout,
+    Cancelled,
+    Disconnected,
+}
+
+impl<T, E> TaskResult<Result<T, E>> {
+    /// Flattens `TaskResult<Result<T, E>>` into `TaskResult<T, E>`.
+    pub fn flatten(self) -> TaskResult<T, E> {
+        match self {
+            TaskResult::Completed(Ok(value)) => TaskResult::Completed(value),
+            TaskResult::Completed(Err(error)) => TaskResult::Error(error),
+            TaskResult::Timeout => TaskResult::Timeout,
+            TaskResult::Cancelled => TaskResult::Cancelled,
+            TaskResult::Disconnected => TaskResult::Disconnected,
+            TaskResult::Error(never) => match never {},
+        }
+    }
+}
+
+#[derive(Default)]
+struct TaskSpawnOptions {
+    timeout_policy: TaskTimeoutPolicy,
+    retry_policy: TaskRetryPolicy,
+    task_name_hash: Option<u64>,
+    on_start: Option<Arc<dyn Fn() + Send + Sync>>,
+    on_retry: Option<Arc<dyn Fn(usize) + Send + Sync>>,
+    on_timeout: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+pub trait TaskSource: Send + 'static {
+    type Output: Send + 'static;
+    fn run_attempt(&mut self) -> Pin<Box<dyn Future<Output = Self::Output> + Send + 'static>>;
+    fn is_retry_capable(&self) -> bool;
+}
+
+#[doc(hidden)]
+pub enum TaskAttemptOutcome<T> {
+    Completed(T),
+    TimedOut,
+    Disconnected,
+}
+
+pub struct FactoryTask<Factory> {
+    factory: Factory,
+}
+
+impl<Factory> FactoryTask<Factory> {
+    fn new(factory: Factory) -> Self {
+        Self { factory }
+    }
+}
+
+impl<Factory, Fut> TaskSource for FactoryTask<Factory>
+where
+    Factory: FnMut() -> Fut + Send + 'static,
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    type Output = Fut::Output;
+
+    fn run_attempt(&mut self) -> Pin<Box<dyn Future<Output = Self::Output> + Send + 'static>> {
+        Box::pin((self.factory)())
+    }
+
+    fn is_retry_capable(&self) -> bool {
+        true
+    }
+}
+
+fn hash_task_name<K: Hash>(key: &K) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Context-like trait used by task builders to obtain a cross-thread event proxy.
+pub trait TaskContext {
+    fn task_proxy(&self) -> ContextProxy;
+    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime>;
+    fn task_scope(&self) -> u64;
+    fn task_entity(&self) -> Entity;
+}
+
+/// Trait implemented by built task pipelines that can be submitted to a context via
+/// `add_task(...)`.
+pub trait AddTask {
+    fn add_to<C: TaskContext>(self, cx: &C) -> TaskHandle;
+}
+
+impl TaskContext for Context {
+    fn task_proxy(&self) -> ContextProxy {
+        self.get_proxy()
+    }
+
+    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime> {
+        self.task_runtime.clone()
+    }
+
+    fn task_scope(&self) -> u64 {
+        self.context_id
+    }
+
+    fn task_entity(&self) -> Entity {
+        self.current
+    }
+}
+
+impl TaskContext for EventContext<'_> {
+    fn task_proxy(&self) -> ContextProxy {
+        self.get_proxy()
+    }
+
+    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime> {
+        self.task_runtime.clone()
+    }
+
+    fn task_scope(&self) -> u64 {
+        self.context_id
+    }
+
+    fn task_entity(&self) -> Entity {
+        self.current
+    }
+}
+
+/// Builder for configuring asynchronous task execution before completion handling.
+pub struct TaskBuilder<S> {
+    source: S,
+    options: TaskSpawnOptions,
+}
+
+impl<S> TaskBuilder<S>
+where
+    S: TaskSource,
+{
+    fn new(source: S) -> Self {
+        Self { source, options: TaskSpawnOptions::default() }
+    }
+
+    /// Set a timeout for completion waiting.
+    ///
+    /// If the timeout elapses, completion yields `TaskResult::Timeout`.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout_policy = TaskTimeoutPolicy::CancelAfter(timeout);
+        self
+    }
+
+    /// Set timeout behavior for completion waiting.
+    pub fn timeout_policy(mut self, policy: TaskTimeoutPolicy) -> Self {
+        self.options.timeout_policy = policy;
+        self
+    }
+
+    /// Name this task and automatically cancel the previous in-flight task with the same key
+    /// for this context/entity.
+    pub fn name<K: Hash>(mut self, key: K) -> Self {
+        self.options.task_name_hash = Some(hash_task_name(&key));
+        self
+    }
+
+    /// Call when the task worker starts processing attempts.
+    pub fn on_start<F>(mut self, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.options.on_start = Some(Arc::new(callback));
+        self
+    }
+
+    /// Call before each retry attempt. The argument is the retry index (starting at 1).
+    pub fn on_retry<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(usize) + Send + Sync + 'static,
+    {
+        self.options.on_retry = Some(Arc::new(callback));
+        self
+    }
+
+    /// Call when an attempt times out.
+    pub fn on_timeout<F>(mut self, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.options.on_timeout = Some(Arc::new(callback));
+        self
+    }
+
+    /// Retry failed attempts (timeouts/disconnected worker) up to `retries` times.
+    ///
+    /// Total attempts = 1 + retries.
+    pub fn retry(mut self, retries: usize) -> Self {
+        let delay = self.options.retry_policy.delay();
+        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay };
+        self
+    }
+
+    /// Delay between retry attempts.
+    pub fn retry_delay(mut self, delay: Duration) -> Self {
+        let retries = self.options.retry_policy.retries();
+        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay: Some(delay) };
+        self
+    }
+
+    /// Set retry behavior.
+    pub fn retry_policy(mut self, policy: TaskRetryPolicy) -> Self {
+        self.options.retry_policy = policy;
+        self
+    }
+
+    /// Handle task completion with direct access to the context proxy.
+    ///
+    /// Use this to emit one or many messages by calling `proxy.emit(...)` and/or
+    /// `proxy.emit_to(...)` yourself.
+    pub fn on_result<Map>(self, completion_handler: Map) -> CompletionTaskBuilder<S, Map>
+    where
+        Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+    {
+        CompletionTaskBuilder { source: self.source, completion_handler, options: self.options }
+    }
+}
+
+/// Builder for spawning an asynchronous task with completion handling.
+pub struct CompletionTaskBuilder<S, Map> {
+    source: S,
+    completion_handler: Map,
+    options: TaskSpawnOptions,
+}
+
+impl<S, Map> CompletionTaskBuilder<S, Map>
+where
+    S: TaskSource,
+    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+{
+    /// Set a timeout for completion waiting.
+    ///
+    /// If the timeout elapses, completion yields `TaskResult::Timeout`.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.options.timeout_policy = TaskTimeoutPolicy::CancelAfter(timeout);
+        self
+    }
+
+    /// Set timeout behavior for completion waiting.
+    pub fn timeout_policy(mut self, policy: TaskTimeoutPolicy) -> Self {
+        self.options.timeout_policy = policy;
+        self
+    }
+
+    /// Name this task and automatically cancel the previous in-flight task with the same key
+    /// for this context/entity.
+    pub fn name<K: Hash>(mut self, key: K) -> Self {
+        self.options.task_name_hash = Some(hash_task_name(&key));
+        self
+    }
+
+    /// Call when the task worker starts processing attempts.
+    pub fn on_start<F>(mut self, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.options.on_start = Some(Arc::new(callback));
+        self
+    }
+
+    /// Call before each retry attempt. The argument is the retry index (starting at 1).
+    pub fn on_retry<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(usize) + Send + Sync + 'static,
+    {
+        self.options.on_retry = Some(Arc::new(callback));
+        self
+    }
+
+    /// Call when an attempt times out.
+    pub fn on_timeout<F>(mut self, callback: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.options.on_timeout = Some(Arc::new(callback));
+        self
+    }
+
+    /// Retry failed attempts (timeouts/disconnected worker) up to `retries` times.
+    ///
+    /// Total attempts = 1 + retries.
+    pub fn retry(mut self, retries: usize) -> Self {
+        let delay = self.options.retry_policy.delay();
+        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay };
+        self
+    }
+
+    /// Delay between retry attempts.
+    pub fn retry_delay(mut self, delay: Duration) -> Self {
+        let retries = self.options.retry_policy.retries();
+        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay: Some(delay) };
+        self
+    }
+
+    /// Set retry behavior.
+    pub fn retry_policy(mut self, policy: TaskRetryPolicy) -> Self {
+        self.options.retry_policy = policy;
+        self
+    }
+}
+
+impl<S, Map> AddTask for CompletionTaskBuilder<S, Map>
+where
+    S: TaskSource,
+    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+{
+    fn add_to<C: TaskContext>(self, cx: &C) -> TaskHandle {
+        execute_task_with_source(
+            cx.task_proxy(),
+            cx.task_runtime(),
+            Some((cx.task_scope(), cx.task_entity())),
+            self.options,
+            self.source,
+            self.completion_handler,
+        )
+    }
+}
+
+fn execute_task_with_source<S, Map>(
+    mut proxy: ContextProxy,
+    runtime: Arc<tokio::runtime::Runtime>,
+    scope_info: Option<(u64, Entity)>,
+    options: TaskSpawnOptions,
+    mut source: S,
+    completion_handler: Map,
+) -> TaskHandle
+where
+    S: TaskSource,
+    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+{
+    let handle = TaskHandle::new();
+    let cancelled = handle.cancelled_flag();
+    let finished = handle.finished_flag();
+
+    let named_task_key = scope_info.and_then(|(scope, entity)| {
+        options.task_name_hash.map(|name_hash| NamedTaskKey { scope, entity, name_hash })
+    });
+
+    register_named_task(named_task_key, &cancelled);
+
+    runtime.spawn(async move {
+        if let Some(callback) = options.on_start.as_ref() {
+            callback();
+        }
+
+        let requested_attempts = options.retry_policy.retries().saturating_add(1);
+        let max_attempts = if source.is_retry_capable() { requested_attempts } else { 1 };
+
+        let mut maybe_output = None;
+        let mut timed_out = false;
+        let mut disconnected = false;
+        for attempt in 0..max_attempts {
+            if cancelled.load(Ordering::Acquire) {
+                break;
+            }
+
+            let attempt_outcome = match options.timeout_policy {
+                TaskTimeoutPolicy::None => {
+                    let output = source.run_attempt().await;
+                    TaskAttemptOutcome::Completed(output)
+                }
+                TaskTimeoutPolicy::CancelAfter(timeout) => {
+                    match tokio::time::timeout(timeout, source.run_attempt()).await {
+                        Ok(output) => TaskAttemptOutcome::Completed(output),
+                        Err(_) => TaskAttemptOutcome::TimedOut,
+                    }
+                }
+            };
+
+            match attempt_outcome {
+                TaskAttemptOutcome::Completed(output) => {
+                    maybe_output = Some(output);
+                    break;
+                }
+                TaskAttemptOutcome::TimedOut => {
+                    timed_out = true;
+                    if let Some(callback) = options.on_timeout.as_ref() {
+                        callback();
+                    }
+                }
+                TaskAttemptOutcome::Disconnected => {
+                    disconnected = true;
+                }
+            }
+
+            if attempt + 1 < max_attempts {
+                if let Some(callback) = options.on_retry.as_ref() {
+                    callback(attempt + 1);
+                }
+                if let Some(delay) = options.retry_policy.delay() {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+
+        let completion_result = if cancelled.load(Ordering::Acquire) {
+            TaskResult::Cancelled
+        } else if let Some(output) = maybe_output {
+            TaskResult::Completed(output)
+        } else if timed_out {
+            TaskResult::Timeout
+        } else if disconnected {
+            TaskResult::Disconnected
+        } else {
+            TaskResult::Cancelled
+        };
+
+        completion_handler(completion_result, &mut proxy);
+
+        clear_named_task(named_task_key, &cancelled);
+
+        finished.store(true, Ordering::Release);
+    });
+
+    handle
+}
+
+fn register_named_task(key: Option<NamedTaskKey>, cancelled: &Arc<AtomicBool>) {
+    if let Some(key) = key {
+        let mut map = NAMED_TASKS.lock().unwrap();
+        if let Some(previous_cancelled) = map.insert(key, cancelled.clone()) {
+            previous_cancelled.store(true, Ordering::Release);
+        }
+    }
+}
+
+fn clear_named_task(key: Option<NamedTaskKey>, cancelled: &Arc<AtomicBool>) {
+    if let Some(key) = key {
+        let mut map = NAMED_TASKS.lock().unwrap();
+        if let Some(current) = map.get(&key) {
+            if Arc::ptr_eq(current, cancelled) {
+                map.remove(&key);
+            }
+        }
+    }
+}

--- a/crates/vizia_core/src/context/task.rs
+++ b/crates/vizia_core/src/context/task.rs
@@ -87,8 +87,14 @@ impl TaskHandle {
     /// The cancellation request is visible to the running task body through the
     /// [`TaskCancellation`] token passed to [`Task::new`].
     ///
-    /// Returns `true` if this call changed the task into a cancelled state.
+    /// Returns `true` if this call requested cancellation for an in-flight task.
+    ///
+    /// Returns `false` if cancellation was already requested or the task already finished.
     pub fn cancel(&self) -> bool {
+        if self.is_finished() {
+            return false;
+        }
+
         !self.cancelled.swap(true, Ordering::AcqRel)
     }
 
@@ -295,7 +301,7 @@ where
                     attempt + 1 < max_attempts
                 };
 
-                if should_retry {
+                if should_retry && !worker_cancelled.load(Ordering::Acquire) {
                     if let Some(delay) = options.retry_delay {
                         tokio::time::sleep(delay).await;
                     }
@@ -587,5 +593,35 @@ mod tests {
             TaskResult::Completed(2) => {}
             other => panic!("expected replacement task to complete, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cancel_after_finish_returns_false_and_does_not_mark_cancelled() {
+        let runtime = test_runtime();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let builder = Task::new(|_| async move { Ok::<usize, std::convert::Infallible>(42usize) })
+            .on_result(move |result, _| {
+                result_tx.send(result).unwrap();
+            });
+
+        let handle = execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            test_named_tasks(),
+            None,
+            builder.options,
+            builder.source,
+            builder.completion_handler,
+        );
+
+        match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Completed(42) => {}
+            other => panic!("expected completed result, got {other:?}"),
+        }
+
+        assert!(handle.is_finished());
+        assert!(!handle.cancel());
+        assert!(!handle.is_cancelled());
     }
 }

--- a/crates/vizia_core/src/context/task.rs
+++ b/crates/vizia_core/src/context/task.rs
@@ -1,68 +1,21 @@
 use std::collections::HashMap;
-use std::convert::Infallible;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::context::{Context, ContextProxy, EventContext};
 use crate::entity::Entity;
 
-static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
-static NAMED_TASKS: LazyLock<Mutex<HashMap<NamedTaskKey, Arc<AtomicBool>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+type NamedTaskKey = (Entity, u64);
+pub(crate) type NamedTaskMap = Arc<Mutex<HashMap<NamedTaskKey, Arc<AtomicBool>>>>;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct NamedTaskKey {
-    scope: u64,
-    entity: Entity,
-    name_hash: u64,
+pub(crate) fn new_named_task_map() -> NamedTaskMap {
+    Arc::new(Mutex::new(HashMap::new()))
 }
-
-/// Policy controlling when an async task attempt times out.
-#[derive(Clone, Copy, Debug, Default)]
-pub enum TaskTimeoutPolicy {
-    /// No timeout is applied.
-    #[default]
-    None,
-    /// Cancel completion delivery if an attempt does not finish before the duration.
-    CancelAfter(Duration),
-}
-
-/// Policy controlling retry behavior for factory-based tasks.
-#[derive(Clone, Copy, Debug, Default)]
-pub enum TaskRetryPolicy {
-    /// Run exactly one attempt.
-    #[default]
-    None,
-    /// Retry failed attempts.
-    ///
-    /// Total attempts = 1 + retries.
-    Attempts { retries: usize, delay: Option<Duration> },
-}
-
-impl TaskRetryPolicy {
-    fn retries(self) -> usize {
-        match self {
-            TaskRetryPolicy::None => 0,
-            TaskRetryPolicy::Attempts { retries, .. } => retries,
-        }
-    }
-
-    fn delay(self) -> Option<Duration> {
-        match self {
-            TaskRetryPolicy::None => None,
-            TaskRetryPolicy::Attempts { delay, .. } => delay,
-        }
-    }
-}
-
-/// Opaque identifier for an asynchronous task submitted via `add_task(...)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TaskId(pub(crate) u64);
 
 /// Entry point for constructing async task pipelines.
 pub struct Task;
@@ -70,22 +23,45 @@ pub struct Task;
 impl Task {
     /// Creates a task builder from a future factory source.
     ///
-    /// Use a zero-arg closure for one-shot tasks, for example
-    /// `Task::new(|| async move { ... })`.
-    pub fn new<Factory, Fut>(factory: Factory) -> TaskBuilder<FactoryTask<Factory>>
+    /// The provided token is shared with [`TaskHandle::cancel`] and named-task replacement.
+    ///
+    /// Ignore the token for one-shot tasks, for example
+    /// `Task::new(|_| async move { Ok::<_, MyError>(value) })`.
+    pub fn new<Factory, Fut, T, E>(mut factory: Factory) -> TaskBuilder<T, E>
     where
-        Factory: FnMut() -> Fut + Send + 'static,
-        Fut: Future + Send + 'static,
-        Fut::Output: Send + 'static,
+        Factory: FnMut(TaskCancellation) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, E>> + Send + 'static,
+        T: Send + 'static,
+        E: Send + 'static,
     {
-        TaskBuilder::new(FactoryTask::new(factory))
+        let source = Box::new(move |cancellation: TaskCancellation| {
+            Box::pin(factory(cancellation))
+                as Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>
+        });
+        TaskBuilder::new(source)
+    }
+}
+
+/// Cooperative cancellation token passed to every [`Task::new`] attempt.
+#[derive(Debug, Clone)]
+pub struct TaskCancellation {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl TaskCancellation {
+    fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self { cancelled }
+    }
+
+    /// Returns `true` if cancellation has been requested for the task.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
     }
 }
 
 /// Handle for observing and cancelling an asynchronous task.
 #[derive(Debug, Clone)]
 pub struct TaskHandle {
-    id: TaskId,
     cancelled: Arc<AtomicBool>,
     finished: Arc<AtomicBool>,
 }
@@ -93,7 +69,6 @@ pub struct TaskHandle {
 impl TaskHandle {
     pub(crate) fn new() -> Self {
         Self {
-            id: TaskId(NEXT_TASK_ID.fetch_add(1, Ordering::Relaxed)),
             cancelled: Arc::new(AtomicBool::new(false)),
             finished: Arc::new(AtomicBool::new(false)),
         }
@@ -107,12 +82,10 @@ impl TaskHandle {
         self.finished.clone()
     }
 
-    /// Returns the task identifier.
-    pub fn id(&self) -> TaskId {
-        self.id
-    }
-
     /// Requests cooperative cancellation.
+    ///
+    /// The cancellation request is visible to the running task body through the
+    /// [`TaskCancellation`] token passed to [`Task::new`].
     ///
     /// Returns `true` if this call changed the task into a cancelled state.
     pub fn cancel(&self) -> bool {
@@ -132,77 +105,28 @@ impl TaskHandle {
 
 /// Final completion state delivered to `TaskBuilder::on_result(...)`.
 #[derive(Debug)]
-pub enum TaskResult<T, E = Infallible> {
+pub enum TaskResult<T, E> {
     Completed(T),
     Error(E),
     Timeout,
     Cancelled,
+    /// The worker task panicked or was aborted before producing a completion result.
     Disconnected,
-}
-
-impl<T, E> TaskResult<Result<T, E>> {
-    /// Flattens `TaskResult<Result<T, E>>` into `TaskResult<T, E>`.
-    pub fn flatten(self) -> TaskResult<T, E> {
-        match self {
-            TaskResult::Completed(Ok(value)) => TaskResult::Completed(value),
-            TaskResult::Completed(Err(error)) => TaskResult::Error(error),
-            TaskResult::Timeout => TaskResult::Timeout,
-            TaskResult::Cancelled => TaskResult::Cancelled,
-            TaskResult::Disconnected => TaskResult::Disconnected,
-            TaskResult::Error(never) => match never {},
-        }
-    }
 }
 
 #[derive(Default)]
 struct TaskSpawnOptions {
-    timeout_policy: TaskTimeoutPolicy,
-    retry_policy: TaskRetryPolicy,
+    timeout: Option<Duration>,
+    retries: usize,
+    retry_delay: Option<Duration>,
     task_name_hash: Option<u64>,
-    on_start: Option<Arc<dyn Fn() + Send + Sync>>,
-    on_retry: Option<Arc<dyn Fn(usize) + Send + Sync>>,
-    on_timeout: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
-pub trait TaskSource: Send + 'static {
-    type Output: Send + 'static;
-    fn run_attempt(&mut self) -> Pin<Box<dyn Future<Output = Self::Output> + Send + 'static>>;
-    fn is_retry_capable(&self) -> bool;
-}
-
-#[doc(hidden)]
-pub enum TaskAttemptOutcome<T> {
-    Completed(T),
-    TimedOut,
-    Disconnected,
-}
-
-pub struct FactoryTask<Factory> {
-    factory: Factory,
-}
-
-impl<Factory> FactoryTask<Factory> {
-    fn new(factory: Factory) -> Self {
-        Self { factory }
-    }
-}
-
-impl<Factory, Fut> TaskSource for FactoryTask<Factory>
-where
-    Factory: FnMut() -> Fut + Send + 'static,
-    Fut: Future + Send + 'static,
-    Fut::Output: Send + 'static,
-{
-    type Output = Fut::Output;
-
-    fn run_attempt(&mut self) -> Pin<Box<dyn Future<Output = Self::Output> + Send + 'static>> {
-        Box::pin((self.factory)())
-    }
-
-    fn is_retry_capable(&self) -> bool {
-        true
-    }
-}
+type TaskSourceFn<T, E> = Box<
+    dyn FnMut(TaskCancellation) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>
+        + Send
+        + 'static,
+>;
 
 fn hash_task_name<K: Hash>(key: &K) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -210,245 +134,92 @@ fn hash_task_name<K: Hash>(key: &K) -> u64 {
     hasher.finish()
 }
 
-/// Context-like trait used by task builders to obtain a cross-thread event proxy.
-pub trait TaskContext {
-    fn task_proxy(&self) -> ContextProxy;
-    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime>;
-    fn task_scope(&self) -> u64;
-    fn task_entity(&self) -> Entity;
-}
-
-/// Trait implemented by built task pipelines that can be submitted to a context via
-/// `add_task(...)`.
-pub trait AddTask {
-    fn add_to<C: TaskContext>(self, cx: &C) -> TaskHandle;
-}
-
-impl TaskContext for Context {
-    fn task_proxy(&self) -> ContextProxy {
-        self.get_proxy()
-    }
-
-    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime> {
-        self.task_runtime.clone()
-    }
-
-    fn task_scope(&self) -> u64 {
-        self.context_id
-    }
-
-    fn task_entity(&self) -> Entity {
-        self.current
-    }
-}
-
-impl TaskContext for EventContext<'_> {
-    fn task_proxy(&self) -> ContextProxy {
-        self.get_proxy()
-    }
-
-    fn task_runtime(&self) -> Arc<tokio::runtime::Runtime> {
-        self.task_runtime.clone()
-    }
-
-    fn task_scope(&self) -> u64 {
-        self.context_id
-    }
-
-    fn task_entity(&self) -> Entity {
-        self.current
-    }
-}
-
 /// Builder for configuring asynchronous task execution before completion handling.
-pub struct TaskBuilder<S> {
-    source: S,
+pub struct TaskBuilder<T, E, Map = NoCompletion> {
+    source: TaskSourceFn<T, E>,
     options: TaskSpawnOptions,
+    completion_handler: Map,
 }
 
-impl<S> TaskBuilder<S>
+pub struct NoCompletion;
+
+impl<T, E> TaskBuilder<T, E, NoCompletion>
 where
-    S: TaskSource,
+    T: Send + 'static,
+    E: Send + 'static,
 {
-    fn new(source: S) -> Self {
-        Self { source, options: TaskSpawnOptions::default() }
-    }
-
-    /// Set a timeout for completion waiting.
-    ///
-    /// If the timeout elapses, completion yields `TaskResult::Timeout`.
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.options.timeout_policy = TaskTimeoutPolicy::CancelAfter(timeout);
-        self
-    }
-
-    /// Set timeout behavior for completion waiting.
-    pub fn timeout_policy(mut self, policy: TaskTimeoutPolicy) -> Self {
-        self.options.timeout_policy = policy;
-        self
-    }
-
-    /// Name this task and automatically cancel the previous in-flight task with the same key
-    /// for this context/entity.
-    pub fn name<K: Hash>(mut self, key: K) -> Self {
-        self.options.task_name_hash = Some(hash_task_name(&key));
-        self
-    }
-
-    /// Call when the task worker starts processing attempts.
-    pub fn on_start<F>(mut self, callback: F) -> Self
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        self.options.on_start = Some(Arc::new(callback));
-        self
-    }
-
-    /// Call before each retry attempt. The argument is the retry index (starting at 1).
-    pub fn on_retry<F>(mut self, callback: F) -> Self
-    where
-        F: Fn(usize) + Send + Sync + 'static,
-    {
-        self.options.on_retry = Some(Arc::new(callback));
-        self
-    }
-
-    /// Call when an attempt times out.
-    pub fn on_timeout<F>(mut self, callback: F) -> Self
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        self.options.on_timeout = Some(Arc::new(callback));
-        self
-    }
-
-    /// Retry failed attempts (timeouts/disconnected worker) up to `retries` times.
-    ///
-    /// Total attempts = 1 + retries.
-    pub fn retry(mut self, retries: usize) -> Self {
-        let delay = self.options.retry_policy.delay();
-        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay };
-        self
-    }
-
-    /// Delay between retry attempts.
-    pub fn retry_delay(mut self, delay: Duration) -> Self {
-        let retries = self.options.retry_policy.retries();
-        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay: Some(delay) };
-        self
-    }
-
-    /// Set retry behavior.
-    pub fn retry_policy(mut self, policy: TaskRetryPolicy) -> Self {
-        self.options.retry_policy = policy;
-        self
+    fn new(source: TaskSourceFn<T, E>) -> Self {
+        Self { source, options: TaskSpawnOptions::default(), completion_handler: NoCompletion }
     }
 
     /// Handle task completion with direct access to the context proxy.
     ///
     /// Use this to emit one or many messages by calling `proxy.emit(...)` and/or
     /// `proxy.emit_to(...)` yourself.
-    pub fn on_result<Map>(self, completion_handler: Map) -> CompletionTaskBuilder<S, Map>
+    pub fn on_result<Map>(self, completion_handler: Map) -> TaskBuilder<T, E, Map>
     where
-        Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+        Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
     {
-        CompletionTaskBuilder { source: self.source, completion_handler, options: self.options }
+        TaskBuilder { source: self.source, options: self.options, completion_handler }
     }
 }
 
-/// Builder for spawning an asynchronous task with completion handling.
-pub struct CompletionTaskBuilder<S, Map> {
-    source: S,
-    completion_handler: Map,
-    options: TaskSpawnOptions,
-}
+impl<T, E, Map> TaskBuilder<T, E, Map> {
+    fn map_options(mut self, f: impl FnOnce(&mut TaskSpawnOptions)) -> Self {
+        f(&mut self.options);
+        self
+    }
 
-impl<S, Map> CompletionTaskBuilder<S, Map>
-where
-    S: TaskSource,
-    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
-{
     /// Set a timeout for completion waiting.
     ///
     /// If the timeout elapses, completion yields `TaskResult::Timeout`.
-    pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.options.timeout_policy = TaskTimeoutPolicy::CancelAfter(timeout);
-        self
-    }
-
-    /// Set timeout behavior for completion waiting.
-    pub fn timeout_policy(mut self, policy: TaskTimeoutPolicy) -> Self {
-        self.options.timeout_policy = policy;
-        self
+    pub fn timeout(self, timeout: Duration) -> Self {
+        self.map_options(|options| options.timeout = Some(timeout))
     }
 
     /// Name this task and automatically cancel the previous in-flight task with the same key
     /// for this context/entity.
-    pub fn name<K: Hash>(mut self, key: K) -> Self {
-        self.options.task_name_hash = Some(hash_task_name(&key));
-        self
+    pub fn name<K: Hash>(self, key: K) -> Self {
+        self.map_options(|options| options.task_name_hash = Some(hash_task_name(&key)))
     }
 
-    /// Call when the task worker starts processing attempts.
-    pub fn on_start<F>(mut self, callback: F) -> Self
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        self.options.on_start = Some(Arc::new(callback));
-        self
-    }
-
-    /// Call before each retry attempt. The argument is the retry index (starting at 1).
-    pub fn on_retry<F>(mut self, callback: F) -> Self
-    where
-        F: Fn(usize) + Send + Sync + 'static,
-    {
-        self.options.on_retry = Some(Arc::new(callback));
-        self
-    }
-
-    /// Call when an attempt times out.
-    pub fn on_timeout<F>(mut self, callback: F) -> Self
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        self.options.on_timeout = Some(Arc::new(callback));
-        self
-    }
-
-    /// Retry failed attempts (timeouts/disconnected worker) up to `retries` times.
+    /// Retry `Err(_)`, timed out, or disconnected attempts up to `retries` times.
     ///
     /// Total attempts = 1 + retries.
-    pub fn retry(mut self, retries: usize) -> Self {
-        let delay = self.options.retry_policy.delay();
-        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay };
-        self
+    pub fn retry(self, retries: usize) -> Self {
+        self.map_options(|options| options.retries = retries)
     }
 
     /// Delay between retry attempts.
-    pub fn retry_delay(mut self, delay: Duration) -> Self {
-        let retries = self.options.retry_policy.retries();
-        self.options.retry_policy = TaskRetryPolicy::Attempts { retries, delay: Some(delay) };
-        self
-    }
-
-    /// Set retry behavior.
-    pub fn retry_policy(mut self, policy: TaskRetryPolicy) -> Self {
-        self.options.retry_policy = policy;
-        self
+    pub fn retry_delay(self, delay: Duration) -> Self {
+        self.map_options(|options| options.retry_delay = Some(delay))
     }
 }
 
-impl<S, Map> AddTask for CompletionTaskBuilder<S, Map>
+impl<T, E, Map> TaskBuilder<T, E, Map>
 where
-    S: TaskSource,
-    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+    T: Send + 'static,
+    E: Send + 'static,
+    Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
 {
-    fn add_to<C: TaskContext>(self, cx: &C) -> TaskHandle {
+    pub(crate) fn add_to_context(self, cx: &Context) -> TaskHandle {
         execute_task_with_source(
-            cx.task_proxy(),
-            cx.task_runtime(),
-            Some((cx.task_scope(), cx.task_entity())),
+            cx.get_proxy(),
+            cx.task_runtime.clone(),
+            cx.named_tasks.clone(),
+            Some(cx.current),
+            self.options,
+            self.source,
+            self.completion_handler,
+        )
+    }
+
+    pub(crate) fn add_to_event_context(self, cx: &EventContext<'_>) -> TaskHandle {
+        execute_task_with_source(
+            cx.get_proxy(),
+            cx.task_runtime.clone(),
+            cx.named_tasks.clone(),
+            Some(cx.current),
             self.options,
             self.source,
             self.completion_handler,
@@ -456,98 +227,102 @@ where
     }
 }
 
-fn execute_task_with_source<S, Map>(
+fn execute_task_with_source<T, E, Map>(
     mut proxy: ContextProxy,
     runtime: Arc<tokio::runtime::Runtime>,
-    scope_info: Option<(u64, Entity)>,
+    named_tasks: NamedTaskMap,
+    task_entity: Option<Entity>,
     options: TaskSpawnOptions,
-    mut source: S,
+    mut source: TaskSourceFn<T, E>,
     completion_handler: Map,
 ) -> TaskHandle
 where
-    S: TaskSource,
-    Map: FnOnce(TaskResult<S::Output>, &mut ContextProxy) + Send + 'static,
+    T: Send + 'static,
+    E: Send + 'static,
+    Map: FnOnce(TaskResult<T, E>, &mut ContextProxy) + Send + 'static,
 {
     let handle = TaskHandle::new();
     let cancelled = handle.cancelled_flag();
     let finished = handle.finished_flag();
+    let cancellation = TaskCancellation::new(cancelled.clone());
+    let worker_cancelled = cancelled.clone();
 
-    let named_task_key = scope_info.and_then(|(scope, entity)| {
-        options.task_name_hash.map(|name_hash| NamedTaskKey { scope, entity, name_hash })
-    });
+    let named_task_key =
+        task_entity.and_then(|entity| options.task_name_hash.map(|name_hash| (entity, name_hash)));
 
-    register_named_task(named_task_key, &cancelled);
+    register_named_task(&named_tasks, named_task_key, &cancelled);
 
     runtime.spawn(async move {
-        if let Some(callback) = options.on_start.as_ref() {
-            callback();
-        }
+        let worker = tokio::spawn(async move {
+            let max_attempts = options.retries.saturating_add(1);
 
-        let requested_attempts = options.retry_policy.retries().saturating_add(1);
-        let max_attempts = if source.is_retry_capable() { requested_attempts } else { 1 };
-
-        let mut maybe_output = None;
-        let mut timed_out = false;
-        let mut disconnected = false;
-        for attempt in 0..max_attempts {
-            if cancelled.load(Ordering::Acquire) {
-                break;
-            }
-
-            let attempt_outcome = match options.timeout_policy {
-                TaskTimeoutPolicy::None => {
-                    let output = source.run_attempt().await;
-                    TaskAttemptOutcome::Completed(output)
-                }
-                TaskTimeoutPolicy::CancelAfter(timeout) => {
-                    match tokio::time::timeout(timeout, source.run_attempt()).await {
-                        Ok(output) => TaskAttemptOutcome::Completed(output),
-                        Err(_) => TaskAttemptOutcome::TimedOut,
-                    }
-                }
-            };
-
-            match attempt_outcome {
-                TaskAttemptOutcome::Completed(output) => {
-                    maybe_output = Some(output);
+            let mut maybe_output = None;
+            let mut maybe_error = None;
+            let mut timed_out = false;
+            for attempt in 0..max_attempts {
+                if worker_cancelled.load(Ordering::Acquire) {
                     break;
                 }
-                TaskAttemptOutcome::TimedOut => {
-                    timed_out = true;
-                    if let Some(callback) = options.on_timeout.as_ref() {
-                        callback();
+
+                let attempt_output = if let Some(timeout) = options.timeout {
+                    match tokio::time::timeout(timeout, source(cancellation.clone())).await {
+                        Ok(output) => Some(output),
+                        Err(_) => {
+                            timed_out = true;
+                            None
+                        }
+                    }
+                } else {
+                    Some(source(cancellation.clone()).await)
+                };
+
+                let should_retry = if let Some(output) = attempt_output {
+                    match output {
+                        Ok(value) => {
+                            maybe_output = Some(value);
+                            break;
+                        }
+                        Err(error) => {
+                            if attempt + 1 < max_attempts {
+                                true
+                            } else {
+                                maybe_error = Some(error);
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    attempt + 1 < max_attempts
+                };
+
+                if should_retry {
+                    if let Some(delay) = options.retry_delay {
+                        tokio::time::sleep(delay).await;
                     }
                 }
-                TaskAttemptOutcome::Disconnected => {
-                    disconnected = true;
-                }
             }
 
-            if attempt + 1 < max_attempts {
-                if let Some(callback) = options.on_retry.as_ref() {
-                    callback(attempt + 1);
-                }
-                if let Some(delay) = options.retry_policy.delay() {
-                    tokio::time::sleep(delay).await;
-                }
+            if worker_cancelled.load(Ordering::Acquire) {
+                TaskResult::Cancelled
+            } else if let Some(output) = maybe_output {
+                TaskResult::Completed(output)
+            } else if let Some(error) = maybe_error {
+                TaskResult::Error(error)
+            } else if timed_out {
+                TaskResult::Timeout
+            } else {
+                TaskResult::Cancelled
             }
-        }
+        });
 
-        let completion_result = if cancelled.load(Ordering::Acquire) {
-            TaskResult::Cancelled
-        } else if let Some(output) = maybe_output {
-            TaskResult::Completed(output)
-        } else if timed_out {
-            TaskResult::Timeout
-        } else if disconnected {
-            TaskResult::Disconnected
-        } else {
-            TaskResult::Cancelled
+        let completion_result = match worker.await {
+            Ok(result) => result,
+            Err(_) => TaskResult::Disconnected,
         };
 
         completion_handler(completion_result, &mut proxy);
 
-        clear_named_task(named_task_key, &cancelled);
+        clear_named_task(&named_tasks, named_task_key, &cancelled);
 
         finished.store(true, Ordering::Release);
     });
@@ -555,22 +330,263 @@ where
     handle
 }
 
-fn register_named_task(key: Option<NamedTaskKey>, cancelled: &Arc<AtomicBool>) {
+fn register_named_task(
+    named_tasks: &NamedTaskMap,
+    key: Option<NamedTaskKey>,
+    cancelled: &Arc<AtomicBool>,
+) {
     if let Some(key) = key {
-        let mut map = NAMED_TASKS.lock().unwrap();
+        let mut map = named_tasks.lock().unwrap();
         if let Some(previous_cancelled) = map.insert(key, cancelled.clone()) {
             previous_cancelled.store(true, Ordering::Release);
         }
     }
 }
 
-fn clear_named_task(key: Option<NamedTaskKey>, cancelled: &Arc<AtomicBool>) {
+fn clear_named_task(
+    named_tasks: &NamedTaskMap,
+    key: Option<NamedTaskKey>,
+    cancelled: &Arc<AtomicBool>,
+) {
     if let Some(key) = key {
-        let mut map = NAMED_TASKS.lock().unwrap();
+        let mut map = named_tasks.lock().unwrap();
         if let Some(current) = map.get(&key) {
             if Arc::ptr_eq(current, cancelled) {
                 map.remove(&key);
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::mpsc;
+    use vizia_id::GenerationalId;
+
+    fn test_runtime() -> Arc<tokio::runtime::Runtime> {
+        Arc::new(tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap())
+    }
+
+    fn test_proxy() -> ContextProxy {
+        ContextProxy { current: Entity::root(), event_proxy: None }
+    }
+
+    fn test_named_tasks() -> NamedTaskMap {
+        new_named_task_map()
+    }
+
+    #[test]
+    fn cancellation_token_tracks_handle_cancel() {
+        let runtime = test_runtime();
+        let observed = Arc::new(AtomicBool::new(false));
+        let observed_clone = observed.clone();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let builder = Task::new(move |cancellation| {
+            let started_tx = started_tx.clone();
+            let observed = observed_clone.clone();
+            async move {
+                let _ = started_tx.send(());
+                loop {
+                    if cancellation.is_cancelled() {
+                        observed.store(true, Ordering::Release);
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+
+                Ok::<(), std::convert::Infallible>(())
+            }
+        })
+        .on_result(move |result, _| {
+            result_tx.send(result).unwrap();
+        });
+
+        let handle = execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            test_named_tasks(),
+            None,
+            builder.options,
+            builder.source,
+            builder.completion_handler,
+        );
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(handle.cancel());
+
+        match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Cancelled => {}
+            other => panic!("expected cancelled result, got {other:?}"),
+        }
+        assert!(observed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn retry_retries_error_outputs() {
+        let runtime = test_runtime();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let builder = Task::new(move |_| {
+            let attempts = attempts_clone.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, AtomicOrdering::AcqRel) + 1;
+                if attempt < 3 { Err(attempt) } else { Ok(attempt) }
+            }
+        })
+        .retry(2)
+        .on_result(move |result, _| {
+            result_tx.send(result).unwrap();
+        });
+
+        execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            test_named_tasks(),
+            None,
+            builder.options,
+            builder.source,
+            builder.completion_handler,
+        );
+
+        match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Completed(3) => {}
+            other => panic!("expected completed retry result, got {other:?}"),
+        }
+        assert_eq!(attempts.load(AtomicOrdering::Acquire), 3);
+    }
+
+    #[test]
+    fn timeout_retries_before_completing() {
+        let runtime = test_runtime();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = attempts.clone();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let builder = Task::new(move |_| {
+            let attempts = attempts_clone.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, AtomicOrdering::AcqRel) + 1;
+                if attempt == 1 {
+                    tokio::time::sleep(Duration::from_millis(30)).await;
+                }
+                Ok::<usize, std::convert::Infallible>(attempt)
+            }
+        })
+        .timeout(Duration::from_millis(5))
+        .retry(1)
+        .on_result(move |result, _| {
+            result_tx.send(result).unwrap();
+        });
+
+        execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            test_named_tasks(),
+            None,
+            builder.options,
+            builder.source,
+            builder.completion_handler,
+        );
+
+        match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Completed(2) => {}
+            other => panic!("expected second attempt to complete, got {other:?}"),
+        }
+        assert_eq!(attempts.load(AtomicOrdering::Acquire), 2);
+    }
+
+    #[test]
+    fn disconnected_result_is_reported_when_worker_panics() {
+        let runtime = test_runtime();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let builder = Task::new(|_| async move {
+            panic!("boom");
+            #[allow(unreachable_code)]
+            Ok::<(), ()>(())
+        })
+        .on_result(move |result, _| {
+            result_tx.send(result).unwrap();
+        });
+
+        execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            test_named_tasks(),
+            None,
+            builder.options,
+            builder.source,
+            builder.completion_handler,
+        );
+
+        match result_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Disconnected => {}
+            other => panic!("expected disconnected result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn named_task_replacement_cancels_previous_task() {
+        let runtime = test_runtime();
+        let (first_tx, first_rx) = mpsc::channel();
+        let (second_tx, second_rx) = mpsc::channel();
+
+        let first_builder = Task::new(move |cancellation| async move {
+            loop {
+                if cancellation.is_cancelled() {
+                    break Ok::<usize, std::convert::Infallible>(1usize);
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .name("shared-task")
+        .on_result(move |result, _| {
+            first_tx.send(result).unwrap();
+        });
+
+        let second_builder =
+            Task::new(|_| async move { Ok::<usize, std::convert::Infallible>(2usize) })
+                .name("shared-task")
+                .on_result(move |result, _| {
+                    second_tx.send(result).unwrap();
+                });
+
+        let named_tasks = test_named_tasks();
+
+        execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            named_tasks.clone(),
+            Some(Entity::root()),
+            first_builder.options,
+            first_builder.source,
+            first_builder.completion_handler,
+        );
+
+        execute_task_with_source(
+            test_proxy(),
+            runtime.clone(),
+            named_tasks,
+            Some(Entity::root()),
+            second_builder.options,
+            second_builder.source,
+            second_builder.completion_handler,
+        );
+
+        match first_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Cancelled => {}
+            other => panic!("expected first task to be cancelled, got {other:?}"),
+        }
+        match second_rx.recv_timeout(Duration::from_secs(1)).unwrap() {
+            TaskResult::Completed(2) => {}
+            other => panic!("expected replacement task to complete, got {other:?}"),
         }
     }
 }

--- a/crates/vizia_core/src/context/task.rs
+++ b/crates/vizia_core/src/context/task.rs
@@ -183,7 +183,7 @@ impl<T, E, Map> TaskBuilder<T, E, Map> {
         self.map_options(|options| options.task_name_hash = Some(hash_task_name(&key)))
     }
 
-    /// Retry `Err(_)`, timed out, or disconnected attempts up to `retries` times.
+    /// Retry `Err(_)` or timed out attempts up to `retries` times.
     ///
     /// Total attempts = 1 + retries.
     pub fn retry(self, retries: usize) -> Self {
@@ -320,11 +320,10 @@ where
             Err(_) => TaskResult::Disconnected,
         };
 
-        completion_handler(completion_result, &mut proxy);
-
         clear_named_task(&named_tasks, named_task_key, &cancelled);
-
         finished.store(true, Ordering::Release);
+
+        completion_handler(completion_result, &mut proxy);
     });
 
     handle

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -79,10 +79,7 @@ pub mod prelude {
         EventContext, ProxyEmitError, WindowState,
     };
     #[cfg(feature = "tokio")]
-    pub use super::context::{
-        AddTask, CompletionTaskBuilder, Task, TaskBuilder, TaskContext, TaskHandle, TaskId,
-        TaskResult, TaskRetryPolicy, TaskTimeoutPolicy,
-    };
+    pub use super::context::{Task, TaskBuilder, TaskCancellation, TaskHandle, TaskResult};
     pub use super::entity::Entity;
     pub use super::environment::{Environment, EnvironmentEvent, ThemeMode};
     pub use super::events::{Event, Propagation, Timer, TimerAction};

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -75,8 +75,10 @@ pub mod prelude {
 
     pub use super::animation::{Animation, AnimationBuilder, KeyframeBuilder};
     pub use super::context::{
-        AccessContext, AccessNode, Context, ContextProxy, DataContext, DrawContext, EmitContext,
-        EventContext, ProxyEmitError, WindowState,
+        AccessContext, AccessNode, AddTask, CompletionTaskBuilder, Context, ContextProxy,
+        DataContext, DrawContext, EmitContext, EventContext, ProxyEmitError, Task, TaskBuilder,
+        TaskContext, TaskHandle, TaskId, TaskResult, TaskRetryPolicy, TaskTimeoutPolicy,
+        WindowState,
     };
     pub use super::entity::Entity;
     pub use super::environment::{Environment, EnvironmentEvent, ThemeMode};

--- a/crates/vizia_core/src/lib.rs
+++ b/crates/vizia_core/src/lib.rs
@@ -75,10 +75,13 @@ pub mod prelude {
 
     pub use super::animation::{Animation, AnimationBuilder, KeyframeBuilder};
     pub use super::context::{
-        AccessContext, AccessNode, AddTask, CompletionTaskBuilder, Context, ContextProxy,
-        DataContext, DrawContext, EmitContext, EventContext, ProxyEmitError, Task, TaskBuilder,
-        TaskContext, TaskHandle, TaskId, TaskResult, TaskRetryPolicy, TaskTimeoutPolicy,
-        WindowState,
+        AccessContext, AccessNode, Context, ContextProxy, DataContext, DrawContext, EmitContext,
+        EventContext, ProxyEmitError, WindowState,
+    };
+    #[cfg(feature = "tokio")]
+    pub use super::context::{
+        AddTask, CompletionTaskBuilder, Task, TaskBuilder, TaskContext, TaskHandle, TaskId,
+        TaskResult, TaskRetryPolicy, TaskTimeoutPolicy,
     };
     pub use super::entity::Entity;
     pub use super::environment::{Environment, EnvironmentEvent, ThemeMode};

--- a/examples/gallery/Cargo.toml
+++ b/examples/gallery/Cargo.toml
@@ -8,8 +8,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-vizia.workspace = true
-tokio.workspace = true
+vizia = { workspace = true, features = ["tokio"] }
 serde.workspace = true
 reqwest.workspace = true
 bytes = "1"

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -11,7 +11,6 @@ pub struct AppData {
     images: Signal<Vec<Vec<Id>>>,
     thumbnails: Signal<HashMap<Id, (ImageData, Status)>>,
     original: Signal<Option<Id>>,
-    runtime: tokio::runtime::Runtime,
 }
 
 type GallerySignals =
@@ -19,19 +18,31 @@ type GallerySignals =
 
 impl AppData {
     pub fn create(cx: &mut Context) -> GallerySignals {
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-
-        let mut c = cx.get_proxy();
-        runtime.spawn(async move {
-            let images = list().await;
-            let _ = c.emit(AppEvent::ImagesListed(images));
-        });
+        cx.add_task(Task::new(|| async move { list().await }).on_result(|result, proxy| {
+            match result.flatten() {
+                TaskResult::Completed(images) => {
+                    let _ = proxy.emit(AppEvent::ImagesListed(Ok(images)));
+                }
+                TaskResult::Error(error) => {
+                    let _ = proxy.emit(AppEvent::ImagesListed(Err(error)));
+                }
+                TaskResult::Timeout => {
+                    eprintln!("Image list request timed out");
+                }
+                TaskResult::Cancelled => {
+                    eprintln!("Image list request was cancelled");
+                }
+                TaskResult::Disconnected => {
+                    eprintln!("Image list worker disconnected");
+                }
+            }
+        }));
 
         let images = Signal::new(Vec::default());
         let thumbnails = Signal::new(HashMap::default());
         let original = Signal::new(None);
 
-        Self { images, thumbnails, original, runtime }.build(cx);
+        Self { images, thumbnails, original }.build(cx);
 
         (images, thumbnails, original)
     }
@@ -64,12 +75,32 @@ impl Model for AppData {
                         tn.1 = Status::Loading;
                     }
                 });
-                if let Some(image) = self.thumbnails.get().get(&id).cloned() {
-                    let mut c = cx.get_proxy();
-                    self.runtime.spawn(async move {
-                        let image = download(image.0.url, Size::Thumbnail).await;
-                        let _ = c.emit(AppEvent::ImageDownloaded(id, image));
-                    });
+                if let Some(url) = self.thumbnails.get().get(&id).map(|image| image.0.url.clone()) {
+                    cx.add_task(
+                        Task::new(move || {
+                            let url = url.clone();
+                            async move { download(url, Size::Thumbnail).await }
+                        })
+                        .on_result(move |result, proxy| {
+                            match result.flatten() {
+                                TaskResult::Completed(image) => {
+                                    let _ = proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
+                                }
+                                TaskResult::Error(error) => {
+                                    let _ = proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
+                                }
+                                TaskResult::Timeout => {
+                                    eprintln!("Thumbnail download timed out for image {}", id.0);
+                                }
+                                TaskResult::Cancelled => {
+                                    eprintln!("Thumbnail download cancelled for image {}", id.0);
+                                }
+                                TaskResult::Disconnected => {
+                                    eprintln!("Thumbnail worker disconnected for image {}", id.0);
+                                }
+                            }
+                        }),
+                    );
                 }
             }
 
@@ -100,14 +131,33 @@ impl Model for AppData {
             }
 
             AppEvent::ShowOriginal(id) => {
-                if let Some(image) = self.thumbnails.get().get(&id).cloned() {
-                    let mut c = cx.get_proxy();
-                    self.runtime.block_on(async move {
-                        tokio::spawn(async move {
-                            let image = download(image.0.url, Size::Original).await;
-                            let _ = c.emit(AppEvent::OriginalDownloaded(id, image));
-                        });
-                    });
+                if let Some(url) = self.thumbnails.get().get(&id).map(|image| image.0.url.clone()) {
+                    cx.add_task(
+                        Task::new(move || {
+                            let url = url.clone();
+                            async move { download(url, Size::Original).await }
+                        })
+                        .on_result(move |result, proxy| {
+                            match result.flatten() {
+                                TaskResult::Completed(image) => {
+                                    let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
+                                }
+                                TaskResult::Error(error) => {
+                                    let _ =
+                                        proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
+                                }
+                                TaskResult::Timeout => {
+                                    eprintln!("Original download timed out for image {}", id.0);
+                                }
+                                TaskResult::Cancelled => {
+                                    eprintln!("Original download cancelled for image {}", id.0);
+                                }
+                                TaskResult::Disconnected => {
+                                    eprintln!("Original worker disconnected for image {}", id.0);
+                                }
+                            }
+                        }),
+                    );
                 }
             }
 

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -21,10 +21,10 @@ impl AppData {
         cx.add_task(Task::new(|_| async move { list().await }).on_result(|result, proxy| {
             match result {
                 TaskResult::Completed(images) => {
-                    let _ = proxy.emit(AppEvent::ImagesListed(Ok(images)));
+                    proxy.emit(AppEvent::ImagesListed(Ok(images)));
                 }
                 TaskResult::Error(error) => {
-                    let _ = proxy.emit(AppEvent::ImagesListed(Err(error)));
+                    proxy.emit(AppEvent::ImagesListed(Err(error)));
                 }
                 TaskResult::Timeout => {
                     eprintln!("Image list request timed out");
@@ -83,10 +83,10 @@ impl Model for AppData {
                         })
                         .on_result(move |result, proxy| match result {
                             TaskResult::Completed(image) => {
-                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
+                                proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
                             }
                             TaskResult::Error(error) => {
-                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
+                                proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
                             }
                             TaskResult::Timeout => {
                                 eprintln!("Thumbnail download timed out for image {}", id.0);
@@ -137,10 +137,10 @@ impl Model for AppData {
                         })
                         .on_result(move |result, proxy| match result {
                             TaskResult::Completed(image) => {
-                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
+                                proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
                             }
                             TaskResult::Error(error) => {
-                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
+                                proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
                             }
                             TaskResult::Timeout => {
                                 eprintln!("Original download timed out for image {}", id.0);

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -21,10 +21,10 @@ impl AppData {
         cx.add_task(Task::new(|_| async move { list().await }).on_result(|result, proxy| {
             match result {
                 TaskResult::Completed(images) => {
-                    proxy.emit(AppEvent::ImagesListed(Ok(images)));
+                    let _ = proxy.emit(AppEvent::ImagesListed(Ok(images)));
                 }
                 TaskResult::Error(error) => {
-                    proxy.emit(AppEvent::ImagesListed(Err(error)));
+                    let _ = proxy.emit(AppEvent::ImagesListed(Err(error)));
                 }
                 TaskResult::Timeout => {
                     eprintln!("Image list request timed out");
@@ -83,10 +83,10 @@ impl Model for AppData {
                         })
                         .on_result(move |result, proxy| match result {
                             TaskResult::Completed(image) => {
-                                proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
+                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
                             }
                             TaskResult::Error(error) => {
-                                proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
+                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
                             }
                             TaskResult::Timeout => {
                                 eprintln!("Thumbnail download timed out for image {}", id.0);
@@ -137,10 +137,10 @@ impl Model for AppData {
                         })
                         .on_result(move |result, proxy| match result {
                             TaskResult::Completed(image) => {
-                                proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
+                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
                             }
                             TaskResult::Error(error) => {
-                                proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
+                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
                             }
                             TaskResult::Timeout => {
                                 eprintln!("Original download timed out for image {}", id.0);

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -18,8 +18,8 @@ type GallerySignals =
 
 impl AppData {
     pub fn create(cx: &mut Context) -> GallerySignals {
-        cx.add_task(Task::new(|| async move { list().await }).on_result(|result, proxy| {
-            match result.flatten() {
+        cx.add_task(Task::new(|_| async move { list().await }).on_result(|result, proxy| {
+            match result {
                 TaskResult::Completed(images) => {
                     let _ = proxy.emit(AppEvent::ImagesListed(Ok(images)));
                 }
@@ -77,27 +77,25 @@ impl Model for AppData {
                 });
                 if let Some(url) = self.thumbnails.get().get(&id).map(|image| image.0.url.clone()) {
                     cx.add_task(
-                        Task::new(move || {
+                        Task::new(move |_| {
                             let url = url.clone();
                             async move { download(url, Size::Thumbnail).await }
                         })
-                        .on_result(move |result, proxy| {
-                            match result.flatten() {
-                                TaskResult::Completed(image) => {
-                                    let _ = proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
-                                }
-                                TaskResult::Error(error) => {
-                                    let _ = proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
-                                }
-                                TaskResult::Timeout => {
-                                    eprintln!("Thumbnail download timed out for image {}", id.0);
-                                }
-                                TaskResult::Cancelled => {
-                                    eprintln!("Thumbnail download cancelled for image {}", id.0);
-                                }
-                                TaskResult::Disconnected => {
-                                    eprintln!("Thumbnail worker disconnected for image {}", id.0);
-                                }
+                        .on_result(move |result, proxy| match result {
+                            TaskResult::Completed(image) => {
+                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Ok(image)));
+                            }
+                            TaskResult::Error(error) => {
+                                let _ = proxy.emit(AppEvent::ImageDownloaded(id, Err(error)));
+                            }
+                            TaskResult::Timeout => {
+                                eprintln!("Thumbnail download timed out for image {}", id.0);
+                            }
+                            TaskResult::Cancelled => {
+                                eprintln!("Thumbnail download cancelled for image {}", id.0);
+                            }
+                            TaskResult::Disconnected => {
+                                eprintln!("Thumbnail worker disconnected for image {}", id.0);
                             }
                         }),
                     );
@@ -133,28 +131,25 @@ impl Model for AppData {
             AppEvent::ShowOriginal(id) => {
                 if let Some(url) = self.thumbnails.get().get(&id).map(|image| image.0.url.clone()) {
                     cx.add_task(
-                        Task::new(move || {
+                        Task::new(move |_| {
                             let url = url.clone();
                             async move { download(url, Size::Original).await }
                         })
-                        .on_result(move |result, proxy| {
-                            match result.flatten() {
-                                TaskResult::Completed(image) => {
-                                    let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
-                                }
-                                TaskResult::Error(error) => {
-                                    let _ =
-                                        proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
-                                }
-                                TaskResult::Timeout => {
-                                    eprintln!("Original download timed out for image {}", id.0);
-                                }
-                                TaskResult::Cancelled => {
-                                    eprintln!("Original download cancelled for image {}", id.0);
-                                }
-                                TaskResult::Disconnected => {
-                                    eprintln!("Original worker disconnected for image {}", id.0);
-                                }
+                        .on_result(move |result, proxy| match result {
+                            TaskResult::Completed(image) => {
+                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Ok(image)));
+                            }
+                            TaskResult::Error(error) => {
+                                let _ = proxy.emit(AppEvent::OriginalDownloaded(id, Err(error)));
+                            }
+                            TaskResult::Timeout => {
+                                eprintln!("Original download timed out for image {}", id.0);
+                            }
+                            TaskResult::Cancelled => {
+                                eprintln!("Original download cancelled for image {}", id.0);
+                            }
+                            TaskResult::Disconnected => {
+                                eprintln!("Original worker disconnected for image {}", id.0);
                             }
                         }),
                     );

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -32,7 +32,7 @@ impl AppData {
                 TaskResult::Cancelled => {
                     eprintln!("Image list request was cancelled");
                 }
-                TaskResult::Disconnected => {
+                TaskResult::Disconnected { .. } => {
                     eprintln!("Image list worker disconnected");
                 }
             }
@@ -94,7 +94,7 @@ impl Model for AppData {
                             TaskResult::Cancelled => {
                                 eprintln!("Thumbnail download cancelled for image {}", id.0);
                             }
-                            TaskResult::Disconnected => {
+                            TaskResult::Disconnected { .. } => {
                                 eprintln!("Thumbnail worker disconnected for image {}", id.0);
                             }
                         }),
@@ -148,7 +148,7 @@ impl Model for AppData {
                             TaskResult::Cancelled => {
                                 eprintln!("Original download cancelled for image {}", id.0);
                             }
-                            TaskResult::Disconnected => {
+                            TaskResult::Disconnected { .. } => {
                                 eprintln!("Original worker disconnected for image {}", id.0);
                             }
                         }),

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -1,0 +1,188 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
+
+use vizia::prelude::*;
+
+#[derive(Clone)]
+enum AppEvent {
+    StartDownload,
+    DownloadProgress(u32, f32),
+    DownloadFinished(u32, String),
+    DownloadFailed(u32, String),
+}
+
+struct AppData {
+    status: Signal<String>,
+    progress: Signal<f32>,
+    request_id: Signal<u32>,
+    active_download: Option<TaskHandle>,
+    active_cancel: Option<Arc<AtomicBool>>,
+}
+
+impl AppData {
+    fn new(cx: &mut Context) -> (Signal<String>, Signal<f32>) {
+        let status = Signal::new("Press Download File to start".to_string());
+        let progress = Signal::new(0.0);
+
+        Self {
+            status,
+            progress,
+            request_id: Signal::new(0),
+            active_download: None,
+            active_cancel: None,
+        }
+        .build(cx);
+
+        (status, progress)
+    }
+}
+
+impl Model for AppData {
+    fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
+        event.take(|app_event, _| match app_event {
+            AppEvent::StartDownload => {
+                if let Some(handle) = self.active_download.take() {
+                    handle.cancel();
+                }
+                if let Some(cancel_flag) = self.active_cancel.take() {
+                    cancel_flag.store(true, Ordering::Release);
+                }
+
+                let request = self.request_id.get().saturating_add(1);
+                self.request_id.set(request);
+                self.progress.set(0.0);
+
+                let file_name = format!("report-{}.zip", request);
+                self.status.set(format!("Downloading {}...", file_name));
+
+                // Build a fresh future per attempt so retry policies can re-run work.
+                let mut attempt = 0usize;
+                let cancel_flag = Arc::new(AtomicBool::new(false));
+                let proxy = cx.get_proxy();
+                let task_cancel = cancel_flag.clone();
+                let handle = cx.add_task(
+                    Task::new(move || {
+                        attempt = attempt.saturating_add(1);
+                        let attempt_num = attempt;
+                        let file_name = file_name.clone();
+                        let cancel_flag = task_cancel.clone();
+                        let mut proxy = proxy.clone();
+
+                        async move {
+                            // Simulate a large file transfer with chunked progress over several seconds.
+                            let total_chunks = 40_u32;
+                            for chunk in 1..=total_chunks {
+                                if cancel_flag.load(Ordering::Acquire) {
+                                    return Err(format!("Cancelled {}", file_name));
+                                }
+                                std::thread::sleep(Duration::from_millis(120));
+                                let progress = (chunk as f32 / total_chunks as f32) * 0.95;
+                                let _ = proxy.emit(AppEvent::DownloadProgress(request, progress));
+                            }
+
+                            if request % 4 == 0 {
+                                Err(format!("Server rejected {}", file_name))
+                            } else {
+                                Ok(format!("Downloaded {} on attempt {}", file_name, attempt_num))
+                            }
+                        }
+                    })
+                    .name("download-file")
+                    .timeout_policy(TaskTimeoutPolicy::CancelAfter(Duration::from_secs(8)))
+                    .retry_policy(TaskRetryPolicy::Attempts {
+                        retries: 1,
+                        delay: Some(Duration::from_millis(20)),
+                    })
+                    .on_result(move |result, proxy| match result.flatten() {
+                        TaskResult::Completed(status) => {
+                            let _ = proxy.emit(AppEvent::DownloadFinished(request, status));
+                        }
+                        TaskResult::Error(error) => {
+                            let _ = proxy.emit(AppEvent::DownloadFailed(request, error));
+                        }
+                        TaskResult::Timeout => {
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                                request,
+                                "Download timed out".to_string(),
+                            ));
+                        }
+                        TaskResult::Cancelled => {
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                                request,
+                                "Download cancelled".to_string(),
+                            ));
+                        }
+                        TaskResult::Disconnected => {
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                                request,
+                                "Task worker disconnected".to_string(),
+                            ));
+                        }
+                    }),
+                );
+
+                self.active_cancel = Some(cancel_flag);
+                self.active_download = Some(handle);
+            }
+
+            AppEvent::DownloadProgress(request, progress) => {
+                if request != self.request_id.get() {
+                    return;
+                }
+                self.progress.set(progress.clamp(0.0, 1.0));
+            }
+
+            AppEvent::DownloadFinished(request, status) => {
+                if request != self.request_id.get() {
+                    return;
+                }
+                self.active_download = None;
+                self.active_cancel = None;
+                self.progress.set(1.0);
+                self.status.set(status);
+            }
+
+            AppEvent::DownloadFailed(request, status) => {
+                if request != self.request_id.get() {
+                    return;
+                }
+                self.active_download = None;
+                self.active_cancel = None;
+                self.status.set(status);
+            }
+        });
+    }
+}
+
+fn main() -> Result<(), ApplicationError> {
+    Application::new(|cx| {
+        let (status, progress) = AppData::new(cx);
+
+        VStack::new(cx, |cx| {
+            Label::new(cx, "Task Download Demo").font_size(24.0).height(Auto);
+
+            Label::new(cx, status).height(Pixels(30.0));
+
+            HStack::new(cx, |cx| {
+                ProgressBar::horizontal(cx, progress);
+                Label::new(cx, progress.map(|value| format!("{:.0}%", value * 100.0)));
+            })
+            .height(Auto)
+            .gap(Pixels(8.0))
+            .alignment(Alignment::Center);
+
+            Button::new(cx, |cx| Label::new(cx, "Download File"))
+                .on_press(|cx| cx.emit(AppEvent::StartDownload));
+        })
+        .size(Stretch(1.0))
+        .padding(Pixels(16.0))
+        .gap(Pixels(8.0))
+        .alignment(Alignment::Center);
+    })
+    .title("Task Download")
+    .inner_size((560, 220))
+    .run()
+}

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -1,7 +1,3 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
 use std::time::Duration;
 
 use vizia::prelude::*;
@@ -19,7 +15,6 @@ struct AppData {
     progress: Signal<f32>,
     request_id: Signal<u32>,
     active_download: Option<TaskHandle>,
-    active_cancel: Option<Arc<AtomicBool>>,
 }
 
 impl AppData {
@@ -27,14 +22,7 @@ impl AppData {
         let status = Signal::new("Press Download File to start".to_string());
         let progress = Signal::new(0.0);
 
-        Self {
-            status,
-            progress,
-            request_id: Signal::new(0),
-            active_download: None,
-            active_cancel: None,
-        }
-        .build(cx);
+        Self { status, progress, request_id: Signal::new(0), active_download: None }.build(cx);
 
         (status, progress)
     }
@@ -47,9 +35,6 @@ impl Model for AppData {
                 if let Some(handle) = self.active_download.take() {
                     handle.cancel();
                 }
-                if let Some(cancel_flag) = self.active_cancel.take() {
-                    cancel_flag.store(true, Ordering::Release);
-                }
 
                 let request = self.request_id.get().saturating_add(1);
                 self.request_id.set(request);
@@ -60,22 +45,20 @@ impl Model for AppData {
 
                 // Build a fresh future per attempt so retry policies can re-run work.
                 let mut attempt = 0usize;
-                let cancel_flag = Arc::new(AtomicBool::new(false));
                 let proxy = cx.get_proxy();
-                let task_cancel = cancel_flag.clone();
                 let handle = cx.add_task(
-                    Task::new(move || {
+                    Task::new(move |cancellation| {
                         attempt = attempt.saturating_add(1);
                         let attempt_num = attempt;
                         let file_name = file_name.clone();
-                        let cancel_flag = task_cancel.clone();
+                        let cancellation = cancellation.clone();
                         let mut proxy = proxy.clone();
 
                         async move {
                             // Simulate a large file transfer with chunked progress over several seconds.
                             let total_chunks = 40_u32;
                             for chunk in 1..=total_chunks {
-                                if cancel_flag.load(Ordering::Acquire) {
+                                if cancellation.is_cancelled() {
                                     return Err(format!("Cancelled {}", file_name));
                                 }
                                 std::thread::sleep(Duration::from_millis(120));
@@ -91,12 +74,10 @@ impl Model for AppData {
                         }
                     })
                     .name("download-file")
-                    .timeout_policy(TaskTimeoutPolicy::CancelAfter(Duration::from_secs(8)))
-                    .retry_policy(TaskRetryPolicy::Attempts {
-                        retries: 1,
-                        delay: Some(Duration::from_millis(20)),
-                    })
-                    .on_result(move |result, proxy| match result.flatten() {
+                    .timeout(Duration::from_secs(8))
+                    .retry(1)
+                    .retry_delay(Duration::from_millis(20))
+                    .on_result(move |result, proxy| match result {
                         TaskResult::Completed(status) => {
                             let _ = proxy.emit(AppEvent::DownloadFinished(request, status));
                         }
@@ -124,7 +105,6 @@ impl Model for AppData {
                     }),
                 );
 
-                self.active_cancel = Some(cancel_flag);
                 self.active_download = Some(handle);
             }
 
@@ -140,7 +120,6 @@ impl Model for AppData {
                     return;
                 }
                 self.active_download = None;
-                self.active_cancel = None;
                 self.progress.set(1.0);
                 self.status.set(status);
             }
@@ -150,7 +129,6 @@ impl Model for AppData {
                     return;
                 }
                 self.active_download = None;
-                self.active_cancel = None;
                 self.status.set(status);
             }
         });

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -61,7 +61,7 @@ impl Model for AppData {
                                 if cancellation.is_cancelled() {
                                     return Err(format!("Cancelled {}", file_name));
                                 }
-                                std::thread::sleep(Duration::from_millis(120));
+                                tokio::time::sleep(Duration::from_millis(120)).await;
                                 let progress = (chunk as f32 / total_chunks as f32) * 0.95;
                                 let _ = proxy.emit(AppEvent::DownloadProgress(request, progress));
                             }

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -96,7 +96,7 @@ impl Model for AppData {
                                 "Download cancelled".to_string(),
                             ));
                         }
-                        TaskResult::Disconnected => {
+                        TaskResult::Disconnected { .. } => {
                             let _ = proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Task worker disconnected".to_string(),

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -63,7 +63,7 @@ impl Model for AppData {
                                 }
                                 std::thread::sleep(Duration::from_millis(120));
                                 let progress = (chunk as f32 / total_chunks as f32) * 0.95;
-                                proxy.emit(AppEvent::DownloadProgress(request, progress));
+                                let _ = proxy.emit(AppEvent::DownloadProgress(request, progress));
                             }
 
                             if request % 4 == 0 {
@@ -79,25 +79,25 @@ impl Model for AppData {
                     .retry_delay(Duration::from_millis(20))
                     .on_result(move |result, proxy| match result {
                         TaskResult::Completed(status) => {
-                            proxy.emit(AppEvent::DownloadFinished(request, status));
+                            let _ = proxy.emit(AppEvent::DownloadFinished(request, status));
                         }
                         TaskResult::Error(error) => {
-                            proxy.emit(AppEvent::DownloadFailed(request, error));
+                            let _ = proxy.emit(AppEvent::DownloadFailed(request, error));
                         }
                         TaskResult::Timeout => {
-                            proxy.emit(AppEvent::DownloadFailed(
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Download timed out".to_string(),
                             ));
                         }
                         TaskResult::Cancelled => {
-                            proxy.emit(AppEvent::DownloadFailed(
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Download cancelled".to_string(),
                             ));
                         }
                         TaskResult::Disconnected => {
-                            proxy.emit(AppEvent::DownloadFailed(
+                            let _ = proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Task worker disconnected".to_string(),
                             ));

--- a/examples/task_download.rs
+++ b/examples/task_download.rs
@@ -63,7 +63,7 @@ impl Model for AppData {
                                 }
                                 std::thread::sleep(Duration::from_millis(120));
                                 let progress = (chunk as f32 / total_chunks as f32) * 0.95;
-                                let _ = proxy.emit(AppEvent::DownloadProgress(request, progress));
+                                proxy.emit(AppEvent::DownloadProgress(request, progress));
                             }
 
                             if request % 4 == 0 {
@@ -79,25 +79,25 @@ impl Model for AppData {
                     .retry_delay(Duration::from_millis(20))
                     .on_result(move |result, proxy| match result {
                         TaskResult::Completed(status) => {
-                            let _ = proxy.emit(AppEvent::DownloadFinished(request, status));
+                            proxy.emit(AppEvent::DownloadFinished(request, status));
                         }
                         TaskResult::Error(error) => {
-                            let _ = proxy.emit(AppEvent::DownloadFailed(request, error));
+                            proxy.emit(AppEvent::DownloadFailed(request, error));
                         }
                         TaskResult::Timeout => {
-                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                            proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Download timed out".to_string(),
                             ));
                         }
                         TaskResult::Cancelled => {
-                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                            proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Download cancelled".to_string(),
                             ));
                         }
                         TaskResult::Disconnected => {
-                            let _ = proxy.emit(AppEvent::DownloadFailed(
+                            proxy.emit(AppEvent::DownloadFailed(
                                 request,
                                 "Task worker disconnected".to_string(),
                             ));


### PR DESCRIPTION
This pull request introduces a new async task system using Tokio for asynchronous operations.

# Task API Overview

The new task API lets you run async work off the UI thread and report results back through the Vizia event system.

## Core pieces

- `Task::new(|| async move { ... })`: creates a task pipeline from a future factory.
- `cx.add_task(...)`: submits the built task and returns a `TaskHandle`.
- `TaskHandle`: lets you inspect/cancel in-flight work (`cancel`, `is_cancelled`, `is_finished`, `id`).
- `TaskResult<T, E>`: completion state delivered to `on_result`.
  - `Completed(T)`
  - `Error(E)`
  - `Timeout`
  - `Cancelled`
  - `Disconnected`

## Builder options

Use these while building a task before `add_task`:

- `name(key)`: deduplicates by context/entity/key and cancels previous in-flight task with the same name.
- `timeout(...)` or `timeout_policy(...)`: fail delivery as `TaskResult::Timeout` when attempt timing exceeds policy.
- `retry(...)`, `retry_delay(...)`, or `retry_policy(...)`: retry timeout/disconnect failures.
- `on_start(...)`, `on_retry(...)`, `on_timeout(...)`: lifecycle callbacks.
- `on_result(|result, proxy| ...)`: completion handler where you emit app events via `proxy`.

## Typical usage

1. Build task with `Task::new`.
2. Configure optional naming/timeout/retry.
3. Map completion in `on_result` and emit events back to the app model.
4. Submit with `cx.add_task(...)` and store the returned `TaskHandle` if cancellation is needed.

```rust
use std::time::Duration;
use vizia::prelude::*;

let handle = cx.add_task(
  Task::new(|| async move {
    // background work
    Ok::<String, String>("done".to_owned())
  })
  .on_result(|result, proxy| match result.flatten() {
    TaskResult::Completed(value) => {
      let _ = proxy.emit(AppEvent::TaskFinished(value));
    }
    TaskResult::Error(err) => {
      let _ = proxy.emit(AppEvent::TaskFailed(err));
    }
    TaskResult::Timeout => {
      let _ = proxy.emit(AppEvent::TaskFailed("Timed out".to_owned()));
    }
    TaskResult::Cancelled => {
      let _ = proxy.emit(AppEvent::TaskFailed("Cancelled".to_owned()));
    }
    TaskResult::Disconnected => {
      let _ = proxy.emit(AppEvent::TaskFailed("Worker disconnected".to_owned()));
    }
  }),
);
```

### Timeout and retry snippet

```rust
use std::time::Duration;
use vizia::prelude::*;

let _handle = cx.add_task(
  Task::new(|| async move { fetch_data().await })
    .name("fetch-data")
    .timeout_policy(TaskTimeoutPolicy::CancelAfter(Duration::from_secs(5)))
    .retry_policy(TaskRetryPolicy::Attempts {
      retries: 2,
      delay: Some(Duration::from_millis(100)),
    })
    .on_retry(|attempt| {
      println!("retry #{attempt}");
    })
    .on_result(|result, proxy| {
      let _ = proxy.emit(AppEvent::FetchResult(result));
    }),
);
```

### Cancellation snippet

```rust
// Store this in your model when you start a task.
let handle: TaskHandle = cx.add_task(/* ... */);

// Later (for example, before launching a replacement task):
if handle.cancel() {
  // cancellation request was newly applied
}
```

**Key changes:**

Async Task System Integration:
- Added a Tokio-powered async task runtime to `vizia_core`, exposed via the new `tokio` feature flag and available through the `Context` and `EventContext` structs.

- Introduced new task-related types (`Task`, `TaskBuilder`, `TaskHandle`, etc.) and made them available in the Vizia prelude when the `tokio` feature is enabled.

Refactoring of Async Usage in Gallery Example:
- Replaced manual Tokio runtime management in the `gallery` example with the new `add_task` API, simplifying async task submission and result handling.

Examples and Feature Flags:
- Added a new example, `task_download`, to demonstrate async task usage, and updated feature flags and dependencies to support Tokio integration.

