### PR TITLE
Introduce ProxyEvent for thread-safe event forwarding

### DIFF
--- a/crates/vizia_baseview/src/application.rs
+++ b/crates/vizia_baseview/src/application.rs
@@ -287,7 +287,7 @@ impl ApplicationRunner {
         Runtime::drain_pending_work();
 
         while let Some(event) = queue_get() {
-            self.cx.send_event(event);
+            self.cx.send_event(event.into_event());
         }
 
         // Events. The flush callback can't borrow `&mut self`, so size /

--- a/crates/vizia_baseview/src/proxy.rs
+++ b/crates/vizia_baseview/src/proxy.rs
@@ -1,15 +1,16 @@
 use std::collections::VecDeque;
 use std::sync::{LazyLock, Mutex};
 use vizia_core::context::EventProxy;
-use vizia_core::events::Event;
+use vizia_core::events::ProxyEvent;
 
-pub(crate) static PROXY_QUEUE: LazyLock<Mutex<VecDeque<Event>>> = LazyLock::new(Mutex::default);
+pub(crate) static PROXY_QUEUE: LazyLock<Mutex<VecDeque<ProxyEvent>>> =
+    LazyLock::new(Mutex::default);
 
-pub(crate) fn queue_put(event: Event) {
+pub(crate) fn queue_put(event: ProxyEvent) {
     PROXY_QUEUE.lock().unwrap().push_back(event)
 }
 
-pub(crate) fn queue_get() -> Option<Event> {
+pub(crate) fn queue_get() -> Option<ProxyEvent> {
     PROXY_QUEUE.lock().unwrap().pop_front()
 }
 
@@ -17,7 +18,7 @@ pub(crate) fn queue_get() -> Option<Event> {
 pub(crate) struct BaseviewProxy;
 
 impl EventProxy for BaseviewProxy {
-    fn send(&self, event: Event) -> Result<(), ()> {
+    fn send(&self, event: ProxyEvent) -> Result<(), ()> {
         queue_put(event);
         Ok(())
     }

--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -236,7 +236,7 @@ impl BackendContext {
         layout_system(&mut self.0);
     }
 
-    pub fn emit_origin<M: Send + Any>(&mut self, message: M) {
+    pub fn emit_origin<M: Any>(&mut self, message: M) {
         self.0.event_queue.push_back(
             Event::new(message)
                 .target(self.0.current)
@@ -245,7 +245,7 @@ impl BackendContext {
         );
     }
 
-    pub fn emit_window_event<M: Send + Any>(&mut self, window_entity: Entity, message: M) {
+    pub fn emit_window_event<M: Any>(&mut self, window_entity: Entity, message: M) {
         self.0.event_queue.push_back(
             Event::new(message)
                 .target(window_entity)

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1458,7 +1458,7 @@ impl DataContext for EventContext<'_> {
 }
 
 impl EmitContext for EventContext<'_> {
-    fn emit<M: Any + Send>(&mut self, message: M) {
+    fn emit<M: Any>(&mut self, message: M) {
         self.event_queue.push_back(
             Event::new(message)
                 .target(self.current)
@@ -1467,7 +1467,7 @@ impl EmitContext for EventContext<'_> {
         );
     }
 
-    fn emit_to<M: Any + Send>(&mut self, target: Entity, message: M) {
+    fn emit_to<M: Any>(&mut self, target: Entity, message: M) {
         self.event_queue.push_back(
             Event::new(message).target(target).origin(self.current).propagate(Propagation::Direct),
         );
@@ -1477,7 +1477,7 @@ impl EmitContext for EventContext<'_> {
         self.event_queue.push_back(event);
     }
 
-    fn schedule_emit<M: Any + Send>(&mut self, message: M, at: Instant) -> TimedEventHandle {
+    fn schedule_emit<M: Any>(&mut self, message: M, at: Instant) -> TimedEventHandle {
         self.schedule_emit_custom(
             Event::new(message)
                 .target(self.current)
@@ -1486,7 +1486,7 @@ impl EmitContext for EventContext<'_> {
             at,
         )
     }
-    fn schedule_emit_to<M: Any + Send>(
+    fn schedule_emit_to<M: Any>(
         &mut self,
         target: Entity,
         message: M,

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -1137,7 +1137,7 @@ pub trait EmitContext {
     /// # enum AppEvent {Increment}
     /// cx.emit(AppEvent::Increment);
     /// ```
-    fn emit<M: Any + Send>(&mut self, message: M);
+    fn emit<M: Any>(&mut self, message: M);
 
     /// Send an event containing the provided message directly to a specified entity from the current entity.
     ///
@@ -1149,7 +1149,7 @@ pub trait EmitContext {
     /// # enum AppEvent {Increment}
     /// cx.emit_to(Entity::root(), AppEvent::Increment);
     /// ```
-    fn emit_to<M: Any + Send>(&mut self, target: Entity, message: M);
+    fn emit_to<M: Any>(&mut self, target: Entity, message: M);
 
     /// Send a custom event with custom origin and propagation information.
     ///
@@ -1181,7 +1181,7 @@ pub trait EmitContext {
     /// # enum AppEvent {Increment}
     /// cx.schedule_emit(AppEvent::Increment, Instant::now() + Duration::from_secs(2));
     /// ```
-    fn schedule_emit<M: Any + Send>(&mut self, message: M, at: Instant) -> TimedEventHandle;
+    fn schedule_emit<M: Any>(&mut self, message: M, at: Instant) -> TimedEventHandle;
 
     /// Send an event containing the provided message directly to a specified view at a particular time instant.
     ///
@@ -1196,7 +1196,7 @@ pub trait EmitContext {
     /// # enum AppEvent {Increment}
     /// cx.schedule_emit_to(Entity::root(), AppEvent::Increment, Instant::now() + Duration::from_secs(2));
     /// ```
-    fn schedule_emit_to<M: Any + Send>(
+    fn schedule_emit_to<M: Any>(
         &mut self,
         target: Entity,
         message: M,
@@ -1297,7 +1297,7 @@ impl DataContext for LocalizationContext<'_> {
 }
 
 impl EmitContext for Context {
-    fn emit<M: Any + Send>(&mut self, message: M) {
+    fn emit<M: Any>(&mut self, message: M) {
         self.event_queue.push_back(
             Event::new(message)
                 .target(self.current)
@@ -1306,7 +1306,7 @@ impl EmitContext for Context {
         );
     }
 
-    fn emit_to<M: Any + Send>(&mut self, target: Entity, message: M) {
+    fn emit_to<M: Any>(&mut self, target: Entity, message: M) {
         self.event_queue.push_back(
             Event::new(message).target(target).origin(self.current).propagate(Propagation::Direct),
         );
@@ -1316,7 +1316,7 @@ impl EmitContext for Context {
         self.event_queue.push_back(event);
     }
 
-    fn schedule_emit<M: Any + Send>(&mut self, message: M, at: Instant) -> TimedEventHandle {
+    fn schedule_emit<M: Any>(&mut self, message: M, at: Instant) -> TimedEventHandle {
         self.schedule_emit_custom(
             Event::new(message)
                 .target(self.current)
@@ -1326,7 +1326,7 @@ impl EmitContext for Context {
         )
     }
 
-    fn schedule_emit_to<M: Any + Send>(
+    fn schedule_emit_to<M: Any>(
         &mut self,
         target: Entity,
         message: M,

--- a/crates/vizia_core/src/context/proxy.rs
+++ b/crates/vizia_core/src/context/proxy.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 
 use super::InternalEvent;
 
+use crate::events::ProxyEvent;
 use crate::prelude::*;
 
 /// A bundle of data representing a snapshot of the context when a thread was spawned.
@@ -44,7 +45,7 @@ impl std::error::Error for ProxyEmitError {}
 impl ContextProxy {
     pub fn emit<M: Any + Send>(&mut self, message: M) -> Result<(), ProxyEmitError> {
         if let Some(proxy) = &self.event_proxy {
-            let event = Event::new(message)
+            let event = ProxyEvent::new(message)
                 .target(self.current)
                 .origin(self.current)
                 .propagate(Propagation::Up);
@@ -61,7 +62,7 @@ impl ContextProxy {
         message: M,
     ) -> Result<(), ProxyEmitError> {
         if let Some(proxy) = &self.event_proxy {
-            let event = Event::new(message)
+            let event = ProxyEvent::new(message)
                 .target(target)
                 .origin(self.current)
                 .propagate(Propagation::Direct);
@@ -109,6 +110,6 @@ impl Clone for ContextProxy {
 
 pub trait EventProxy: Send {
     #[allow(clippy::result_unit_err)]
-    fn send(&self, event: Event) -> Result<(), ()>;
+    fn send(&self, event: ProxyEvent) -> Result<(), ()>;
     fn make_clone(&self) -> Box<dyn EventProxy>;
 }

--- a/crates/vizia_core/src/events/event.rs
+++ b/crates/vizia_core/src/events/event.rs
@@ -23,6 +23,14 @@ pub struct Event {
     /// The meta data of the event
     pub(crate) meta: EventMeta,
     /// The message of the event
+    pub(crate) message: Option<Box<dyn Any>>,
+}
+
+/// A sendable event payload used by context proxies to forward events from non-UI threads.
+pub struct ProxyEvent {
+    /// The meta data of the event
+    pub(crate) meta: EventMeta,
+    /// The sendable message payload
     pub(crate) message: Option<Box<dyn Any + Send>>,
 }
 
@@ -32,11 +40,17 @@ impl Debug for Event {
     }
 }
 
+impl Debug for ProxyEvent {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
 impl Event {
     /// Creates a new event with a specified message.
     pub fn new<M>(message: M) -> Self
     where
-        M: Any + Send,
+        M: Any,
     {
         Event { meta: Default::default(), message: Some(Box::new(message)) }
     }
@@ -102,7 +116,7 @@ impl Event {
     /// ```
     pub fn map<M, F>(&mut self, f: F)
     where
-        M: Any + Send,
+        M: Any,
         F: FnOnce(&M, &mut EventMeta),
     {
         if let Some(message) = &self.message {
@@ -141,7 +155,7 @@ impl Event {
     /// #     }
     /// # }
     /// ```
-    pub fn take<M: Any + Send, F>(&mut self, f: F)
+    pub fn take<M: Any, F>(&mut self, f: F)
     where
         F: FnOnce(M, &mut EventMeta),
     {
@@ -155,6 +169,39 @@ impl Event {
                 (f)(*v, &mut self.meta);
             }
         }
+    }
+}
+
+impl ProxyEvent {
+    /// Creates a new proxy event with a sendable message.
+    pub fn new<M>(message: M) -> Self
+    where
+        M: Any + Send,
+    {
+        ProxyEvent { meta: Default::default(), message: Some(Box::new(message)) }
+    }
+
+    /// Sets the target of the event.
+    pub fn target(mut self, entity: Entity) -> Self {
+        self.meta.target = entity;
+        self
+    }
+
+    /// Sets the origin of the event.
+    pub fn origin(mut self, entity: Entity) -> Self {
+        self.meta.origin = entity;
+        self
+    }
+
+    /// Sets the propagation of the event.
+    pub fn propagate(mut self, propagation: Propagation) -> Self {
+        self.meta.propagation = propagation;
+        self
+    }
+
+    /// Converts a proxy event into a normal event on the UI thread.
+    pub fn into_event(self) -> Event {
+        Event { meta: self.meta, message: self.message.map(|message| message as Box<dyn Any>) }
     }
 }
 

--- a/crates/vizia_core/src/events/event_manager.rs
+++ b/crates/vizia_core/src/events/event_manager.rs
@@ -866,13 +866,7 @@ fn mutate_direct_or_up(meta: &mut EventMeta, direct: Entity, up: Entity, root: b
     }
 }
 
-fn emit_direct_or_up<M: Any + Send>(
-    cx: &mut Context,
-    message: M,
-    direct: Entity,
-    up: Entity,
-    root: bool,
-) {
+fn emit_direct_or_up<M: Any>(cx: &mut Context, message: M, direct: Entity, up: Entity, root: bool) {
     let mut event = Event::new(message);
     mutate_direct_or_up(&mut event.meta, direct, up, root);
     cx.emit_custom(event);

--- a/crates/vizia_core/src/events/mod.rs
+++ b/crates/vizia_core/src/events/mod.rs
@@ -90,7 +90,7 @@ pub use event_manager::EventManager;
 
 mod event;
 pub(crate) use event::TimedEvent;
-pub use event::{Event, EventMeta, Propagation, TimedEventHandle};
+pub use event::{Event, EventMeta, Propagation, ProxyEvent, TimedEventHandle};
 
 mod event_handler;
 pub(crate) use event_handler::ViewHandler;

--- a/crates/vizia_core/src/systems/layout.rs
+++ b/crates/vizia_core/src/systems/layout.rs
@@ -1,6 +1,7 @@
 use morphorm::Node;
 use vizia_storage::LayoutTreeIterator;
 
+use crate::events::ProxyEvent;
 use crate::layout::node::SubLayout;
 use crate::prelude::*;
 
@@ -128,7 +129,7 @@ pub(crate) fn layout_system(cx: &mut Context) {
         if let Some(proxy) = &cx.event_proxy {
             if cx.captured.is_null() {
                 let event =
-                    Event::new(WindowEvent::MouseMove(cx.mouse.cursor_x, cx.mouse.cursor_y))
+                    ProxyEvent::new(WindowEvent::MouseMove(cx.mouse.cursor_x, cx.mouse.cursor_y))
                         .target(Entity::root())
                         .origin(Entity::root())
                         .propagate(Propagation::Up);

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -30,6 +30,7 @@ use vizia_input::ImeState;
 // use accesskit_winit;
 // use std::cell::RefCell;
 use vizia_core::context::EventProxy;
+use vizia_core::events::ProxyEvent;
 use vizia_core::prelude::*;
 use vizia_core::{backend::*, events::EventManager};
 use vizia_reactive::Runtime;
@@ -72,7 +73,7 @@ use vizia_window::{Anchor, AnchorTarget, WindowPosition};
 
 #[derive(Debug)]
 pub enum UserEvent {
-    Event(Event),
+    Event(ProxyEvent),
     #[cfg(feature = "accesskit")]
     AccessKitEvent(accesskit_winit::Event),
 }
@@ -81,12 +82,6 @@ pub enum UserEvent {
 impl From<accesskit_winit::Event> for UserEvent {
     fn from(action_request_event: accesskit_winit::Event) -> Self {
         UserEvent::AccessKitEvent(action_request_event)
-    }
-}
-
-impl From<vizia_core::events::Event> for UserEvent {
-    fn from(event: vizia_core::events::Event) -> Self {
-        UserEvent::Event(event)
     }
 }
 
@@ -140,7 +135,7 @@ pub struct Application {
 pub struct WinitEventProxy(EventLoopProxy<UserEvent>);
 
 impl EventProxy for WinitEventProxy {
-    fn send(&self, event: Event) -> Result<(), ()> {
+    fn send(&self, event: ProxyEvent) -> Result<(), ()> {
         self.0.send_event(UserEvent::Event(event)).map_err(|_| ())
     }
 
@@ -172,7 +167,7 @@ impl Application {
         // Ensure we wake the event loop when a SyncSignal is mutated off the UI thread.
         let waker_proxy = proxy.clone();
         Runtime::set_sync_effect_waker(move || {
-            let _ = waker_proxy.send_event(UserEvent::Event(Event::new(())));
+            let _ = waker_proxy.send_event(UserEvent::Event(ProxyEvent::new(())));
         });
 
         cx.renegotiate_language();
@@ -397,7 +392,7 @@ impl ApplicationHandler<UserEvent> for Application {
     fn user_event(&mut self, _event_loop: &ActiveEventLoop, user_event: UserEvent) {
         match user_event {
             UserEvent::Event(event) => {
-                self.cx.send_event(event);
+                self.cx.send_event(event.into_event());
             }
 
             #[cfg(feature = "accesskit")]
@@ -858,7 +853,7 @@ impl ApplicationHandler<UserEvent> for Application {
 
         if self.cx.has_queued_events() {
             self.event_loop_proxy
-                .send_event(UserEvent::Event(Event::new(())))
+                .send_event(UserEvent::Event(ProxyEvent::new(())))
                 .expect("Failed to send event");
         }
 


### PR DESCRIPTION
Introduce ProxyEvent as a sendable event payload for forwarding events from non-UI threads and convert to Event on the UI thread. Relax the Send bound on the core Event/message APIs (emit, emit_to, schedule_emit, etc.) so Event can carry non-Send messages on the UI thread, and update EventProxy/send signatures and proxy queues to use ProxyEvent. Update baseview/winit proxies, layout synthetic events, and event manager helpers to produce/consume ProxyEvent and call into_event() where appropriate. This separates cross-thread sendability concerns from the in-UI Event representation.