### PR TITLE
Add aspect-ratio property and fix HiDPI image sizing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ hashbrown = "0.17"
 indexmap = "2.13"
 keyboard-types = { version = "0.7", default-features = false }
 log = "0.4"
-morphorm = { git = "https://github.com/vizia/morphorm.git", rev = "adf7a4e484a5d4a2d4cc6a25770c419f7a8e3f65" }
+morphorm = { git = "https://github.com/vizia/morphorm.git", rev = "ff08ec25b79e1bd6c638270b36317d092da861e8" }
 open = "5.3"
 parking_lot = "0.12"
 raw-window-handle = "0.5"

--- a/crates/vizia_core/src/layout/node.rs
+++ b/crates/vizia_core/src/layout/node.rs
@@ -254,19 +254,16 @@ impl Node for Entity {
                                 .map(|stored_img| &stored_img.image)
                             {
                                 Some(ImageOrSvg::Image(image)) => {
-                                    max_width =
-                                        max_width.max(image.width() as f32 * store.scale_factor());
-                                    max_height = max_height
-                                        .max(image.height() as f32 * store.scale_factor());
+                                    // Intrinsic image dimensions are already in physical pixels.
+                                    // Do not apply scale-factor again or auto sizing doubles on HiDPI.
+                                    max_width = max_width.max(image.width() as f32);
+                                    max_height = max_height.max(image.height() as f32);
                                 }
 
                                 Some(ImageOrSvg::Svg(svg)) => {
-                                    max_width = max_width.max(
-                                        svg.inner().fContainerSize.fWidth * store.scale_factor(),
-                                    );
-                                    max_height = max_height.max(
-                                        svg.inner().fContainerSize.fWidth * store.scale_factor(),
-                                    );
+                                    // Use SVG intrinsic container size directly in physical pixels.
+                                    max_width = max_width.max(svg.inner().fContainerSize.fWidth);
+                                    max_height = max_height.max(svg.inner().fContainerSize.fHeight);
                                 }
 
                                 _ => {}
@@ -277,8 +274,31 @@ impl Node for Entity {
                 }
             }
 
-            let width = if let Some(width) = width { width } else { max_width };
-            let height = if let Some(height) = height { height } else { max_height };
+            let intrinsic_ratio = if max_width > 0.0 && max_height > 0.0 {
+                Some(max_width / max_height)
+            } else {
+                None
+            };
+
+            let aspect_ratio = store.aspect_ratio.get(*self).copied();
+            let auto_ratio = match aspect_ratio {
+                Some(AspectRatio::Auto) => intrinsic_ratio,
+                Some(AspectRatio::AutoRatio(fallback_ratio)) => {
+                    intrinsic_ratio.or(Some(fallback_ratio))
+                }
+                _ => None,
+            };
+
+            let (width, height) = match (width, height, auto_ratio) {
+                (Some(width), None, Some(ratio)) if ratio > 0.0 => (width, width / ratio),
+                (None, Some(height), Some(ratio)) if ratio > 0.0 => (height * ratio, height),
+                (width, height, _) => {
+                    let width = width.unwrap_or(max_width);
+                    let height = height.unwrap_or(max_height);
+                    (width, height)
+                }
+            };
+
             Some((width, height))
         } else {
             None
@@ -290,6 +310,23 @@ impl Node for Entity {
             Units::Pixels(val) => Units::Pixels(store.logical_to_physical(val)),
             t => t,
         })
+    }
+
+    fn aspect_ratio(&self, store: &Self::Store) -> Option<f32> {
+        match store.aspect_ratio.get(*self).copied() {
+            Some(AspectRatio::Ratio(ratio)) => Some(ratio),
+
+            // For image-backed nodes, `auto` and `auto <ratio>` are resolved from intrinsic
+            // dimensions inside `content_size`, where resource data is available.
+            Some(AspectRatio::Auto) | Some(AspectRatio::AutoRatio(_))
+                if store.background_image.get(*self).is_some() =>
+            {
+                None
+            }
+
+            Some(AspectRatio::AutoRatio(ratio)) => Some(ratio),
+            _ => None,
+        }
     }
 
     fn min_height(&self, store: &Self::Store) -> Option<morphorm::Units> {

--- a/crates/vizia_core/src/modifiers/layout.rs
+++ b/crates/vizia_core/src/modifiers/layout.rs
@@ -173,6 +173,13 @@ pub trait LayoutModifiers: internal::Modifiable {
         SystemFlags::RELAYOUT
     );
 
+    modifier!(
+        /// Sets the preferred aspect ratio of the view.
+        aspect_ratio,
+        AspectRatio,
+        SystemFlags::RELAYOUT
+    );
+
     /// Sets the width and height of the view.
     fn size<U: Into<Units>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -72,15 +72,15 @@ use crate::prelude::*;
 use crate::storage::animatable_var_set::AnimatableVarSet;
 
 pub use vizia_style::{
-    Alignment, Angle, BackgroundImage, BackgroundRepeat, BackgroundSize, BorderStyleKeyword,
-    ClipPath, Color, CornerShape, CssRule, CursorIcon, Direction, Display, Filter, FontFamily,
-    FontSize, FontSizeKeyword, FontSlant, FontVariation, FontWeight, FontWeightKeyword, FontWidth,
-    GenericFontFamily, Gradient, HorizontalPosition, HorizontalPositionKeyword, LayoutWrap, Length,
-    LengthOrPercentage, LengthValue, LetterSpacing, LineClamp, LineDirection, LineHeight,
-    LinearGradient, Matrix, Opacity, Overflow, PointerEvents, Position, PositionType, RGBA, Scale,
-    Shadow, TextAlign, TextDecorationLine, TextDecorationStyle, TextOverflow, TextStroke,
-    TextStrokeStyle, Transform, Transition, Translate, VerticalPosition, VerticalPositionKeyword,
-    Visibility,
+    Alignment, Angle, AspectRatio, BackgroundImage, BackgroundRepeat, BackgroundSize,
+    BorderStyleKeyword, ClipPath, Color, CornerShape, CssRule, CursorIcon, Direction, Display,
+    Filter, FontFamily, FontSize, FontSizeKeyword, FontSlant, FontVariation, FontWeight,
+    FontWeightKeyword, FontWidth, GenericFontFamily, Gradient, HorizontalPosition,
+    HorizontalPositionKeyword, LayoutWrap, Length, LengthOrPercentage, LengthValue, LetterSpacing,
+    LineClamp, LineDirection, LineHeight, LinearGradient, Matrix, Opacity, Overflow, PointerEvents,
+    Position, PositionType, RGBA, Scale, Shadow, TextAlign, TextDecorationLine,
+    TextDecorationStyle, TextOverflow, TextStroke, TextStrokeStyle, Transform, Transition,
+    Translate, VerticalPosition, VerticalPositionKeyword, Visibility,
 };
 
 use cssparser::Token as CssToken;
@@ -373,6 +373,7 @@ pub struct Style {
     // Size
     pub(crate) width: AnimatableVarSet<Units>,
     pub(crate) height: AnimatableVarSet<Units>,
+    pub(crate) aspect_ratio: StyleSet<AspectRatio>,
 
     // Size Constraints
     pub(crate) min_width: AnimatableVarSet<Units>,
@@ -1759,6 +1760,10 @@ impl Style {
                 self.height.insert_rule(rule_id, height);
             }
 
+            Property::AspectRatio(aspect_ratio) => {
+                self.aspect_ratio.insert_rule(rule_id, aspect_ratio);
+            }
+
             // Padding
             Property::Padding(padding) => {
                 self.padding_left.insert_rule(rule_id, padding);
@@ -2879,6 +2884,7 @@ impl Style {
         // Size
         self.width.remove(entity);
         self.height.remove(entity);
+        self.aspect_ratio.remove(entity);
 
         // Size Constraints
         self.min_width.remove(entity);

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -783,6 +783,11 @@ fn link_style_data(
         should_redraw = true;
     }
 
+    if style.aspect_ratio.link(entity, matched_rules) {
+        should_relayout = true;
+        should_redraw = true;
+    }
+
     // Size Constraints
     if style.max_width.link(entity, matched_rules, &style.custom_units_props) {
         should_relayout = true;

--- a/crates/vizia_style/src/property.rs
+++ b/crates/vizia_style/src/property.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Alignment, Angle, BackgroundImage, BackgroundRepeat, BackgroundSize, BlendMode, Border,
-    BorderStyle, BorderWidth, ClipPath, Color, CornerRadius, CornerShape, CursorIcon,
+    Alignment, Angle, AspectRatio, BackgroundImage, BackgroundRepeat, BackgroundSize, BlendMode,
+    Border, BorderStyle, BorderWidth, ClipPath, Color, CornerRadius, CornerShape, CursorIcon,
     CustomParseError, CustomProperty, Direction, Display, Filter, FontFamily, FontSize, FontSlant,
     FontVariation, FontWeight, FontWidth, LayoutType, LayoutWrap, Length, LengthOrPercentage,
     LetterSpacing, LineClamp, LineHeight, Opacity, Outline, Overflow, Parse, PointerEvents,
@@ -47,6 +47,7 @@ define_property! {
         "top": Top(Units),
         "size": Size(Units),
         "height": Height(Units),
+        "aspect-ratio": AspectRatio(AspectRatio),
         "bottom": Bottom(Units),
 
         // Constraints
@@ -265,6 +266,22 @@ mod tests {
             }
 
             _ => panic!("background-repeat parsed to wrong property"),
+        }
+    }
+
+    #[test]
+    fn parse_aspect_ratio_property() {
+        let mut parser_input = ParserInput::new("auto 16/9");
+        let mut parser = Parser::new(&mut parser_input);
+        let parsed_property = Property::parse_value(CowRcStr::from("aspect-ratio"), &mut parser)
+            .expect("Failed to parse aspect-ratio");
+
+        match parsed_property {
+            Property::AspectRatio(AspectRatio::AutoRatio(ratio)) => {
+                assert_eq!(ratio, 16.0 / 9.0);
+            }
+
+            _ => panic!("aspect-ratio parsed to wrong property"),
         }
     }
 

--- a/crates/vizia_style/src/values/aspect_ratio.rs
+++ b/crates/vizia_style/src/values/aspect_ratio.rs
@@ -1,0 +1,136 @@
+use cssparser::{ParseError, ParseErrorKind, Parser, ParserInput};
+
+use crate::{CustomParseError, Parse};
+
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub enum AspectRatio {
+    #[default]
+    Auto,
+    Ratio(f32),
+    AutoRatio(f32),
+}
+
+impl AspectRatio {
+    pub fn ratio(self) -> Option<f32> {
+        match self {
+            AspectRatio::Auto => None,
+            AspectRatio::Ratio(ratio) | AspectRatio::AutoRatio(ratio) => Some(ratio),
+        }
+    }
+
+    pub fn is_auto(self) -> bool {
+        matches!(self, AspectRatio::Auto | AspectRatio::AutoRatio(_))
+    }
+}
+
+impl<'i> Parse<'i> for AspectRatio {
+    fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, CustomParseError<'i>>> {
+        let location = input.current_source_location();
+
+        let has_auto = input.try_parse(|parser| parser.expect_ident_matching("auto")).is_ok();
+
+        // CSS allows either `auto`, `<number>`, `<number>/<number>`, or `auto <ratio>`.
+        let ratio = input.try_parse(|parser| {
+            let error_at = |location| ParseError {
+                kind: ParseErrorKind::Custom(CustomParseError::InvalidValue),
+                location,
+            };
+
+            let numerator = parser.expect_number()?;
+            if numerator <= 0.0 || !numerator.is_finite() {
+                return Err(error_at(parser.current_source_location()));
+            }
+
+            let denominator = parser
+                .try_parse(|inner| {
+                    inner.expect_delim('/')?;
+                    let value = inner.expect_number()?;
+                    if value <= 0.0 || !value.is_finite() {
+                        return Err(error_at(inner.current_source_location()));
+                    }
+
+                    Ok(value)
+                })
+                .unwrap_or(1.0);
+
+            let ratio = numerator / denominator;
+            if ratio <= 0.0 || !ratio.is_finite() {
+                return Err(error_at(parser.current_source_location()));
+            }
+
+            Ok(ratio)
+        });
+
+        let parsed = match (has_auto, ratio) {
+            (true, Ok(ratio)) => AspectRatio::AutoRatio(ratio),
+            (true, Err(_)) if input.is_exhausted() => AspectRatio::Auto,
+            (false, Ok(ratio)) => AspectRatio::Ratio(ratio),
+            _ => {
+                return Err(ParseError {
+                    kind: ParseErrorKind::Custom(CustomParseError::InvalidDeclaration),
+                    location,
+                });
+            }
+        };
+
+        if !input.is_exhausted() {
+            return Err(ParseError {
+                kind: ParseErrorKind::Custom(CustomParseError::InvalidDeclaration),
+                location,
+            });
+        }
+
+        Ok(parsed)
+    }
+}
+
+impl From<f32> for AspectRatio {
+    fn from(value: f32) -> Self {
+        if value > 0.0 && value.is_finite() { AspectRatio::Ratio(value) } else { AspectRatio::Auto }
+    }
+}
+
+impl From<f64> for AspectRatio {
+    fn from(value: f64) -> Self {
+        AspectRatio::from(value as f32)
+    }
+}
+
+impl From<&str> for AspectRatio {
+    fn from(s: &str) -> Self {
+        let mut input = ParserInput::new(s);
+        let mut parser = Parser::new(&mut input);
+        AspectRatio::parse(&mut parser).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::assert_parse;
+
+    assert_parse! {
+        AspectRatio, parse_aspect_ratio,
+
+        custom {
+            success {
+                "auto" => AspectRatio::Auto,
+                "1" => AspectRatio::Ratio(1.0),
+                "16/9" => AspectRatio::Ratio(16.0 / 9.0),
+                "1.5" => AspectRatio::Ratio(1.5),
+                "auto 4/3" => AspectRatio::AutoRatio(4.0 / 3.0),
+            }
+
+            failure {
+                "",
+                "none",
+                "0",
+                "-1",
+                "1/0",
+                "auto auto",
+                "auto / 2",
+                "16/9/2",
+            }
+        }
+    }
+}

--- a/crates/vizia_style/src/values/mod.rs
+++ b/crates/vizia_style/src/values/mod.rs
@@ -1,6 +1,7 @@
 pub mod alignment;
 pub mod alpha;
 pub mod angle;
+pub mod aspect_ratio;
 pub mod backdrop_filter;
 pub mod background_repeat;
 pub mod background_size;
@@ -64,6 +65,7 @@ pub mod visibility;
 pub use alignment::*;
 pub use alpha::*;
 pub use angle::*;
+pub use aspect_ratio::*;
 pub use backdrop_filter::*;
 pub use background_repeat::*;
 pub use background_size::*;


### PR DESCRIPTION
Implements CSS aspect-ratio property support with parsing and layout integration. Fixes image sizing bugs:
- Remove double scale-factor application to intrinsic image dimensions to prevent auto-sizing doubling on HiDPI displays
- Correct SVG height assignment (was using fWidth twice)
- Add auto and auto <ratio> aspect ratio handling

Updates morphorm dependency for layout engine compatibility.