### PR TITLE
Add per-side border support

### DIFF
--- a/crates/vizia_core/src/binding/res.rs
+++ b/crates/vizia_core/src/binding/res.rs
@@ -319,6 +319,12 @@ impl Res<PositionType> for PositionType {
     }
 }
 
+impl Res<BorderStyleKeyword> for BorderStyleKeyword {
+    fn get_value(&self, _: &impl DataContext) -> BorderStyleKeyword {
+        *self
+    }
+}
+
 impl<T: Clone + Res<T>> Res<Option<T>> for Option<T> {
     fn get_value(&self, _: &impl DataContext) -> Option<T> {
         self.clone()

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -1135,6 +1135,191 @@ impl DrawContext<'_> {
         Some(path.detach())
     }
 
+    fn round_corner_side_stroke_path(
+        side_ix: usize,
+        bounds: BoundingBox,
+        outer_radii: (f32, f32, f32, f32),
+    ) -> Option<Path> {
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        let (r_tl, r_tr, r_br, r_bl) = outer_radii;
+
+        let mut path = PathBuilder::new();
+        let diag = SQRT_2.recip();
+
+        let outer_tl_center = Point::new(bx + r_tl, by + r_tl);
+        let outer_tr_center = Point::new(bx + bw - r_tr, by + r_tr);
+        let outer_br_center = Point::new(bx + bw - r_br, by + bh - r_br);
+        let outer_bl_center = Point::new(bx + r_bl, by + bh - r_bl);
+
+        match side_ix {
+            0 => {
+                let outer_start = if r_tl > 0.0 {
+                    Point::new(outer_tl_center.x - r_tl * diag, outer_tl_center.y - r_tl * diag)
+                } else {
+                    Point::new(bx, by)
+                };
+                path.move_to(outer_start);
+                if r_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tl_center.x, outer_tl_center.y, r_tl),
+                        225.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw - r_tr, by));
+                if r_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tr_center.x, outer_tr_center.y, r_tr),
+                        270.0,
+                        45.0,
+                        false,
+                    );
+                }
+            }
+            1 => {
+                let outer_start = if r_tr > 0.0 {
+                    Point::new(outer_tr_center.x + r_tr * diag, outer_tr_center.y - r_tr * diag)
+                } else {
+                    Point::new(bx + bw, by)
+                };
+                path.move_to(outer_start);
+                if r_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tr_center.x, outer_tr_center.y, r_tr),
+                        315.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw, by + bh - r_br));
+                if r_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_br_center.x, outer_br_center.y, r_br),
+                        0.0,
+                        45.0,
+                        false,
+                    );
+                }
+            }
+            2 => {
+                let outer_start = if r_br > 0.0 {
+                    Point::new(outer_br_center.x + r_br * diag, outer_br_center.y + r_br * diag)
+                } else {
+                    Point::new(bx + bw, by + bh)
+                };
+                path.move_to(outer_start);
+                if r_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_br_center.x, outer_br_center.y, r_br),
+                        45.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + r_bl, by + bh));
+                if r_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_bl_center.x, outer_bl_center.y, r_bl),
+                        90.0,
+                        45.0,
+                        false,
+                    );
+                }
+            }
+            3 => {
+                let outer_start = if r_bl > 0.0 {
+                    Point::new(outer_bl_center.x - r_bl * diag, outer_bl_center.y + r_bl * diag)
+                } else {
+                    Point::new(bx, by + bh)
+                };
+                path.move_to(outer_start);
+                if r_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_bl_center.x, outer_bl_center.y, r_bl),
+                        135.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx, by + r_tl));
+                if r_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tl_center.x, outer_tl_center.y, r_tl),
+                        180.0,
+                        45.0,
+                        false,
+                    );
+                }
+            }
+            _ => return None,
+        }
+
+        Some(path.detach())
+    }
+
+    fn bevel_corner_side_stroke_path(
+        side_ix: usize,
+        bounds: BoundingBox,
+        outer_radii: (f32, f32, f32, f32),
+    ) -> Option<Path> {
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        let (r_tl, r_tr, r_br, r_bl) = outer_radii;
+
+        let otl = r_tl.min(bw * 0.5).min(bh * 0.5);
+        let otr = r_tr.min(bw * 0.5).min(bh * 0.5);
+        let obr = r_br.min(bw * 0.5).min(bh * 0.5);
+        let obl = r_bl.min(bw * 0.5).min(bh * 0.5);
+
+        let outer_tl_top = Point::new(bx + otl, by);
+        let outer_tl_left = Point::new(bx, by + otl);
+        let outer_tr_top = Point::new(bx + bw - otr, by);
+        let outer_tr_right = Point::new(bx + bw, by + otr);
+        let outer_br_right = Point::new(bx + bw, by + bh - obr);
+        let outer_br_bottom = Point::new(bx + bw - obr, by + bh);
+        let outer_bl_bottom = Point::new(bx + obl, by + bh);
+        let outer_bl_left = Point::new(bx, by + bh - obl);
+
+        let mut path = PathBuilder::new();
+        match side_ix {
+            0 => {
+                path.move_to(outer_tl_left);
+                path.line_to(outer_tl_top);
+                path.line_to(outer_tr_top);
+                path.line_to(outer_tr_right);
+            }
+            1 => {
+                path.move_to(outer_tr_top);
+                path.line_to(outer_tr_right);
+                path.line_to(outer_br_right);
+                path.line_to(outer_br_bottom);
+            }
+            2 => {
+                path.move_to(outer_br_right);
+                path.line_to(outer_br_bottom);
+                path.line_to(outer_bl_bottom);
+                path.line_to(outer_bl_left);
+            }
+            3 => {
+                path.move_to(outer_bl_bottom);
+                path.line_to(outer_bl_left);
+                path.line_to(outer_tl_left);
+                path.line_to(outer_tl_top);
+            }
+            _ => return None,
+        }
+
+        Some(path.detach())
+    }
+
     fn smooth_corner_side_path(
         side_ix: usize,
         bounds: BoundingBox,
@@ -1955,37 +2140,123 @@ impl DrawContext<'_> {
                     canvas.save();
                     canvas.clip_path(&side_region, ClipOp::Intersect, true);
 
-                    // Side-local center-line stroke with independent dashing.
-                    let mut side_path = PathBuilder::new();
-                    let (sx, sy, ex, ey) = match side_ix {
-                        0 => (
-                            bx + left_width * 0.5,
-                            by + top_width * 0.5,
-                            bx + bw - right_width * 0.5,
-                            by + top_width * 0.5,
-                        ),
-                        1 => (
-                            bx + bw - right_width * 0.5,
-                            by + top_width * 0.5,
-                            bx + bw - right_width * 0.5,
-                            by + bh - bottom_width * 0.5,
-                        ),
-                        2 => (
-                            bx + left_width * 0.5,
-                            by + bh - bottom_width * 0.5,
-                            bx + bw - right_width * 0.5,
-                            by + bh - bottom_width * 0.5,
-                        ),
-                        _ => (
-                            bx + left_width * 0.5,
-                            by + top_width * 0.5,
-                            bx + left_width * 0.5,
-                            by + bh - bottom_width * 0.5,
-                        ),
+                    let stroke_path = if exact_round_solid {
+                        Self::round_corner_side_stroke_path(
+                            side_ix,
+                            bounds,
+                            (r_tl, r_tr, r_br, r_bl),
+                        )
+                        .unwrap_or_else(|| {
+                            let mut side_path = PathBuilder::new();
+                            let (sx, sy, ex, ey) = match side_ix {
+                                0 => (
+                                    bx + left_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + top_width * 0.5,
+                                ),
+                                1 => (
+                                    bx + bw - right_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                                2 => (
+                                    bx + left_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                                _ => (
+                                    bx + left_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + left_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                            };
+                            side_path.move_to((sx, sy));
+                            side_path.line_to((ex, ey));
+                            side_path.detach()
+                        })
+                    } else if exact_bevel_solid {
+                        Self::bevel_corner_side_stroke_path(
+                            side_ix,
+                            bounds,
+                            (r_tl, r_tr, r_br, r_bl),
+                        )
+                        .unwrap_or_else(|| {
+                            let mut side_path = PathBuilder::new();
+                            let (sx, sy, ex, ey) = match side_ix {
+                                0 => (
+                                    bx + left_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + top_width * 0.5,
+                                ),
+                                1 => (
+                                    bx + bw - right_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                                2 => (
+                                    bx + left_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                    bx + bw - right_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                                _ => (
+                                    bx + left_width * 0.5,
+                                    by + top_width * 0.5,
+                                    bx + left_width * 0.5,
+                                    by + bh - bottom_width * 0.5,
+                                ),
+                            };
+                            side_path.move_to((sx, sy));
+                            side_path.line_to((ex, ey));
+                            side_path.detach()
+                        })
+                    } else if exact_smooth_solid {
+                        self.build_path_with_corners(
+                            bounds,
+                            (-side_width * 0.5, -side_width * 0.5),
+                            (r_tl, r_tr, r_br, r_bl),
+                            corner_shapes,
+                            corner_smoothing,
+                        )
+                        .make_offset(bounds.top_left())
+                    } else {
+                        let mut side_path = PathBuilder::new();
+                        let (sx, sy, ex, ey) = match side_ix {
+                            0 => (
+                                bx + left_width * 0.5,
+                                by + top_width * 0.5,
+                                bx + bw - right_width * 0.5,
+                                by + top_width * 0.5,
+                            ),
+                            1 => (
+                                bx + bw - right_width * 0.5,
+                                by + top_width * 0.5,
+                                bx + bw - right_width * 0.5,
+                                by + bh - bottom_width * 0.5,
+                            ),
+                            2 => (
+                                bx + left_width * 0.5,
+                                by + bh - bottom_width * 0.5,
+                                bx + bw - right_width * 0.5,
+                                by + bh - bottom_width * 0.5,
+                            ),
+                            _ => (
+                                bx + left_width * 0.5,
+                                by + top_width * 0.5,
+                                bx + left_width * 0.5,
+                                by + bh - bottom_width * 0.5,
+                            ),
+                        };
+                        side_path.move_to((sx, sy));
+                        side_path.line_to((ex, ey));
+                        side_path.detach()
                     };
-                    side_path.move_to((sx, sy));
-                    side_path.line_to((ex, ey));
-                    let stroke_path = side_path.detach();
                     let mut paint = Paint::default();
                     paint.set_style(PaintStyle::Stroke);
                     paint.set_color(color);

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -2131,9 +2131,9 @@ impl DrawContext<'_> {
             side_mask.line_to(mask_pts[3]);
             side_mask.close();
             let side_mask = side_mask.detach();
-            let side_region = ring_path
-                .op(&side_mask, skia_safe::PathOp::Intersect)
-                .unwrap_or_else(|| ring_path.clone());
+            let Some(side_region) = ring_path.op(&side_mask, skia_safe::PathOp::Intersect) else {
+                continue;
+            };
 
             match style {
                 BorderStyleKeyword::Dashed | BorderStyleKeyword::Dotted => {
@@ -2309,8 +2309,11 @@ impl DrawContext<'_> {
                     paint.set_color(color);
                     paint.set_anti_alias(true);
                     if let Some(path) = exact_side_path {
-                        let constrained_path =
-                            path.op(&ring_path, skia_safe::PathOp::Intersect).unwrap_or(path);
+                        let Some(constrained_path) =
+                            path.op(&ring_path, skia_safe::PathOp::Intersect)
+                        else {
+                            continue;
+                        };
                         canvas.draw_path(&constrained_path, &paint);
                     } else {
                         canvas.draw_path(&side_region, &paint);

--- a/crates/vizia_core/src/context/draw.rs
+++ b/crates/vizia_core/src/context/draw.rs
@@ -224,15 +224,100 @@ impl DrawContext<'_> {
         self.style.physical_to_logical(physical)
     }
 
-    /// Returns the border width of the current view in physical pixels.
-    pub fn border_width(&self) -> f32 {
-        if let Some(length) =
-            self.style.border_width.get_resolved(self.current, &self.style.custom_length_props)
-        {
-            let bounds = self.bounds();
-            return length.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round();
-        }
-        0.0
+    /// Returns the top border width of the current view in physical pixels.
+    pub fn border_top_width(&self) -> f32 {
+        let bounds = self.bounds();
+        self.style
+            .border_top_width
+            .get_resolved(self.current, &self.style.custom_length_props)
+            .map(|l| l.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round())
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the right border width of the current view in physical pixels.
+    pub fn border_right_width(&self) -> f32 {
+        let bounds = self.bounds();
+        self.style
+            .border_right_width
+            .get_resolved(self.current, &self.style.custom_length_props)
+            .map(|l| l.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round())
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the bottom border width of the current view in physical pixels.
+    pub fn border_bottom_width(&self) -> f32 {
+        let bounds = self.bounds();
+        self.style
+            .border_bottom_width
+            .get_resolved(self.current, &self.style.custom_length_props)
+            .map(|l| l.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round())
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the left border width of the current view in physical pixels.
+    pub fn border_left_width(&self) -> f32 {
+        let bounds = self.bounds();
+        self.style
+            .border_left_width
+            .get_resolved(self.current, &self.style.custom_length_props)
+            .map(|l| l.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round())
+            .unwrap_or(0.0)
+    }
+
+    /// Returns the top border color of the current view.
+    pub fn border_top_color(&self) -> Color {
+        self.style
+            .border_top_color
+            .get_resolved(self.current, &self.style.custom_color_props)
+            .map(|c| Color::rgba(c.r(), c.g(), c.b(), c.a()))
+            .unwrap_or(Color::rgba(0, 0, 0, 0))
+    }
+
+    /// Returns the right border color of the current view.
+    pub fn border_right_color(&self) -> Color {
+        self.style
+            .border_right_color
+            .get_resolved(self.current, &self.style.custom_color_props)
+            .map(|c| Color::rgba(c.r(), c.g(), c.b(), c.a()))
+            .unwrap_or(Color::rgba(0, 0, 0, 0))
+    }
+
+    /// Returns the bottom border color of the current view.
+    pub fn border_bottom_color(&self) -> Color {
+        self.style
+            .border_bottom_color
+            .get_resolved(self.current, &self.style.custom_color_props)
+            .map(|c| Color::rgba(c.r(), c.g(), c.b(), c.a()))
+            .unwrap_or(Color::rgba(0, 0, 0, 0))
+    }
+
+    /// Returns the left border color of the current view.
+    pub fn border_left_color(&self) -> Color {
+        self.style
+            .border_left_color
+            .get_resolved(self.current, &self.style.custom_color_props)
+            .map(|c| Color::rgba(c.r(), c.g(), c.b(), c.a()))
+            .unwrap_or(Color::rgba(0, 0, 0, 0))
+    }
+
+    /// Returns the top border style of the current view.
+    pub fn border_top_style(&self) -> BorderStyleKeyword {
+        self.style.border_top_style.get(self.current).copied().unwrap_or_default()
+    }
+
+    /// Returns the right border style of the current view.
+    pub fn border_right_style(&self) -> BorderStyleKeyword {
+        self.style.border_right_style.get(self.current).copied().unwrap_or_default()
+    }
+
+    /// Returns the bottom border style of the current view.
+    pub fn border_bottom_style(&self) -> BorderStyleKeyword {
+        self.style.border_bottom_style.get(self.current).copied().unwrap_or_default()
+    }
+
+    /// Returns the left border style of the current view.
+    pub fn border_left_style(&self) -> BorderStyleKeyword {
+        self.style.border_left_style.get(self.current).copied().unwrap_or_default()
     }
 
     /// Returns the outline color of the current view.
@@ -389,19 +474,21 @@ impl DrawContext<'_> {
     }
 
     /// Returns the border color of the current view.
+    /// This returns the top border color; use side-specific getters for per-side access.
     pub fn border_color(&self) -> Color {
-        if let Some(col) =
-            self.style.border_color.get_resolved(self.current, &self.style.custom_color_props)
-        {
-            Color::rgba(col.r(), col.g(), col.b(), col.a())
-        } else {
-            Color::rgba(0, 0, 0, 0)
-        }
+        self.border_top_color()
     }
 
     /// Returns the border style of the current view.
+    /// This returns the top border style; use side-specific getters for per-side access.
     pub fn border_style(&self) -> BorderStyleKeyword {
-        self.style.border_style.get(self.current).copied().unwrap_or_default()
+        self.border_top_style()
+    }
+
+    /// Returns the border width of the current view in physical pixels.
+    /// This returns the top border width; use side-specific getters for per-side access.
+    pub fn border_width(&self) -> f32 {
+        self.border_top_width()
     }
 
     /// Returns the text selection color for the current view.
@@ -502,20 +589,56 @@ impl DrawContext<'_> {
 
     /// Get the vector path of the current view.
     pub fn build_path(&self, bounds: BoundingBox, outset: (f32, f32)) -> Path {
-        let corner_top_left_radius = self.corner_top_left_radius();
-        let corner_top_right_radius = self.corner_top_right_radius();
-        let corner_bottom_right_radius = self.corner_bottom_right_radius();
-        let corner_bottom_left_radius = self.corner_bottom_left_radius();
+        self.build_path_with_corners(
+            bounds,
+            outset,
+            (
+                self.corner_top_left_radius(),
+                self.corner_top_right_radius(),
+                self.corner_bottom_right_radius(),
+                self.corner_bottom_left_radius(),
+            ),
+            (
+                self.corner_top_left_shape(),
+                self.corner_top_right_shape(),
+                self.corner_bottom_right_shape(),
+                self.corner_bottom_left_shape(),
+            ),
+            (
+                self.corner_top_left_smoothing(),
+                self.corner_top_right_smoothing(),
+                self.corner_bottom_right_smoothing(),
+                self.corner_bottom_left_smoothing(),
+            ),
+        )
+    }
 
-        let corner_top_left_shape = self.corner_top_left_shape();
-        let corner_top_right_shape = self.corner_top_right_shape();
-        let corner_bottom_right_shape = self.corner_bottom_right_shape();
-        let corner_bottom_left_shape = self.corner_bottom_left_shape();
-
-        let corner_top_left_smoothing = self.corner_top_left_smoothing();
-        let corner_top_right_smoothing = self.corner_top_right_smoothing();
-        let corner_bottom_right_smoothing = self.corner_bottom_right_smoothing();
-        let corner_bottom_left_smoothing = self.corner_bottom_left_smoothing();
+    fn build_path_with_corners(
+        &self,
+        bounds: BoundingBox,
+        outset: (f32, f32),
+        corner_radii: (f32, f32, f32, f32),
+        corner_shapes: (CornerShape, CornerShape, CornerShape, CornerShape),
+        corner_smoothing: (f32, f32, f32, f32),
+    ) -> Path {
+        let (
+            corner_top_left_radius,
+            corner_top_right_radius,
+            corner_bottom_right_radius,
+            corner_bottom_left_radius,
+        ) = corner_radii;
+        let (
+            corner_top_left_shape,
+            corner_top_right_shape,
+            corner_bottom_right_shape,
+            corner_bottom_left_shape,
+        ) = corner_shapes;
+        let (
+            corner_top_left_smoothing,
+            corner_top_right_smoothing,
+            corner_bottom_right_smoothing,
+            corner_bottom_left_smoothing,
+        ) = corner_smoothing;
 
         let bounds = BoundingBox::from_min_max(0.0, 0.0, bounds.w, bounds.h);
 
@@ -539,7 +662,6 @@ impl DrawContext<'_> {
         let height = rr.height();
         let mut should_offset = true;
 
-        //TODO: Cache the path and regenerate if the bounds change
         let mut path = PathBuilder::new();
 
         if width == height
@@ -670,6 +792,901 @@ impl DrawContext<'_> {
         if should_offset { path.make_offset((x, y)) } else { path }
     }
 
+    fn corner_oval(center_x: f32, center_y: f32, radius: f32) -> Rect {
+        Rect::from_xywh(center_x - radius, center_y - radius, radius * 2.0, radius * 2.0)
+    }
+
+    fn round_corner_side_path(
+        side_ix: usize,
+        bounds: BoundingBox,
+        outer_radii: (f32, f32, f32, f32),
+        inner_radii: (f32, f32, f32, f32),
+        widths: (f32, f32, f32, f32),
+    ) -> Option<Path> {
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        let (r_tl, r_tr, r_br, r_bl) = outer_radii;
+        let (ir_tl, ir_tr, ir_br, ir_bl) = inner_radii;
+        let (top_width, right_width, bottom_width, left_width) = widths;
+
+        let mut path = PathBuilder::new();
+        let diag = SQRT_2.recip();
+
+        let outer_tl_center = Point::new(bx + r_tl, by + r_tl);
+        let outer_tr_center = Point::new(bx + bw - r_tr, by + r_tr);
+        let outer_br_center = Point::new(bx + bw - r_br, by + bh - r_br);
+        let outer_bl_center = Point::new(bx + r_bl, by + bh - r_bl);
+
+        let inner_tl_center = Point::new(bx + left_width + ir_tl, by + top_width + ir_tl);
+        let inner_tr_center = Point::new(bx + bw - right_width - ir_tr, by + top_width + ir_tr);
+        let inner_br_center =
+            Point::new(bx + bw - right_width - ir_br, by + bh - bottom_width - ir_br);
+        let inner_bl_center = Point::new(bx + left_width + ir_bl, by + bh - bottom_width - ir_bl);
+
+        match side_ix {
+            0 => {
+                let outer_start = if r_tl > 0.0 {
+                    Point::new(outer_tl_center.x - r_tl * diag, outer_tl_center.y - r_tl * diag)
+                } else {
+                    Point::new(bx, by)
+                };
+                path.move_to(outer_start);
+                if r_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tl_center.x, outer_tl_center.y, r_tl),
+                        225.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw - r_tr, by));
+                if r_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tr_center.x, outer_tr_center.y, r_tr),
+                        270.0,
+                        45.0,
+                        false,
+                    );
+                }
+
+                let inner_split = if ir_tr > 0.0 {
+                    Point::new(inner_tr_center.x + ir_tr * diag, inner_tr_center.y - ir_tr * diag)
+                } else {
+                    Point::new(bx + bw - right_width, by + top_width)
+                };
+                path.line_to(inner_split);
+                if ir_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_tr_center.x, inner_tr_center.y, ir_tr),
+                        315.0,
+                        -45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + left_width + ir_tl, by + top_width));
+                if ir_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_tl_center.x, inner_tl_center.y, ir_tl),
+                        270.0,
+                        -45.0,
+                        false,
+                    );
+                }
+            }
+            1 => {
+                let outer_start = if r_tr > 0.0 {
+                    Point::new(outer_tr_center.x + r_tr * diag, outer_tr_center.y - r_tr * diag)
+                } else {
+                    Point::new(bx + bw, by)
+                };
+                path.move_to(outer_start);
+                if r_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tr_center.x, outer_tr_center.y, r_tr),
+                        315.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw, by + bh - r_br));
+                if r_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_br_center.x, outer_br_center.y, r_br),
+                        0.0,
+                        45.0,
+                        false,
+                    );
+                }
+
+                let inner_split = if ir_br > 0.0 {
+                    Point::new(inner_br_center.x + ir_br * diag, inner_br_center.y + ir_br * diag)
+                } else {
+                    Point::new(bx + bw - right_width, by + bh - bottom_width)
+                };
+                path.line_to(inner_split);
+                if ir_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_br_center.x, inner_br_center.y, ir_br),
+                        45.0,
+                        -45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw - right_width, by + top_width + ir_tr));
+                if ir_tr > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_tr_center.x, inner_tr_center.y, ir_tr),
+                        0.0,
+                        -45.0,
+                        false,
+                    );
+                }
+            }
+            2 => {
+                let outer_start = if r_br > 0.0 {
+                    Point::new(outer_br_center.x + r_br * diag, outer_br_center.y + r_br * diag)
+                } else {
+                    Point::new(bx + bw, by + bh)
+                };
+                path.move_to(outer_start);
+                if r_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_br_center.x, outer_br_center.y, r_br),
+                        45.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + r_bl, by + bh));
+                if r_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_bl_center.x, outer_bl_center.y, r_bl),
+                        90.0,
+                        45.0,
+                        false,
+                    );
+                }
+
+                let inner_split = if ir_bl > 0.0 {
+                    Point::new(inner_bl_center.x - ir_bl * diag, inner_bl_center.y + ir_bl * diag)
+                } else {
+                    Point::new(bx + left_width, by + bh - bottom_width)
+                };
+                path.line_to(inner_split);
+                if ir_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_bl_center.x, inner_bl_center.y, ir_bl),
+                        135.0,
+                        -45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + bw - right_width - ir_br, by + bh - bottom_width));
+                if ir_br > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_br_center.x, inner_br_center.y, ir_br),
+                        90.0,
+                        -45.0,
+                        false,
+                    );
+                }
+            }
+            3 => {
+                let outer_start = if r_bl > 0.0 {
+                    Point::new(outer_bl_center.x - r_bl * diag, outer_bl_center.y + r_bl * diag)
+                } else {
+                    Point::new(bx, by + bh)
+                };
+                path.move_to(outer_start);
+                if r_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_bl_center.x, outer_bl_center.y, r_bl),
+                        135.0,
+                        45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx, by + r_tl));
+                if r_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(outer_tl_center.x, outer_tl_center.y, r_tl),
+                        180.0,
+                        45.0,
+                        false,
+                    );
+                }
+
+                let inner_split = if ir_tl > 0.0 {
+                    Point::new(inner_tl_center.x - ir_tl * diag, inner_tl_center.y - ir_tl * diag)
+                } else {
+                    Point::new(bx + left_width, by + top_width)
+                };
+                path.line_to(inner_split);
+                if ir_tl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_tl_center.x, inner_tl_center.y, ir_tl),
+                        225.0,
+                        -45.0,
+                        false,
+                    );
+                }
+                path.line_to((bx + left_width, by + bh - bottom_width - ir_bl));
+                if ir_bl > 0.0 {
+                    path.arc_to(
+                        Self::corner_oval(inner_bl_center.x, inner_bl_center.y, ir_bl),
+                        180.0,
+                        -45.0,
+                        false,
+                    );
+                }
+            }
+            _ => return None,
+        }
+
+        path.close();
+        Some(path.detach())
+    }
+
+    fn bevel_corner_side_path(
+        side_ix: usize,
+        bounds: BoundingBox,
+        outer_radii: (f32, f32, f32, f32),
+        inner_radii: (f32, f32, f32, f32),
+        widths: (f32, f32, f32, f32),
+    ) -> Option<Path> {
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        let (r_tl, r_tr, r_br, r_bl) = outer_radii;
+        let (ir_tl, ir_tr, ir_br, ir_bl) = inner_radii;
+        let (top_width, right_width, bottom_width, left_width) = widths;
+
+        let otl = r_tl.min(bw * 0.5).min(bh * 0.5);
+        let otr = r_tr.min(bw * 0.5).min(bh * 0.5);
+        let obr = r_br.min(bw * 0.5).min(bh * 0.5);
+        let obl = r_bl.min(bw * 0.5).min(bh * 0.5);
+
+        let itl = ir_tl
+            .max(0.0)
+            .min((bw - left_width - right_width).max(0.0) * 0.5)
+            .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+        let itr = ir_tr
+            .max(0.0)
+            .min((bw - left_width - right_width).max(0.0) * 0.5)
+            .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+        let ibr = ir_br
+            .max(0.0)
+            .min((bw - left_width - right_width).max(0.0) * 0.5)
+            .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+        let ibl = ir_bl
+            .max(0.0)
+            .min((bw - left_width - right_width).max(0.0) * 0.5)
+            .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+
+        let outer_tl_top = Point::new(bx + otl, by);
+        let outer_tl_left = Point::new(bx, by + otl);
+        let outer_tr_top = Point::new(bx + bw - otr, by);
+        let outer_tr_right = Point::new(bx + bw, by + otr);
+        let outer_br_right = Point::new(bx + bw, by + bh - obr);
+        let outer_br_bottom = Point::new(bx + bw - obr, by + bh);
+        let outer_bl_bottom = Point::new(bx + obl, by + bh);
+        let outer_bl_left = Point::new(bx, by + bh - obl);
+
+        let inner_tl_top = Point::new(bx + left_width + itl, by + top_width);
+        let inner_tl_left = Point::new(bx + left_width, by + top_width + itl);
+        let inner_tr_top = Point::new(bx + bw - right_width - itr, by + top_width);
+        let inner_tr_right = Point::new(bx + bw - right_width, by + top_width + itr);
+        let inner_br_right = Point::new(bx + bw - right_width, by + bh - bottom_width - ibr);
+        let inner_br_bottom = Point::new(bx + bw - right_width - ibr, by + bh - bottom_width);
+        let inner_bl_bottom = Point::new(bx + left_width + ibl, by + bh - bottom_width);
+        let inner_bl_left = Point::new(bx + left_width, by + bh - bottom_width - ibl);
+
+        let mut path = PathBuilder::new();
+        match side_ix {
+            0 => {
+                path.move_to(outer_tl_left);
+                path.line_to(outer_tl_top);
+                path.line_to(outer_tr_top);
+                path.line_to(outer_tr_right);
+                path.line_to(inner_tr_right);
+                path.line_to(inner_tr_top);
+                path.line_to(inner_tl_top);
+                path.line_to(inner_tl_left);
+            }
+            1 => {
+                path.move_to(outer_tr_top);
+                path.line_to(outer_tr_right);
+                path.line_to(outer_br_right);
+                path.line_to(outer_br_bottom);
+                path.line_to(inner_br_bottom);
+                path.line_to(inner_br_right);
+                path.line_to(inner_tr_right);
+                path.line_to(inner_tr_top);
+            }
+            2 => {
+                path.move_to(outer_br_right);
+                path.line_to(outer_br_bottom);
+                path.line_to(outer_bl_bottom);
+                path.line_to(outer_bl_left);
+                path.line_to(inner_bl_left);
+                path.line_to(inner_bl_bottom);
+                path.line_to(inner_br_bottom);
+                path.line_to(inner_br_right);
+            }
+            3 => {
+                path.move_to(outer_bl_bottom);
+                path.line_to(outer_bl_left);
+                path.line_to(outer_tl_left);
+                path.line_to(outer_tl_top);
+                path.line_to(inner_tl_top);
+                path.line_to(inner_tl_left);
+                path.line_to(inner_bl_left);
+                path.line_to(inner_bl_bottom);
+            }
+            _ => return None,
+        }
+
+        path.close();
+        Some(path.detach())
+    }
+
+    fn smooth_corner_side_path(
+        side_ix: usize,
+        bounds: BoundingBox,
+        outer_radii: (f32, f32, f32, f32),
+        inner_radii: (f32, f32, f32, f32),
+        corner_shapes: (CornerShape, CornerShape, CornerShape, CornerShape),
+        corner_smoothing: (f32, f32, f32, f32),
+        widths: (f32, f32, f32, f32),
+    ) -> Option<Path> {
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        let (r_tl, r_tr, r_br, r_bl) = outer_radii;
+        let (ir_tl, ir_tr, ir_br, ir_bl) = inner_radii;
+        let (corner_tl_shape, corner_tr_shape, corner_br_shape, corner_bl_shape) = corner_shapes;
+        let (corner_tl_smoothing, corner_tr_smoothing, corner_br_smoothing, corner_bl_smoothing) =
+            corner_smoothing;
+        let (top_width, right_width, bottom_width, left_width) = widths;
+
+        let mut path = PathBuilder::new();
+
+        match side_ix {
+            0 => {
+                // Top side: top-left to top-right
+                let otl = r_tl.min(bw * 0.5).min(bh * 0.5);
+                let otr = r_tr.min(bw * 0.5).min(bh * 0.5);
+                let itl = ir_tl
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+                let itr = ir_tr
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+
+                path.move_to((bx + left_width, by + top_width + itl));
+
+                // Outer top-left corner
+                if otl > 0.0 && corner_tl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) =
+                        compute_smooth_corner(otl, corner_tl_smoothing, bw, bh);
+                    let start_x = bx + f32::max(left_width * 0.5, left_width + p - left_width);
+                    let start_y = by + top_width;
+                    path.line_to((start_x, start_y));
+                    path.cubic_to(
+                        (bx + left_width + (p - a), by),
+                        (bx + left_width + (p - a - b), by),
+                        (bx + left_width + (p - a - b - c), d + by),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, l))
+                    .cubic_to(
+                        (bx + left_width + (p - a - b), by + top_width),
+                        (bx + left_width + (p - a), by + top_width),
+                        (bx + left_width + p.min(bw * 0.5), by + top_width),
+                    );
+                } else if otl > 0.0 {
+                    let p = otl.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + left_width + p, by + top_width));
+                } else {
+                    path.line_to((bx + left_width, by + top_width));
+                }
+
+                // Outer top-right corner
+                if otr > 0.0 {
+                    let p = otr.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + bw - right_width - p, by + top_width));
+                    if corner_tr_shape == CornerShape::Round {
+                        let (a, b, c, d, l, radius_val, _) =
+                            compute_smooth_corner(otr, corner_tr_smoothing, bw, bh);
+                        path.cubic_to(
+                            (bx + bw - right_width - (p - a), by),
+                            (bx + bw - right_width - (p - a - b), by),
+                            (bx + bw - right_width - (p - a - b - c) + d, by),
+                        )
+                        .r_arc_to(
+                            (radius_val, radius_val),
+                            0.0,
+                            ArcSize::Small,
+                            PathDirection::CW,
+                            (l, l),
+                        )
+                        .cubic_to(
+                            (bx + bw - right_width - (p - a - b), by + top_width),
+                            (bx + bw - right_width - (p - a), by + top_width),
+                            (bx + bw - right_width - p.min(bw * 0.5), by + top_width),
+                        );
+                    }
+                } else {
+                    path.line_to((bx + bw - right_width, by + top_width));
+                }
+
+                path.line_to((bx + bw - right_width, by + top_width + itr));
+
+                // Inner top-right corner
+                if itr > 0.0 && corner_tr_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        itr,
+                        corner_tr_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.cubic_to(
+                        (bx + bw - right_width - (p - a), by + top_width),
+                        (bx + bw - right_width - (p - a - b), by + top_width),
+                        (bx + bw - right_width - (p - a - b - c), by + top_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, l))
+                    .cubic_to(
+                        (bx + bw - right_width, by + top_width + (p - a - b)),
+                        (bx + bw - right_width, by + top_width + (p - a)),
+                        (
+                            bx + bw - right_width,
+                            by + top_width + p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if itr > 0.0 {
+                    let p = itr.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + bw - right_width, by + top_width + p));
+                }
+
+                // Inner top-left corner
+                if itl > 0.0 && corner_tl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        itl,
+                        corner_tl_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.line_to((bx + left_width + p, by + top_width));
+                    path.cubic_to(
+                        (bx + left_width + (p - a), by + top_width),
+                        (bx + left_width + (p - a - b), by + top_width),
+                        (bx + left_width + (p - a - b - c), by + top_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, -l))
+                    .cubic_to(
+                        (bx + left_width, by + top_width + (p - a - b)),
+                        (bx + left_width, by + top_width + (p - a)),
+                        (
+                            bx + left_width,
+                            by + top_width + p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if itl > 0.0 {
+                    let p = itl.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + left_width, by + top_width + p));
+                }
+            }
+            1 => {
+                // Right side: top-right to bottom-right
+                let otr = r_tr.min(bw * 0.5).min(bh * 0.5);
+                let obr = r_br.min(bw * 0.5).min(bh * 0.5);
+                let itr = ir_tr
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+                let ibr = ir_br
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+
+                path.move_to((bx + bw - right_width - itr, by + top_width));
+
+                // Outer top-right corner
+                if otr > 0.0 && corner_tr_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) =
+                        compute_smooth_corner(otr, corner_tr_smoothing, bw, bh);
+                    let start_x = bx + bw - right_width;
+                    path.line_to((start_x, by + top_width + p));
+                    path.cubic_to(
+                        (start_x, by + (p - a)),
+                        (start_x, by + (p - a - b)),
+                        (start_x - d, by + (p - a - b - c)),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, l))
+                    .cubic_to(
+                        (start_x - (p - a - b), by),
+                        (start_x - (p - a), by),
+                        (start_x - p.min(bw * 0.5), by),
+                    );
+                } else if otr > 0.0 {
+                    let p = otr.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + bw - right_width, by + top_width + p));
+                } else {
+                    path.line_to((bx + bw - right_width, by + top_width));
+                }
+
+                // Outer bottom-right corner
+                if obr > 0.0 {
+                    let p = obr.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + bw - right_width, by + bh - bottom_width - p));
+                    if corner_br_shape == CornerShape::Round {
+                        let (a, b, c, d, l, radius_val, _) =
+                            compute_smooth_corner(obr, corner_br_smoothing, bw, bh);
+                        path.cubic_to(
+                            (bx + bw, by + bh - bottom_width - (p - a)),
+                            (bx + bw, by + bh - bottom_width - (p - a - b)),
+                            (bx + bw, by + bh - bottom_width - (p - a - b - c) + d),
+                        )
+                        .r_arc_to(
+                            (radius_val, radius_val),
+                            0.0,
+                            ArcSize::Small,
+                            PathDirection::CW,
+                            (l, l),
+                        )
+                        .cubic_to(
+                            (bx + bw - (p - a - b), by + bh),
+                            (bx + bw - (p - a), by + bh),
+                            (bx + bw - p.min(bw * 0.5), by + bh),
+                        );
+                    }
+                } else {
+                    path.line_to((bx + bw - right_width, by + bh - bottom_width));
+                }
+
+                path.line_to((bx + bw - right_width - ibr, by + bh - bottom_width));
+
+                // Inner bottom-right corner
+                if ibr > 0.0 && corner_br_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        ibr,
+                        corner_br_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.cubic_to(
+                        (bx + bw - right_width - (p - a), by + bh - bottom_width),
+                        (bx + bw - right_width - (p - a - b), by + bh - bottom_width),
+                        (bx + bw - right_width - (p - a - b - c), by + bh - bottom_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, -l))
+                    .cubic_to(
+                        (bx + bw - right_width, by + bh - bottom_width - (p - a - b)),
+                        (bx + bw - right_width, by + bh - bottom_width - (p - a)),
+                        (
+                            bx + bw - right_width,
+                            by + bh - bottom_width - p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if ibr > 0.0 {
+                    let p = ibr.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + bw - right_width, by + bh - bottom_width - p));
+                }
+
+                // Inner top-right corner
+                if itr > 0.0 && corner_tr_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        itr,
+                        corner_tr_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.line_to((bx + bw - right_width, by + top_width + p));
+                    path.cubic_to(
+                        (bx + bw - right_width, by + top_width + (p - a)),
+                        (bx + bw - right_width, by + top_width + (p - a - b)),
+                        (bx + bw - right_width + d, by + top_width + (p - a - b - c)),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, -l))
+                    .cubic_to(
+                        (bx + bw - right_width - (p - a - b), by + top_width),
+                        (bx + bw - right_width - (p - a), by + top_width),
+                        (
+                            bx + bw - right_width - p.min((bw - left_width - right_width) * 0.5),
+                            by + top_width,
+                        ),
+                    );
+                } else if itr > 0.0 {
+                    let p = itr.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + bw - right_width, by + top_width + p));
+                }
+            }
+            2 => {
+                // Bottom side: bottom-right to bottom-left
+                let obr = r_br.min(bw * 0.5).min(bh * 0.5);
+                let obl = r_bl.min(bw * 0.5).min(bh * 0.5);
+                let ibr = ir_br
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+                let ibl = ir_bl
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+
+                path.move_to((bx + bw - right_width - ibr, by + bh - bottom_width));
+
+                // Outer bottom-right corner
+                if obr > 0.0 && corner_br_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) =
+                        compute_smooth_corner(obr, corner_br_smoothing, bw, bh);
+                    let end_x = bx + bw - right_width;
+                    path.line_to((end_x - p, by + bh - bottom_width));
+                    path.cubic_to(
+                        (end_x - (p - a), by + bh),
+                        (end_x - (p - a - b), by + bh),
+                        (end_x - (p - a - b - c) + d, by + bh),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, l))
+                    .cubic_to(
+                        (end_x - (p - a - b), by + bh - bottom_width),
+                        (end_x - (p - a), by + bh - bottom_width),
+                        (end_x - p.min(bw * 0.5), by + bh - bottom_width),
+                    );
+                } else if obr > 0.0 {
+                    let p = obr.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + bw - right_width - p, by + bh - bottom_width));
+                } else {
+                    path.line_to((bx + bw - right_width, by + bh - bottom_width));
+                }
+
+                // Outer bottom-left corner
+                if obl > 0.0 {
+                    let p = obl.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + left_width + p, by + bh - bottom_width));
+                    if corner_bl_shape == CornerShape::Round {
+                        let (a, b, c, d, l, radius_val, _) =
+                            compute_smooth_corner(obl, corner_bl_smoothing, bw, bh);
+                        path.cubic_to(
+                            (bx + left_width + (p - a), by + bh),
+                            (bx + left_width + (p - a - b), by + bh),
+                            (bx + left_width + (p - a - b - c) - d, by + bh),
+                        )
+                        .r_arc_to(
+                            (radius_val, radius_val),
+                            0.0,
+                            ArcSize::Small,
+                            PathDirection::CW,
+                            (-l, -l),
+                        )
+                        .cubic_to(
+                            (bx + left_width + (p - a - b), by + bh - bottom_width),
+                            (bx + left_width + (p - a), by + bh - bottom_width),
+                            (bx + left_width + p.min(bw * 0.5), by + bh - bottom_width),
+                        );
+                    }
+                } else {
+                    path.line_to((bx + left_width, by + bh - bottom_width));
+                }
+
+                path.line_to((bx + left_width + ibl, by + bh - bottom_width));
+
+                // Inner bottom-left corner
+                if ibl > 0.0 && corner_bl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        ibl,
+                        corner_bl_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.cubic_to(
+                        (bx + left_width + (p - a), by + bh - bottom_width),
+                        (bx + left_width + (p - a - b), by + bh - bottom_width),
+                        (bx + left_width + (p - a - b - c), by + bh - bottom_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, -l))
+                    .cubic_to(
+                        (bx + left_width, by + bh - bottom_width - (p - a - b)),
+                        (bx + left_width, by + bh - bottom_width - (p - a)),
+                        (
+                            bx + left_width,
+                            by + bh - bottom_width - p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if ibl > 0.0 {
+                    let p = ibl.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + left_width, by + bh - bottom_width - p));
+                }
+
+                // Inner bottom-right corner
+                if ibr > 0.0 && corner_br_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        ibr,
+                        corner_br_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.line_to((bx + bw - right_width - p, by + bh - bottom_width));
+                    path.cubic_to(
+                        (bx + bw - right_width - (p - a), by + bh - bottom_width),
+                        (bx + bw - right_width - (p - a - b), by + bh - bottom_width),
+                        (bx + bw - right_width - (p - a - b - c), by + bh - bottom_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, l))
+                    .cubic_to(
+                        (bx + bw - right_width, by + bh - bottom_width - (p - a - b)),
+                        (bx + bw - right_width, by + bh - bottom_width - (p - a)),
+                        (
+                            bx + bw - right_width,
+                            by + bh - bottom_width - p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if ibr > 0.0 {
+                    let p = ibr.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + bw - right_width, by + bh - bottom_width - p));
+                }
+            }
+            3 => {
+                // Left side: bottom-left to top-left
+                let obl = r_bl.min(bw * 0.5).min(bh * 0.5);
+                let otl = r_tl.min(bw * 0.5).min(bh * 0.5);
+                let ibl = ir_bl
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+                let itl = ir_tl
+                    .max(0.0)
+                    .min((bw - left_width - right_width).max(0.0) * 0.5)
+                    .min((bh - top_width - bottom_width).max(0.0) * 0.5);
+
+                path.move_to((bx + left_width + ibl, by + bh - bottom_width));
+
+                // Outer bottom-left corner
+                if obl > 0.0 && corner_bl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) =
+                        compute_smooth_corner(obl, corner_bl_smoothing, bw, bh);
+                    path.line_to((bx + left_width, by + bh - bottom_width - p));
+                    path.cubic_to(
+                        (bx, by + bh - bottom_width - (p - a)),
+                        (bx, by + bh - bottom_width - (p - a - b)),
+                        (bx, by + bh - bottom_width - (p - a - b - c) - d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, -l))
+                    .cubic_to(
+                        (bx + (p - a - b), by),
+                        (bx + (p - a), by),
+                        (bx + p.min(bw * 0.5), by),
+                    );
+                } else if obl > 0.0 {
+                    let p = obl.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + left_width, by + bh - bottom_width - p));
+                } else {
+                    path.line_to((bx + left_width, by + bh - bottom_width));
+                }
+
+                // Outer top-left corner
+                if otl > 0.0 {
+                    let p = otl.min((bw * 0.5).min(bh * 0.5));
+                    path.line_to((bx + left_width, by + top_width + p));
+                    if corner_tl_shape == CornerShape::Round {
+                        let (a, b, c, d, l, radius_val, _) =
+                            compute_smooth_corner(otl, corner_tl_smoothing, bw, bh);
+                        path.cubic_to(
+                            (bx, by + top_width + (p - a)),
+                            (bx, by + top_width + (p - a - b)),
+                            (bx, by + top_width + (p - a - b - c) - d),
+                        )
+                        .r_arc_to(
+                            (radius_val, radius_val),
+                            0.0,
+                            ArcSize::Small,
+                            PathDirection::CW,
+                            (l, l),
+                        )
+                        .cubic_to(
+                            (bx + (p - a - b), by),
+                            (bx + (p - a), by),
+                            (bx + p.min(bw * 0.5), by),
+                        );
+                    }
+                } else {
+                    path.line_to((bx + left_width, by + top_width));
+                }
+
+                path.line_to((bx + left_width + itl, by + top_width));
+
+                // Inner top-left corner
+                if itl > 0.0 && corner_tl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        itl,
+                        corner_tl_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.cubic_to(
+                        (bx + left_width + (p - a), by + top_width),
+                        (bx + left_width + (p - a - b), by + top_width),
+                        (bx + left_width + (p - a - b - c), by + top_width + d),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (l, l))
+                    .cubic_to(
+                        (bx + left_width, by + top_width + (p - a - b)),
+                        (bx + left_width, by + top_width + (p - a)),
+                        (
+                            bx + left_width,
+                            by + top_width + p.min((bh - top_width - bottom_width) * 0.5),
+                        ),
+                    );
+                } else if itl > 0.0 {
+                    let p = itl.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + left_width, by + top_width + p));
+                }
+
+                // Inner bottom-left corner
+                if ibl > 0.0 && corner_bl_shape == CornerShape::Round {
+                    let (a, b, c, d, l, p, radius) = compute_smooth_corner(
+                        ibl,
+                        corner_bl_smoothing,
+                        bw - left_width - right_width,
+                        bh - top_width - bottom_width,
+                    );
+                    path.line_to((bx + left_width, by + bh - bottom_width - p));
+                    path.cubic_to(
+                        (bx + left_width, by + bh - bottom_width - (p - a)),
+                        (bx + left_width, by + bh - bottom_width - (p - a - b)),
+                        (bx + left_width - d, by + bh - bottom_width - (p - a - b - c)),
+                    )
+                    .r_arc_to((radius, radius), 0.0, ArcSize::Small, PathDirection::CW, (-l, -l))
+                    .cubic_to(
+                        (bx + left_width + (p - a - b), by + bh),
+                        (bx + left_width + (p - a), by + bh),
+                        (bx + left_width + p.min((bw - left_width - right_width) * 0.5), by + bh),
+                    );
+                } else if ibl > 0.0 {
+                    let p = ibl.min(
+                        ((bh - top_width - bottom_width) * 0.5)
+                            .min((bw - left_width - right_width) * 0.5),
+                    );
+                    path.line_to((bx + left_width, by + bh - bottom_width - p));
+                }
+            }
+            _ => return None,
+        }
+
+        path.close();
+        Some(path.detach())
+    }
+
     /// Draw background color or background image (including gradients) for the current view.
     pub fn draw_background(&mut self, canvas: &Canvas) {
         let background_color = self.background_color();
@@ -691,38 +1708,344 @@ impl DrawContext<'_> {
     }
 
     /// Draw the border of the current view.
+    ///
+    /// Supports individual side widths, colors, and styles. Borders are rendered from a
+    /// ring path (outer minus inner), then split into per-side ownership paths using path
+    /// intersections. Dashed/dotted use side-local center-line strokes clipped by the
+    /// corresponding side ownership path.
     pub fn draw_border(&mut self, canvas: &Canvas) {
-        let border_color = self.border_color();
-        let border_width = self.border_width();
-        let border_style = self.border_style();
+        let top_width = self.border_top_width();
+        let right_width = self.border_right_width();
+        let bottom_width = self.border_bottom_width();
+        let left_width = self.border_left_width();
 
-        if border_width > 0.0 && border_color.a() > 0 && border_style != BorderStyleKeyword::None {
-            let bounds = self.bounds();
-            let path = self
-                .build_path(bounds, (-border_width / 2.0, -border_width / 2.0))
-                .make_offset(bounds.top_left());
-            let mut paint = Paint::default();
-            paint.set_style(PaintStyle::Stroke);
-            paint.set_color(border_color);
-            paint.set_stroke_width(border_width);
-            match border_style {
-                BorderStyleKeyword::Dashed => {
-                    paint.set_path_effect(PathEffect::dash(
-                        &[border_width * 2.0, border_width],
-                        0.0,
-                    ));
+        let top_color = self.border_top_color();
+        let right_color = self.border_right_color();
+        let bottom_color = self.border_bottom_color();
+        let left_color = self.border_left_color();
+
+        let top_style = self.border_top_style();
+        let right_style = self.border_right_style();
+        let bottom_style = self.border_bottom_style();
+        let left_style = self.border_left_style();
+
+        let top_vis = top_width > 0.0 && top_color.a() > 0 && top_style != BorderStyleKeyword::None;
+        let right_vis =
+            right_width > 0.0 && right_color.a() > 0 && right_style != BorderStyleKeyword::None;
+        let bottom_vis =
+            bottom_width > 0.0 && bottom_color.a() > 0 && bottom_style != BorderStyleKeyword::None;
+        let left_vis =
+            left_width > 0.0 && left_color.a() > 0 && left_style != BorderStyleKeyword::None;
+
+        if !top_vis && !right_vis && !bottom_vis && !left_vis {
+            return;
+        }
+
+        let bounds = self.bounds();
+        let bx = bounds.x;
+        let by = bounds.y;
+        let bw = bounds.w;
+        let bh = bounds.h;
+
+        // Outer corner radii (from style).
+        let r_tl = self.corner_top_left_radius();
+        let r_tr = self.corner_top_right_radius();
+        let r_br = self.corner_bottom_right_radius();
+        let r_bl = self.corner_bottom_left_radius();
+
+        // Inner corner radii: outer radius minus the thicker adjacent border, clamped to 0.
+        let ir_tl = (r_tl - top_width.max(left_width)).max(0.0);
+        let ir_tr = (r_tr - top_width.max(right_width)).max(0.0);
+        let ir_br = (r_br - bottom_width.max(right_width)).max(0.0);
+        let ir_bl = (r_bl - bottom_width.max(left_width)).max(0.0);
+
+        // Inner rect dimensions.
+        let inner_w = (bw - left_width - right_width).max(0.0);
+        let inner_h = (bh - top_width - bottom_width).max(0.0);
+        let inner_is_empty = inner_w <= 0.0 || inner_h <= 0.0;
+
+        let corner_shapes = (
+            self.corner_top_left_shape(),
+            self.corner_top_right_shape(),
+            self.corner_bottom_right_shape(),
+            self.corner_bottom_left_shape(),
+        );
+        let corner_smoothing = (
+            self.corner_top_left_smoothing(),
+            self.corner_top_right_smoothing(),
+            self.corner_bottom_right_smoothing(),
+            self.corner_bottom_left_smoothing(),
+        );
+        let uniform_borders = top_width == right_width
+            && right_width == bottom_width
+            && bottom_width == left_width
+            && top_color == right_color
+            && right_color == bottom_color
+            && bottom_color == left_color
+            && top_style == right_style
+            && right_style == bottom_style
+            && bottom_style == left_style;
+        let uniform_corners = r_tl == r_tr
+            && r_tr == r_br
+            && r_br == r_bl
+            && corner_shapes.0 == corner_shapes.1
+            && corner_shapes.1 == corner_shapes.2
+            && corner_shapes.2 == corner_shapes.3
+            && corner_smoothing.0 == corner_smoothing.1
+            && corner_smoothing.1 == corner_smoothing.2
+            && corner_smoothing.2 == corner_smoothing.3;
+        let exact_round_solid = !inner_is_empty
+            && corner_shapes.0 == CornerShape::Round
+            && corner_shapes.1 == CornerShape::Round
+            && corner_shapes.2 == CornerShape::Round
+            && corner_shapes.3 == CornerShape::Round
+            && corner_smoothing.0 == 0.0
+            && corner_smoothing.1 == 0.0
+            && corner_smoothing.2 == 0.0
+            && corner_smoothing.3 == 0.0;
+        let exact_bevel_solid = !inner_is_empty
+            && corner_shapes.0 == CornerShape::Bevel
+            && corner_shapes.1 == CornerShape::Bevel
+            && corner_shapes.2 == CornerShape::Bevel
+            && corner_shapes.3 == CornerShape::Bevel
+            && corner_smoothing.0 == 0.0
+            && corner_smoothing.1 == 0.0
+            && corner_smoothing.2 == 0.0
+            && corner_smoothing.3 == 0.0;
+        let exact_smooth_solid = !inner_is_empty
+            && corner_shapes.0 == CornerShape::Round
+            && corner_shapes.1 == CornerShape::Round
+            && corner_shapes.2 == CornerShape::Round
+            && corner_shapes.3 == CornerShape::Round
+            && (corner_smoothing.0 > 0.0
+                || corner_smoothing.1 > 0.0
+                || corner_smoothing.2 > 0.0
+                || corner_smoothing.3 > 0.0);
+
+        // Outer path in world coordinates.
+        let outer_path = self
+            .build_path_with_corners(
+                bounds,
+                (0.0, 0.0),
+                (r_tl, r_tr, r_br, r_bl),
+                corner_shapes,
+                corner_smoothing,
+            )
+            .make_offset(bounds.top_left());
+
+        // Inner path in world coordinates uses the same corner shape/smoothing pipeline as outer.
+        let inner_path = if inner_is_empty {
+            None
+        } else {
+            let inner_bounds = BoundingBox::from_min_max(0.0, 0.0, inner_w, inner_h);
+            Some(
+                self.build_path_with_corners(
+                    inner_bounds,
+                    (0.0, 0.0),
+                    (ir_tl, ir_tr, ir_br, ir_bl),
+                    corner_shapes,
+                    corner_smoothing,
+                )
+                .make_offset((bx + left_width, by + top_width)),
+            )
+        };
+
+        let ring_path = if let Some(inner) = inner_path.as_ref() {
+            outer_path
+                .op(inner, skia_safe::PathOp::Difference)
+                .unwrap_or_else(|| outer_path.clone())
+        } else {
+            outer_path.clone()
+        };
+
+        if uniform_borders && uniform_corners {
+            match top_style {
+                BorderStyleKeyword::Dashed | BorderStyleKeyword::Dotted => {
+                    canvas.save();
+                    canvas.clip_path(&ring_path, ClipOp::Intersect, true);
+
+                    let half = top_width * 0.5;
+                    let stroke_path = self
+                        .build_path_with_corners(
+                            bounds,
+                            (-half, -half),
+                            (r_tl, r_tr, r_br, r_bl),
+                            corner_shapes,
+                            corner_smoothing,
+                        )
+                        .make_offset(bounds.top_left());
+
+                    let mut paint = Paint::default();
+                    paint.set_style(PaintStyle::Stroke);
+                    paint.set_color(top_color);
+                    paint.set_stroke_width(top_width);
+                    if top_style == BorderStyleKeyword::Dashed {
+                        paint.set_path_effect(PathEffect::dash(&[top_width * 2.0, top_width], 0.0));
+                    } else {
+                        paint.set_path_effect(PathEffect::dash(&[0.0, top_width * 2.0], 0.0));
+                        paint.set_stroke_cap(skia_safe::PaintCap::Round);
+                    }
+                    paint.set_anti_alias(true);
+                    canvas.draw_path(&stroke_path, &paint);
+                    canvas.restore();
+                    return;
                 }
 
-                BorderStyleKeyword::Dotted => {
-                    paint.set_path_effect(PathEffect::dash(&[0.0, border_width * 2.0], 0.0));
-                    paint.set_stroke_cap(skia_safe::PaintCap::Round);
+                _ => {
+                    let mut paint = Paint::default();
+                    paint.set_color(top_color);
+                    paint.set_anti_alias(true);
+                    canvas.draw_path(&ring_path, &paint);
+                    return;
                 }
+            }
+        }
 
-                _ => {}
+        // Side ownership masks split corner ownership at the outer->inner corner join line.
+        let mask_top: [Point; 4] = [
+            Point::new(bx, by),
+            Point::new(bx + bw, by),
+            Point::new(bx + bw - right_width, by + top_width),
+            Point::new(bx + left_width, by + top_width),
+        ];
+        let mask_right: [Point; 4] = [
+            Point::new(bx + bw - right_width, by + top_width),
+            Point::new(bx + bw, by),
+            Point::new(bx + bw, by + bh),
+            Point::new(bx + bw - right_width, by + bh - bottom_width),
+        ];
+        let mask_bottom: [Point; 4] = [
+            Point::new(bx + left_width, by + bh - bottom_width),
+            Point::new(bx + bw - right_width, by + bh - bottom_width),
+            Point::new(bx + bw, by + bh),
+            Point::new(bx, by + bh),
+        ];
+        let mask_left: [Point; 4] = [
+            Point::new(bx, by),
+            Point::new(bx + left_width, by + top_width),
+            Point::new(bx + left_width, by + bh - bottom_width),
+            Point::new(bx, by + bh),
+        ];
+
+        let sides: [(usize, bool, Color, BorderStyleKeyword, f32, [Point; 4]); 4] = [
+            (0, top_vis, top_color, top_style, top_width, mask_top),
+            (1, right_vis, right_color, right_style, right_width, mask_right),
+            (2, bottom_vis, bottom_color, bottom_style, bottom_width, mask_bottom),
+            (3, left_vis, left_color, left_style, left_width, mask_left),
+        ];
+
+        for (side_ix, vis, color, style, side_width, mask_pts) in sides {
+            if !vis {
+                continue;
             }
 
-            paint.set_anti_alias(true);
-            canvas.draw_path(&path, &paint);
+            let mut side_mask = PathBuilder::new();
+            side_mask.move_to(mask_pts[0]);
+            side_mask.line_to(mask_pts[1]);
+            side_mask.line_to(mask_pts[2]);
+            side_mask.line_to(mask_pts[3]);
+            side_mask.close();
+            let side_mask = side_mask.detach();
+            let side_region = ring_path
+                .op(&side_mask, skia_safe::PathOp::Intersect)
+                .unwrap_or_else(|| ring_path.clone());
+
+            match style {
+                BorderStyleKeyword::Dashed | BorderStyleKeyword::Dotted => {
+                    canvas.save();
+                    canvas.clip_path(&side_region, ClipOp::Intersect, true);
+
+                    // Side-local center-line stroke with independent dashing.
+                    let mut side_path = PathBuilder::new();
+                    let (sx, sy, ex, ey) = match side_ix {
+                        0 => (
+                            bx + left_width * 0.5,
+                            by + top_width * 0.5,
+                            bx + bw - right_width * 0.5,
+                            by + top_width * 0.5,
+                        ),
+                        1 => (
+                            bx + bw - right_width * 0.5,
+                            by + top_width * 0.5,
+                            bx + bw - right_width * 0.5,
+                            by + bh - bottom_width * 0.5,
+                        ),
+                        2 => (
+                            bx + left_width * 0.5,
+                            by + bh - bottom_width * 0.5,
+                            bx + bw - right_width * 0.5,
+                            by + bh - bottom_width * 0.5,
+                        ),
+                        _ => (
+                            bx + left_width * 0.5,
+                            by + top_width * 0.5,
+                            bx + left_width * 0.5,
+                            by + bh - bottom_width * 0.5,
+                        ),
+                    };
+                    side_path.move_to((sx, sy));
+                    side_path.line_to((ex, ey));
+                    let stroke_path = side_path.detach();
+                    let mut paint = Paint::default();
+                    paint.set_style(PaintStyle::Stroke);
+                    paint.set_color(color);
+                    paint.set_stroke_width(side_width);
+                    if style == BorderStyleKeyword::Dashed {
+                        paint.set_path_effect(PathEffect::dash(
+                            &[side_width * 2.0, side_width],
+                            0.0,
+                        ));
+                    } else {
+                        paint.set_path_effect(PathEffect::dash(&[0.0, side_width * 2.0], 0.0));
+                        paint.set_stroke_cap(skia_safe::PaintCap::Round);
+                    }
+                    paint.set_anti_alias(true);
+                    canvas.draw_path(&stroke_path, &paint);
+                    canvas.restore();
+                }
+                _ => {
+                    let exact_side_path = if exact_round_solid {
+                        Self::round_corner_side_path(
+                            side_ix,
+                            bounds,
+                            (r_tl, r_tr, r_br, r_bl),
+                            (ir_tl, ir_tr, ir_br, ir_bl),
+                            (top_width, right_width, bottom_width, left_width),
+                        )
+                    } else if exact_bevel_solid {
+                        Self::bevel_corner_side_path(
+                            side_ix,
+                            bounds,
+                            (r_tl, r_tr, r_br, r_bl),
+                            (ir_tl, ir_tr, ir_br, ir_bl),
+                            (top_width, right_width, bottom_width, left_width),
+                        )
+                    } else if exact_smooth_solid {
+                        Self::smooth_corner_side_path(
+                            side_ix,
+                            bounds,
+                            (r_tl, r_tr, r_br, r_bl),
+                            (ir_tl, ir_tr, ir_br, ir_bl),
+                            corner_shapes,
+                            corner_smoothing,
+                            (top_width, right_width, bottom_width, left_width),
+                        )
+                    } else {
+                        None
+                    };
+                    // Solid and any other opaque style: fill this side's owned part of the ring.
+                    let mut paint = Paint::default();
+                    paint.set_color(color);
+                    paint.set_anti_alias(true);
+                    if let Some(path) = exact_side_path {
+                        let constrained_path =
+                            path.op(&ring_path, skia_safe::PathOp::Intersect).unwrap_or(path);
+                        canvas.draw_path(&constrained_path, &paint);
+                    } else {
+                        canvas.draw_path(&side_region, &paint);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1306,10 +1306,48 @@ impl<'a> EventContext<'a> {
     }
 
     // GETTERS
-    get_length_property!(
-        /// Returns the border width of the current view in physical pixels.
-        border_width
-    );
+
+    /// Returns the top border width of the current view in physical pixels.
+    pub fn border_top_width(&self) -> f32 {
+        if let Some(length) = self.style.border_top_width.get(self.current) {
+            let bounds = self.bounds();
+            return length.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round();
+        }
+        0.0
+    }
+
+    /// Returns the right border width of the current view in physical pixels.
+    pub fn border_right_width(&self) -> f32 {
+        if let Some(length) = self.style.border_right_width.get(self.current) {
+            let bounds = self.bounds();
+            return length.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round();
+        }
+        0.0
+    }
+
+    /// Returns the bottom border width of the current view in physical pixels.
+    pub fn border_bottom_width(&self) -> f32 {
+        if let Some(length) = self.style.border_bottom_width.get(self.current) {
+            let bounds = self.bounds();
+            return length.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round();
+        }
+        0.0
+    }
+
+    /// Returns the left border width of the current view in physical pixels.
+    pub fn border_left_width(&self) -> f32 {
+        if let Some(length) = self.style.border_left_width.get(self.current) {
+            let bounds = self.bounds();
+            return length.to_pixels(bounds.w.min(bounds.h), self.scale_factor()).round();
+        }
+        0.0
+    }
+
+    /// Returns the top border width of the current view in physical pixels.
+    /// Equivalent to `border_top_width`; kept for backward compatibility.
+    pub fn border_width(&self) -> f32 {
+        self.border_top_width()
+    }
 
     /// Returns the font-size of the current view in physical pixels.
     pub fn font_size(&self) -> f32 {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -95,25 +95,6 @@ pub struct EventContext<'a> {
     pub windows: &'a mut HashMap<Entity, WindowState>,
 }
 
-macro_rules! get_length_property {
-    (
-        $(#[$meta:meta])*
-        $name:ident
-    ) => {
-        $(#[$meta])*
-        pub fn $name(&self) -> f32 {
-            if let Some(length) = self.style.$name.get(self.current) {
-                let bounds = self.bounds();
-
-                let px = length.to_pixels(bounds.w.min(bounds.h), self.scale_factor());
-                return px.round();
-            }
-
-            0.0
-        }
-    };
-}
-
 impl<'a> EventContext<'a> {
     /// Creates a new [EventContext].
     pub fn new(cx: &'a mut Context) -> Self {

--- a/crates/vizia_core/src/modifiers/style.rs
+++ b/crates/vizia_core/src/modifiers/style.rs
@@ -493,29 +493,151 @@ pub trait StyleModifiers: internal::Modifiable {
     }
 
     // Border Properties
+
+    /// Sets the border width for all four sides of the view.
     fn border_width<U: Into<LengthOrPercentage>>(mut self, value: impl Res<U>) -> Self {
         let entity = self.entity();
-        let _current = self.current();
         value.set_or_bind(self.context(), move |cx, v| {
-            cx.style.border_width.insert(entity, v.get_value(cx).into());
+            let w: LengthOrPercentage = v.get_value(cx).into();
+            cx.style.border_top_width.insert(entity, w.clone());
+            cx.style.border_right_width.insert(entity, w.clone());
+            cx.style.border_bottom_width.insert(entity, w.clone());
+            cx.style.border_left_width.insert(entity, w);
             cx.cache.path.remove(entity);
             cx.style.system_flags |= SystemFlags::RELAYOUT | SystemFlags::REDRAW;
             cx.set_system_flags(entity, SystemFlags::RELAYOUT | SystemFlags::REDRAW);
         });
+        self
+    }
 
+    /// Sets the top border width of the view.
+    fn border_top_width<U: Into<LengthOrPercentage>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            cx.style.border_top_width.insert(entity, v.get_value(cx).into());
+            cx.cache.path.remove(entity);
+            cx.style.system_flags |= SystemFlags::RELAYOUT | SystemFlags::REDRAW;
+            cx.set_system_flags(entity, SystemFlags::RELAYOUT | SystemFlags::REDRAW);
+        });
+        self
+    }
+
+    /// Sets the right border width of the view.
+    fn border_right_width<U: Into<LengthOrPercentage>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            cx.style.border_right_width.insert(entity, v.get_value(cx).into());
+            cx.cache.path.remove(entity);
+            cx.style.system_flags |= SystemFlags::RELAYOUT | SystemFlags::REDRAW;
+            cx.set_system_flags(entity, SystemFlags::RELAYOUT | SystemFlags::REDRAW);
+        });
+        self
+    }
+
+    /// Sets the bottom border width of the view.
+    fn border_bottom_width<U: Into<LengthOrPercentage>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            cx.style.border_bottom_width.insert(entity, v.get_value(cx).into());
+            cx.cache.path.remove(entity);
+            cx.style.system_flags |= SystemFlags::RELAYOUT | SystemFlags::REDRAW;
+            cx.set_system_flags(entity, SystemFlags::RELAYOUT | SystemFlags::REDRAW);
+        });
+        self
+    }
+
+    /// Sets the left border width of the view.
+    fn border_left_width<U: Into<LengthOrPercentage>>(mut self, value: impl Res<U>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            cx.style.border_left_width.insert(entity, v.get_value(cx).into());
+            cx.cache.path.remove(entity);
+            cx.style.system_flags |= SystemFlags::RELAYOUT | SystemFlags::REDRAW;
+            cx.set_system_flags(entity, SystemFlags::RELAYOUT | SystemFlags::REDRAW);
+        });
+        self
+    }
+
+    /// Sets the border color for all four sides of the view.
+    fn border_color(mut self, value: impl Res<Color>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            let c = v.get_value(cx);
+            cx.style.border_top_color.insert(entity, c);
+            cx.style.border_right_color.insert(entity, c);
+            cx.style.border_bottom_color.insert(entity, c);
+            cx.style.border_left_color.insert(entity, c);
+            cx.needs_redraw(entity);
+        });
         self
     }
 
     modifier!(
-        /// Sets the border color of the view.
-        border_color,
+        /// Sets the top border color of the view.
+        border_top_color,
         Color,
         SystemFlags::REDRAW
     );
 
     modifier!(
-        /// Sets the border color of the view.
-        border_style,
+        /// Sets the right border color of the view.
+        border_right_color,
+        Color,
+        SystemFlags::REDRAW
+    );
+
+    modifier!(
+        /// Sets the bottom border color of the view.
+        border_bottom_color,
+        Color,
+        SystemFlags::REDRAW
+    );
+
+    modifier!(
+        /// Sets the left border color of the view.
+        border_left_color,
+        Color,
+        SystemFlags::REDRAW
+    );
+
+    /// Sets the border style for all four sides of the view.
+    fn border_style(mut self, value: impl Res<BorderStyleKeyword>) -> Self {
+        let entity = self.entity();
+        value.set_or_bind(self.context(), move |cx, v| {
+            let s = v.get_value(cx);
+            cx.style.border_top_style.insert(entity, s);
+            cx.style.border_right_style.insert(entity, s);
+            cx.style.border_bottom_style.insert(entity, s);
+            cx.style.border_left_style.insert(entity, s);
+            cx.needs_redraw(entity);
+        });
+        self
+    }
+
+    modifier!(
+        /// Sets the top border style of the view.
+        border_top_style,
+        BorderStyleKeyword,
+        SystemFlags::REDRAW
+    );
+
+    modifier!(
+        /// Sets the right border style of the view.
+        border_right_style,
+        BorderStyleKeyword,
+        SystemFlags::REDRAW
+    );
+
+    modifier!(
+        /// Sets the bottom border style of the view.
+        border_bottom_style,
+        BorderStyleKeyword,
+        SystemFlags::REDRAW
+    );
+
+    modifier!(
+        /// Sets the left border style of the view.
+        border_left_style,
         BorderStyleKeyword,
         SystemFlags::REDRAW
     );

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -264,10 +264,23 @@ pub struct Style {
     pub(crate) rotate: AnimatableSet<Angle>,
     pub(crate) scale: AnimatableSet<Scale>,
 
-    // Border
-    pub(crate) border_width: AnimatableVarSet<LengthOrPercentage>,
-    pub(crate) border_color: AnimatableVarSet<Color>,
-    pub(crate) border_style: StyleSet<BorderStyleKeyword>,
+    // Border widths (per side)
+    pub(crate) border_top_width: AnimatableVarSet<LengthOrPercentage>,
+    pub(crate) border_right_width: AnimatableVarSet<LengthOrPercentage>,
+    pub(crate) border_bottom_width: AnimatableVarSet<LengthOrPercentage>,
+    pub(crate) border_left_width: AnimatableVarSet<LengthOrPercentage>,
+
+    // Border colors (per side)
+    pub(crate) border_top_color: AnimatableVarSet<Color>,
+    pub(crate) border_right_color: AnimatableVarSet<Color>,
+    pub(crate) border_bottom_color: AnimatableVarSet<Color>,
+    pub(crate) border_left_color: AnimatableVarSet<Color>,
+
+    // Border styles (per side)
+    pub(crate) border_top_style: StyleSet<BorderStyleKeyword>,
+    pub(crate) border_right_style: StyleSet<BorderStyleKeyword>,
+    pub(crate) border_bottom_style: StyleSet<BorderStyleKeyword>,
+    pub(crate) border_left_style: StyleSet<BorderStyleKeyword>,
 
     // Corner Shape
     pub(crate) corner_top_left_shape: StyleSet<CornerShape>,
@@ -525,17 +538,116 @@ impl Style {
                 }
 
                 // BORDER
+                Property::Border(value) => {
+                    if let Some(color) = value.color {
+                        insert_keyframe2(&mut self.border_top_color, animation_id, time, color);
+                        insert_keyframe2(&mut self.border_right_color, animation_id, time, color);
+                        insert_keyframe2(&mut self.border_bottom_color, animation_id, time, color);
+                        insert_keyframe2(&mut self.border_left_color, animation_id, time, color);
+                    }
+                    if let Some(width) = value.width.clone() {
+                        let w: LengthOrPercentage = width.into();
+                        insert_keyframe2(&mut self.border_top_width, animation_id, time, w.clone());
+                        insert_keyframe2(
+                            &mut self.border_right_width,
+                            animation_id,
+                            time,
+                            w.clone(),
+                        );
+                        insert_keyframe2(
+                            &mut self.border_bottom_width,
+                            animation_id,
+                            time,
+                            w.clone(),
+                        );
+                        insert_keyframe2(&mut self.border_left_width, animation_id, time, w);
+                    }
+                }
+
                 Property::BorderWidth(value) => {
                     insert_keyframe2(
-                        &mut self.border_width,
+                        &mut self.border_top_width,
+                        animation_id,
+                        time,
+                        value.top.0.clone(),
+                    );
+                    insert_keyframe2(
+                        &mut self.border_right_width,
+                        animation_id,
+                        time,
+                        value.right.0.clone(),
+                    );
+                    insert_keyframe2(
+                        &mut self.border_bottom_width,
+                        animation_id,
+                        time,
+                        value.bottom.0.clone(),
+                    );
+                    insert_keyframe2(
+                        &mut self.border_left_width,
                         animation_id,
                         time,
                         value.left.0.clone(),
                     );
                 }
 
+                Property::BorderTopWidth(value) => {
+                    insert_keyframe2(
+                        &mut self.border_top_width,
+                        animation_id,
+                        time,
+                        value.0.clone(),
+                    );
+                }
+
+                Property::BorderRightWidth(value) => {
+                    insert_keyframe2(
+                        &mut self.border_right_width,
+                        animation_id,
+                        time,
+                        value.0.clone(),
+                    );
+                }
+
+                Property::BorderBottomWidth(value) => {
+                    insert_keyframe2(
+                        &mut self.border_bottom_width,
+                        animation_id,
+                        time,
+                        value.0.clone(),
+                    );
+                }
+
+                Property::BorderLeftWidth(value) => {
+                    insert_keyframe2(
+                        &mut self.border_left_width,
+                        animation_id,
+                        time,
+                        value.0.clone(),
+                    );
+                }
+
                 Property::BorderColor(value) => {
-                    insert_keyframe2(&mut self.border_color, animation_id, time, *value);
+                    insert_keyframe2(&mut self.border_top_color, animation_id, time, *value);
+                    insert_keyframe2(&mut self.border_right_color, animation_id, time, *value);
+                    insert_keyframe2(&mut self.border_bottom_color, animation_id, time, *value);
+                    insert_keyframe2(&mut self.border_left_color, animation_id, time, *value);
+                }
+
+                Property::BorderTopColor(value) => {
+                    insert_keyframe2(&mut self.border_top_color, animation_id, time, *value);
+                }
+
+                Property::BorderRightColor(value) => {
+                    insert_keyframe2(&mut self.border_right_color, animation_id, time, *value);
+                }
+
+                Property::BorderBottomColor(value) => {
+                    insert_keyframe2(&mut self.border_bottom_color, animation_id, time, *value);
+                }
+
+                Property::BorderLeftColor(value) => {
+                    insert_keyframe2(&mut self.border_left_color, animation_id, time, *value);
                 }
 
                 Property::CornerTopLeftRadius(value) => {
@@ -820,8 +932,14 @@ impl Style {
         self.rotate.play_animation(entity, animation, start_time, duration, delay);
         self.scale.play_animation(entity, animation, start_time, duration, delay);
 
-        self.border_width.play_animation(entity, animation, start_time, duration, delay);
-        self.border_color.play_animation(entity, animation, start_time, duration, delay);
+        self.border_top_width.play_animation(entity, animation, start_time, duration, delay);
+        self.border_right_width.play_animation(entity, animation, start_time, duration, delay);
+        self.border_bottom_width.play_animation(entity, animation, start_time, duration, delay);
+        self.border_left_width.play_animation(entity, animation, start_time, duration, delay);
+        self.border_top_color.play_animation(entity, animation, start_time, duration, delay);
+        self.border_right_color.play_animation(entity, animation, start_time, duration, delay);
+        self.border_bottom_color.play_animation(entity, animation, start_time, duration, delay);
+        self.border_left_color.play_animation(entity, animation, start_time, duration, delay);
 
         self.corner_top_left_radius.play_animation(entity, animation, start_time, duration, delay);
         self.corner_top_right_radius.play_animation(entity, animation, start_time, duration, delay);
@@ -921,8 +1039,14 @@ impl Style {
             | self.translate.has_active_animation(entity, animation)
             | self.rotate.has_active_animation(entity, animation)
             | self.scale.has_active_animation(entity, animation)
-            | self.border_width.has_active_animation(entity, animation)
-            | self.border_color.has_active_animation(entity, animation)
+            | self.border_top_width.has_active_animation(entity, animation)
+            | self.border_right_width.has_active_animation(entity, animation)
+            | self.border_bottom_width.has_active_animation(entity, animation)
+            | self.border_left_width.has_active_animation(entity, animation)
+            | self.border_top_color.has_active_animation(entity, animation)
+            | self.border_right_color.has_active_animation(entity, animation)
+            | self.border_bottom_color.has_active_animation(entity, animation)
+            | self.border_left_color.has_active_animation(entity, animation)
             | self.corner_top_left_radius.has_active_animation(entity, animation)
             | self.corner_top_right_radius.has_active_animation(entity, animation)
             | self.corner_bottom_left_radius.has_active_animation(entity, animation)
@@ -1074,20 +1198,96 @@ impl Style {
             }
 
             "border" => {
-                self.border_width.insert_animation(animation, self.add_transition(transition));
-                self.border_width.insert_transition(rule_id, animation);
-                self.border_color.insert_animation(animation, self.add_transition(transition));
-                self.border_color.insert_transition(rule_id, animation);
+                self.border_top_width.insert_animation(animation, self.add_transition(transition));
+                self.border_top_width.insert_transition(rule_id, animation);
+                self.border_right_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_width.insert_transition(rule_id, animation);
+                self.border_bottom_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_width.insert_transition(rule_id, animation);
+                self.border_left_width.insert_animation(animation, self.add_transition(transition));
+                self.border_left_width.insert_transition(rule_id, animation);
+                self.border_top_color.insert_animation(animation, self.add_transition(transition));
+                self.border_top_color.insert_transition(rule_id, animation);
+                self.border_right_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_color.insert_transition(rule_id, animation);
+                self.border_bottom_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_color.insert_transition(rule_id, animation);
+                self.border_left_color.insert_animation(animation, self.add_transition(transition));
+                self.border_left_color.insert_transition(rule_id, animation);
             }
 
             "border-width" => {
-                self.border_width.insert_animation(animation, self.add_transition(transition));
-                self.border_width.insert_transition(rule_id, animation);
+                self.border_top_width.insert_animation(animation, self.add_transition(transition));
+                self.border_top_width.insert_transition(rule_id, animation);
+                self.border_right_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_width.insert_transition(rule_id, animation);
+                self.border_bottom_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_width.insert_transition(rule_id, animation);
+                self.border_left_width.insert_animation(animation, self.add_transition(transition));
+                self.border_left_width.insert_transition(rule_id, animation);
+            }
+
+            "border-top-width" => {
+                self.border_top_width.insert_animation(animation, self.add_transition(transition));
+                self.border_top_width.insert_transition(rule_id, animation);
+            }
+
+            "border-right-width" => {
+                self.border_right_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_width.insert_transition(rule_id, animation);
+            }
+
+            "border-bottom-width" => {
+                self.border_bottom_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_width.insert_transition(rule_id, animation);
+            }
+
+            "border-left-width" => {
+                self.border_left_width.insert_animation(animation, self.add_transition(transition));
+                self.border_left_width.insert_transition(rule_id, animation);
             }
 
             "border-color" => {
-                self.border_color.insert_animation(animation, self.add_transition(transition));
-                self.border_color.insert_transition(rule_id, animation);
+                self.border_top_color.insert_animation(animation, self.add_transition(transition));
+                self.border_top_color.insert_transition(rule_id, animation);
+                self.border_right_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_color.insert_transition(rule_id, animation);
+                self.border_bottom_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_color.insert_transition(rule_id, animation);
+                self.border_left_color.insert_animation(animation, self.add_transition(transition));
+                self.border_left_color.insert_transition(rule_id, animation);
+            }
+
+            "border-top-color" => {
+                self.border_top_color.insert_animation(animation, self.add_transition(transition));
+                self.border_top_color.insert_transition(rule_id, animation);
+            }
+
+            "border-right-color" => {
+                self.border_right_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_color.insert_transition(rule_id, animation);
+            }
+
+            "border-bottom-color" => {
+                self.border_bottom_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_color.insert_transition(rule_id, animation);
+            }
+
+            "border-left-color" => {
+                self.border_left_color.insert_animation(animation, self.add_transition(transition));
+                self.border_left_color.insert_transition(rule_id, animation);
             }
 
             "corner-radius" => {
@@ -1862,30 +2062,148 @@ impl Style {
 
             // Border
             Property::Border(border) => {
-                if let Some(border_color) = border.color {
-                    self.border_color.insert_rule(rule_id, border_color);
+                if let Some(color) = border.color {
+                    self.border_top_color.insert_rule(rule_id, color);
+                    self.border_right_color.insert_rule(rule_id, color);
+                    self.border_bottom_color.insert_rule(rule_id, color);
+                    self.border_left_color.insert_rule(rule_id, color);
                 }
 
-                if let Some(border_width) = border.width {
-                    self.border_width.insert_rule(rule_id, border_width.into());
+                if let Some(width) = border.width {
+                    let w: LengthOrPercentage = width.into();
+                    self.border_top_width.insert_rule(rule_id, w.clone());
+                    self.border_right_width.insert_rule(rule_id, w.clone());
+                    self.border_bottom_width.insert_rule(rule_id, w.clone());
+                    self.border_left_width.insert_rule(rule_id, w);
                 }
 
-                if let Some(border_style) = border.style {
-                    self.border_style.insert_rule(rule_id, border_style.top);
+                if let Some(style) = border.style {
+                    self.border_top_style.insert_rule(rule_id, style.top);
+                    self.border_right_style.insert_rule(rule_id, style.right);
+                    self.border_bottom_style.insert_rule(rule_id, style.bottom);
+                    self.border_left_style.insert_rule(rule_id, style.left);
                 }
             }
 
-            // Border
+            // Border side shorthands
+            Property::BorderTop(border) => {
+                if let Some(color) = border.color {
+                    self.border_top_color.insert_rule(rule_id, color);
+                }
+                if let Some(width) = border.width {
+                    self.border_top_width.insert_rule(rule_id, width.into());
+                }
+                if let Some(style) = border.style {
+                    self.border_top_style.insert_rule(rule_id, style.top);
+                }
+            }
+
+            Property::BorderRight(border) => {
+                if let Some(color) = border.color {
+                    self.border_right_color.insert_rule(rule_id, color);
+                }
+                if let Some(width) = border.width {
+                    self.border_right_width.insert_rule(rule_id, width.into());
+                }
+                if let Some(style) = border.style {
+                    self.border_right_style.insert_rule(rule_id, style.right);
+                }
+            }
+
+            Property::BorderBottom(border) => {
+                if let Some(color) = border.color {
+                    self.border_bottom_color.insert_rule(rule_id, color);
+                }
+                if let Some(width) = border.width {
+                    self.border_bottom_width.insert_rule(rule_id, width.into());
+                }
+                if let Some(style) = border.style {
+                    self.border_bottom_style.insert_rule(rule_id, style.bottom);
+                }
+            }
+
+            Property::BorderLeft(border) => {
+                if let Some(color) = border.color {
+                    self.border_left_color.insert_rule(rule_id, color);
+                }
+                if let Some(width) = border.width {
+                    self.border_left_width.insert_rule(rule_id, width.into());
+                }
+                if let Some(style) = border.style {
+                    self.border_left_style.insert_rule(rule_id, style.left);
+                }
+            }
+
+            // Border Width
             Property::BorderWidth(border_width) => {
-                self.border_width.insert_rule(rule_id, border_width.top.0);
+                self.border_top_width.insert_rule(rule_id, border_width.top.0);
+                self.border_right_width.insert_rule(rule_id, border_width.right.0);
+                self.border_bottom_width.insert_rule(rule_id, border_width.bottom.0);
+                self.border_left_width.insert_rule(rule_id, border_width.left.0);
             }
 
+            Property::BorderTopWidth(width) => {
+                self.border_top_width.insert_rule(rule_id, width.into());
+            }
+
+            Property::BorderRightWidth(width) => {
+                self.border_right_width.insert_rule(rule_id, width.into());
+            }
+
+            Property::BorderBottomWidth(width) => {
+                self.border_bottom_width.insert_rule(rule_id, width.into());
+            }
+
+            Property::BorderLeftWidth(width) => {
+                self.border_left_width.insert_rule(rule_id, width.into());
+            }
+
+            // Border Color
             Property::BorderColor(color) => {
-                self.border_color.insert_rule(rule_id, color);
+                self.border_top_color.insert_rule(rule_id, color);
+                self.border_right_color.insert_rule(rule_id, color);
+                self.border_bottom_color.insert_rule(rule_id, color);
+                self.border_left_color.insert_rule(rule_id, color);
             }
 
+            Property::BorderTopColor(color) => {
+                self.border_top_color.insert_rule(rule_id, color);
+            }
+
+            Property::BorderRightColor(color) => {
+                self.border_right_color.insert_rule(rule_id, color);
+            }
+
+            Property::BorderBottomColor(color) => {
+                self.border_bottom_color.insert_rule(rule_id, color);
+            }
+
+            Property::BorderLeftColor(color) => {
+                self.border_left_color.insert_rule(rule_id, color);
+            }
+
+            // Border Style
             Property::BorderStyle(style) => {
-                self.border_style.insert_rule(rule_id, style.top);
+                self.border_top_style.insert_rule(rule_id, style.top);
+                self.border_right_style.insert_rule(rule_id, style.right);
+                self.border_bottom_style.insert_rule(rule_id, style.bottom);
+                self.border_left_style.insert_rule(rule_id, style.left);
+            }
+
+            Property::BorderTopStyle(style) => {
+                self.border_top_style.insert_rule(rule_id, style);
+            }
+
+            Property::BorderRightStyle(style) => {
+                self.border_right_style.insert_rule(rule_id, style);
+            }
+
+            Property::BorderBottomStyle(style) => {
+                self.border_bottom_style.insert_rule(rule_id, style);
+            }
+
+            Property::BorderLeftStyle(style) => {
+                self.border_left_style.insert_rule(rule_id, style);
             }
 
             // Border Radius
@@ -2155,13 +2473,11 @@ impl Style {
             // Unparsed. TODO: Log the error.
             Property::Unparsed(unparsed) => {
                 macro_rules! parse_color_var {
-                    ($prop:expr) => {
+                    ($($prop:expr),+) => {
                         if let Some(TokenOrValue::Var(var)) = unparsed.value.0.first() {
-                            $prop.insert_variable_rule(
-                                rule_id,
-                                variable_hash(var),
-                                color_fallback(var),
-                            );
+                            let hash = variable_hash(var);
+                            let fallback = color_fallback(var);
+                            $($prop.insert_variable_rule(rule_id, hash, fallback.clone());)+
                         }
                     };
                 }
@@ -2218,7 +2534,12 @@ impl Style {
                 }
                 match unparsed.name.as_ref() {
                     "background-color" => parse_color_var!(self.background_color),
-                    "border-color" => parse_color_var!(self.border_color),
+                    "border-color" => parse_color_var!(
+                        self.border_top_color,
+                        self.border_right_color,
+                        self.border_bottom_color,
+                        self.border_left_color
+                    ),
                     "outline-color" => parse_color_var!(self.outline_color),
                     "color" => parse_color_var!(self.font_color),
                     "caret-color" => parse_color_var!(self.caret_color),
@@ -2242,20 +2563,41 @@ impl Style {
                     "corner-bottom-right-radius" => {
                         parse_length_var!(self.corner_bottom_right_radius)
                     }
-                    "border-width" => parse_length_var!(self.border_width),
+                    "border-width" => parse_length_var!(
+                        self.border_top_width,
+                        self.border_right_width,
+                        self.border_bottom_width,
+                        self.border_left_width
+                    ),
+                    "border-top-width" => parse_length_var!(self.border_top_width),
+                    "border-right-width" => parse_length_var!(self.border_right_width),
+                    "border-bottom-width" => parse_length_var!(self.border_bottom_width),
+                    "border-left-width" => parse_length_var!(self.border_left_width),
+                    "border-top-color" => parse_color_var!(self.border_top_color),
+                    "border-right-color" => parse_color_var!(self.border_right_color),
+                    "border-bottom-color" => parse_color_var!(self.border_bottom_color),
+                    "border-left-color" => parse_color_var!(self.border_left_color),
                     "border" => {
                         if let Some(TokenOrValue::Var(var)) = unparsed.value.0.first() {
                             let hash = variable_hash(var);
-                            self.border_width.insert_variable_rule(
+                            let lf = length_fallback(var);
+                            let cf = color_fallback(var);
+                            self.border_top_width.insert_variable_rule(rule_id, hash, lf.clone());
+                            self.border_right_width.insert_variable_rule(rule_id, hash, lf.clone());
+                            self.border_bottom_width.insert_variable_rule(
                                 rule_id,
                                 hash,
-                                length_fallback(var),
+                                lf.clone(),
                             );
-                            self.border_color.insert_variable_rule(
+                            self.border_left_width.insert_variable_rule(rule_id, hash, lf);
+                            self.border_top_color.insert_variable_rule(rule_id, hash, cf.clone());
+                            self.border_right_color.insert_variable_rule(rule_id, hash, cf.clone());
+                            self.border_bottom_color.insert_variable_rule(
                                 rule_id,
                                 hash,
-                                color_fallback(var),
+                                cf.clone(),
                             );
+                            self.border_left_color.insert_variable_rule(rule_id, hash, cf);
                         }
                     }
                     "outline" => {
@@ -2783,10 +3125,21 @@ impl Style {
         self.rotate.remove(entity);
         self.scale.remove(entity);
 
-        // Border
-        self.border_width.remove(entity);
-        self.border_color.remove(entity);
-        self.border_style.remove(entity);
+        // Border widths
+        self.border_top_width.remove(entity);
+        self.border_right_width.remove(entity);
+        self.border_bottom_width.remove(entity);
+        self.border_left_width.remove(entity);
+        // Border colors
+        self.border_top_color.remove(entity);
+        self.border_right_color.remove(entity);
+        self.border_bottom_color.remove(entity);
+        self.border_left_color.remove(entity);
+        // Border styles
+        self.border_top_style.remove(entity);
+        self.border_right_style.remove(entity);
+        self.border_bottom_style.remove(entity);
+        self.border_left_style.remove(entity);
 
         // Corner Shape
         self.corner_bottom_left_shape.remove(entity);
@@ -2996,10 +3349,21 @@ impl Style {
         self.overflowx.clear_rules();
         self.overflowy.clear_rules();
 
-        // Border
-        self.border_width.clear_rules();
-        self.border_color.clear_rules();
-        self.border_style.clear_rules();
+        // Border widths
+        self.border_top_width.clear_rules();
+        self.border_right_width.clear_rules();
+        self.border_bottom_width.clear_rules();
+        self.border_left_width.clear_rules();
+        // Border colors
+        self.border_top_color.clear_rules();
+        self.border_right_color.clear_rules();
+        self.border_bottom_color.clear_rules();
+        self.border_left_color.clear_rules();
+        // Border styles
+        self.border_top_style.clear_rules();
+        self.border_right_style.clear_rules();
+        self.border_bottom_style.clear_rules();
+        self.border_left_style.clear_rules();
 
         // Corner Shape
         self.corner_bottom_left_shape.clear_rules();

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -564,6 +564,62 @@ impl Style {
                     }
                 }
 
+                Property::BorderTop(value) => {
+                    if let Some(color) = value.color {
+                        insert_keyframe2(&mut self.border_top_color, animation_id, time, color);
+                    }
+                    if let Some(width) = value.width.clone() {
+                        insert_keyframe2(
+                            &mut self.border_top_width,
+                            animation_id,
+                            time,
+                            width.into(),
+                        );
+                    }
+                }
+
+                Property::BorderRight(value) => {
+                    if let Some(color) = value.color {
+                        insert_keyframe2(&mut self.border_right_color, animation_id, time, color);
+                    }
+                    if let Some(width) = value.width.clone() {
+                        insert_keyframe2(
+                            &mut self.border_right_width,
+                            animation_id,
+                            time,
+                            width.into(),
+                        );
+                    }
+                }
+
+                Property::BorderBottom(value) => {
+                    if let Some(color) = value.color {
+                        insert_keyframe2(&mut self.border_bottom_color, animation_id, time, color);
+                    }
+                    if let Some(width) = value.width.clone() {
+                        insert_keyframe2(
+                            &mut self.border_bottom_width,
+                            animation_id,
+                            time,
+                            width.into(),
+                        );
+                    }
+                }
+
+                Property::BorderLeft(value) => {
+                    if let Some(color) = value.color {
+                        insert_keyframe2(&mut self.border_left_color, animation_id, time, color);
+                    }
+                    if let Some(width) = value.width.clone() {
+                        insert_keyframe2(
+                            &mut self.border_left_width,
+                            animation_id,
+                            time,
+                            width.into(),
+                        );
+                    }
+                }
+
                 Property::BorderWidth(value) => {
                     insert_keyframe2(
                         &mut self.border_top_width,
@@ -1231,6 +1287,38 @@ impl Style {
                 self.border_bottom_width.insert_transition(rule_id, animation);
                 self.border_left_width.insert_animation(animation, self.add_transition(transition));
                 self.border_left_width.insert_transition(rule_id, animation);
+            }
+
+            "border-top" => {
+                self.border_top_width.insert_animation(animation, self.add_transition(transition));
+                self.border_top_width.insert_transition(rule_id, animation);
+                self.border_top_color.insert_animation(animation, self.add_transition(transition));
+                self.border_top_color.insert_transition(rule_id, animation);
+            }
+
+            "border-right" => {
+                self.border_right_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_width.insert_transition(rule_id, animation);
+                self.border_right_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_right_color.insert_transition(rule_id, animation);
+            }
+
+            "border-bottom" => {
+                self.border_bottom_width
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_width.insert_transition(rule_id, animation);
+                self.border_bottom_color
+                    .insert_animation(animation, self.add_transition(transition));
+                self.border_bottom_color.insert_transition(rule_id, animation);
+            }
+
+            "border-left" => {
+                self.border_left_width.insert_animation(animation, self.add_transition(transition));
+                self.border_left_width.insert_transition(rule_id, animation);
+                self.border_left_color.insert_animation(animation, self.add_transition(transition));
+                self.border_left_color.insert_transition(rule_id, animation);
             }
 
             "border-top-width" => {

--- a/crates/vizia_core/src/style/mod.rs
+++ b/crates/vizia_core/src/style/mod.rs
@@ -2590,13 +2590,9 @@ impl Style {
                                 lf.clone(),
                             );
                             self.border_left_width.insert_variable_rule(rule_id, hash, lf);
-                            self.border_top_color.insert_variable_rule(rule_id, hash, cf.clone());
-                            self.border_right_color.insert_variable_rule(rule_id, hash, cf.clone());
-                            self.border_bottom_color.insert_variable_rule(
-                                rule_id,
-                                hash,
-                                cf.clone(),
-                            );
+                            self.border_top_color.insert_variable_rule(rule_id, hash, cf);
+                            self.border_right_color.insert_variable_rule(rule_id, hash, cf);
+                            self.border_bottom_color.insert_variable_rule(rule_id, hash, cf);
                             self.border_left_color.insert_variable_rule(rule_id, hash, cf);
                         }
                     }

--- a/crates/vizia_core/src/systems/animation.rs
+++ b/crates/vizia_core/src/systems/animation.rs
@@ -99,7 +99,10 @@ pub(crate) fn animation_system(cx: &mut Context) -> bool {
     // Opacity
     redraw_entities.extend(cx.style.opacity.tick(time));
     // Corner Colour
-    redraw_entities.extend(cx.style.border_color.tick(time));
+    redraw_entities.extend(cx.style.border_top_color.tick(time));
+    redraw_entities.extend(cx.style.border_right_color.tick(time));
+    redraw_entities.extend(cx.style.border_bottom_color.tick(time));
+    redraw_entities.extend(cx.style.border_left_color.tick(time));
     // Corner Radius
     redraw_entities.extend(cx.style.corner_top_left_radius.tick(time));
     redraw_entities.extend(cx.style.corner_top_right_radius.tick(time));
@@ -138,7 +141,10 @@ pub(crate) fn animation_system(cx: &mut Context) -> bool {
     // Properties which affect layout
     relayout_entities.extend(cx.style.display.tick(time));
     // Border Width
-    relayout_entities.extend(cx.style.border_width.tick(time));
+    relayout_entities.extend(cx.style.border_top_width.tick(time));
+    relayout_entities.extend(cx.style.border_right_width.tick(time));
+    relayout_entities.extend(cx.style.border_bottom_width.tick(time));
+    relayout_entities.extend(cx.style.border_left_width.tick(time));
     // Space
     relayout_entities.extend(cx.style.left.tick(time));
     relayout_entities.extend(cx.style.right.tick(time));

--- a/crates/vizia_core/src/systems/style.rs
+++ b/crates/vizia_core/src/systems/style.rs
@@ -830,18 +830,62 @@ fn link_style_data(
         should_redraw = true;
     }
 
-    // Border
-    if style.border_width.link(entity, matched_rules, &style.custom_length_props) {
+    // Border widths
+    if style.border_top_width.link(entity, matched_rules, &style.custom_length_props) {
         should_relayout = true;
         should_redraw = true;
         cache.path.remove(entity);
     }
 
-    if style.border_color.link(entity, matched_rules, &style.custom_color_props) {
+    if style.border_right_width.link(entity, matched_rules, &style.custom_length_props) {
+        should_relayout = true;
+        should_redraw = true;
+        cache.path.remove(entity);
+    }
+
+    if style.border_bottom_width.link(entity, matched_rules, &style.custom_length_props) {
+        should_relayout = true;
+        should_redraw = true;
+        cache.path.remove(entity);
+    }
+
+    if style.border_left_width.link(entity, matched_rules, &style.custom_length_props) {
+        should_relayout = true;
+        should_redraw = true;
+        cache.path.remove(entity);
+    }
+
+    // Border colors
+    if style.border_top_color.link(entity, matched_rules, &style.custom_color_props) {
         should_redraw = true;
     }
 
-    if style.border_style.link(entity, matched_rules) {
+    if style.border_right_color.link(entity, matched_rules, &style.custom_color_props) {
+        should_redraw = true;
+    }
+
+    if style.border_bottom_color.link(entity, matched_rules, &style.custom_color_props) {
+        should_redraw = true;
+    }
+
+    if style.border_left_color.link(entity, matched_rules, &style.custom_color_props) {
+        should_redraw = true;
+    }
+
+    // Border styles
+    if style.border_top_style.link(entity, matched_rules) {
+        should_redraw = true;
+    }
+
+    if style.border_right_style.link(entity, matched_rules) {
+        should_redraw = true;
+    }
+
+    if style.border_bottom_style.link(entity, matched_rules) {
+        should_redraw = true;
+    }
+
+    if style.border_left_style.link(entity, matched_rules) {
         should_redraw = true;
     }
 

--- a/crates/vizia_style/src/property.rs
+++ b/crates/vizia_style/src/property.rs
@@ -1,12 +1,13 @@
 use crate::{
     Alignment, Angle, AspectRatio, BackgroundImage, BackgroundRepeat, BackgroundSize, BlendMode,
-    Border, BorderStyle, BorderWidth, ClipPath, Color, CornerRadius, CornerShape, CursorIcon,
-    CustomParseError, CustomProperty, Direction, Display, Filter, FontFamily, FontSize, FontSlant,
-    FontVariation, FontWeight, FontWidth, LayoutType, LayoutWrap, Length, LengthOrPercentage,
-    LetterSpacing, LineClamp, LineHeight, Opacity, Outline, Overflow, Parse, PointerEvents,
-    Position, PositionType, Rect, Scale, Shadow, TextAlign, TextDecoration, TextDecorationLine,
-    TextDecorationStyle, TextOverflow, TextStroke, TextStrokeStyle, Transform, Transition,
-    Translate, Units, UnparsedProperty, Visibility, define_property,
+    Border, BorderStyle, BorderStyleKeyword, BorderWidth, BorderWidthValue, ClipPath, Color,
+    CornerRadius, CornerShape, CursorIcon, CustomParseError, CustomProperty, Direction, Display,
+    Filter, FontFamily, FontSize, FontSlant, FontVariation, FontWeight, FontWidth, LayoutType,
+    LayoutWrap, Length, LengthOrPercentage, LetterSpacing, LineClamp, LineHeight, Opacity, Outline,
+    Overflow, Parse, PointerEvents, Position, PositionType, Rect, Scale, Shadow, TextAlign,
+    TextDecoration, TextDecorationLine, TextDecorationStyle, TextOverflow, TextStroke,
+    TextStrokeStyle, Transform, Transition, Translate, Units, UnparsedProperty, Visibility,
+    define_property,
 };
 use cssparser::Parser;
 
@@ -81,13 +82,18 @@ define_property! {
         // Border Shorthand
         "border": Border(Border),
 
+        // Border Side Shorthands
+        "border-top": BorderTop(Border),
+        "border-right": BorderRight(Border),
+        "border-bottom": BorderBottom(Border),
+        "border-left": BorderLeft(Border),
+
         // Border Color
         "border-color": BorderColor(Color),
-        // TODO: Support coloring individual borders.
-        // "border-top-color": BorderTopColor(Color),
-        // "border-right-color": BorderRightColor(Color),
-        // "border-bottom-color": BorderBottomColor(Color),
-        // "border-left-color": BorderLeftColor(Color),
+        "border-top-color": BorderTopColor(Color),
+        "border-right-color": BorderRightColor(Color),
+        "border-bottom-color": BorderBottomColor(Color),
+        "border-left-color": BorderLeftColor(Color),
 
         // Corner Shape
         "corner-shape": CornerShape(Rect<CornerShape>),
@@ -104,19 +110,18 @@ define_property! {
         "corner-bottom-right-radius": CornerBottomRightRadius(LengthOrPercentage),
 
         // Border Style
-        // TODO: Support styling borders.
         "border-style": BorderStyle(BorderStyle),
-        // "border-top-style": BorderTopStyle(BorderStyleKeyword),
-        // "border-right-style": BorderRightStyle(BorderStyleKeyword),
-        // "border-bottom-style": BorderBottomStyle(BorderStyleKeyword),
-        // "border-left-style": BorderLeftStyle(BorderStyleKeyword),
+        "border-top-style": BorderTopStyle(BorderStyleKeyword),
+        "border-right-style": BorderRightStyle(BorderStyleKeyword),
+        "border-bottom-style": BorderBottomStyle(BorderStyleKeyword),
+        "border-left-style": BorderLeftStyle(BorderStyleKeyword),
 
         // Border Width
         "border-width": BorderWidth(BorderWidth),
-        // "border-top-width": BorderTopWidth(BorderWidthValue),
-        // "border-right-width": BorderRightWidth(BorderWidthValue),
-        // "border-bottom-width": BorderBottomWidth(BorderWidthValue),
-        // "border-left-width": BorderLeftWidth(BorderWidthValue),
+        "border-top-width": BorderTopWidth(BorderWidthValue),
+        "border-right-width": BorderRightWidth(BorderWidthValue),
+        "border-bottom-width": BorderBottomWidth(BorderWidthValue),
+        "border-left-width": BorderLeftWidth(BorderWidthValue),
 
 
         // ----- Outline -----

--- a/crates/vizia_style/src/stylesheet.rs
+++ b/crates/vizia_style/src/stylesheet.rs
@@ -65,6 +65,10 @@ button label {
     padding-right: 10px;
     border-width: 1px;
     border-color: #e5e5e5;
+    border-top: 2px solid red;
+    border-top-width: 3px;
+    border-top-color: blue;
+    border-top-style: dotted;
     outer-shadow: 0px 1px 1px #00000055;
     overflow: visible;
     position: relative;


### PR DESCRIPTION
Reworks border handling from single shared values to per-side width, color, and style across style storage, parsing, modifiers, rule linking, and animation/transition pipelines. Adds support for border-top/right/bottom/left shorthands and side-specific border-* properties in vizia_style.

Updates drawing to render side-specific borders (including mixed widths/colors/styles) with corner-aware path splitting, plus improved dashed/dotted handling. Introduces side-specific border getters in draw/event contexts while keeping `border_width`, `border_color`, and `border_style` behavior as top-side compatibility accessors.