### PR TITLE
Add type-ahead text support for Select list

### DIFF
--- a/crates/vizia_core/src/views/select.rs
+++ b/crates/vizia_core/src/views/select.rs
@@ -90,13 +90,20 @@ impl Select {
                     let is_open = is_open.get();
                     if is_open {
                         Popover::new(cx, |cx| {
-                            List::new(cx, list, move |cx, _, item| {
+                            let list_signal = list.to_signal(cx);
+
+                            List::new(cx, list_signal, move |cx, _, item| {
                                 Svg::new(cx, ICON_CHECK).class("checkmark").size(Pixels(16.0));
                                 Label::new(cx, item.map(|v| v.clone())).hoverable(false);
                             })
                             .selectable(Selectable::Single)
                             .min_selected(min_selected)
                             .max_selected(max_selected)
+                            .type_ahead_text(move |cx, index| {
+                                list_signal.with(|list| {
+                                    list.get(index).map(|item| item.to_string_local(cx))
+                                })
+                            })
                             .selection(
                                 selected.map(|s| {
                                     if let Some(index) = s { vec![*index] } else { vec![] }


### PR DESCRIPTION
Convert the provided list into a signal and pass that to List::new, then implement a type_ahead_text closure that looks up the item string via the list signal and to_string_local(cx). This enables type-ahead/search behavior for the Select popover by providing per-index text for matching, while preserving existing selectable/selection behavior.