### PR TITLE
Fix infinite loop in Context::modify_timer (#530)

### DIFF
--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -866,6 +866,14 @@ impl Context {
 
     /// Modifies the state of an existing timer with the provided `Timer` id.
     pub fn modify_timer(&mut self, timer: Timer, timer_function: impl Fn(&mut TimerState)) {
+        // `running_timers` is a min-heap ordered by trigger time, not by id -
+        // the target timer isn't necessarily at the top. The previous version
+        // only ever `peek()`ed the top and returned early on a mismatch
+        // without advancing, so a target that wasn't already the top-of-heap
+        // entry spun this loop forever (`peek()` keeps returning the same
+        // element). Pop non-matching entries aside, keep searching, and push
+        // everything back (including the modified target) before returning.
+        let mut passed_over = Vec::new();
         while let Some(next_timer_state) = self.running_timers.peek() {
             if next_timer_state.id == timer {
                 let mut timer_state = self.running_timers.pop().unwrap();
@@ -873,9 +881,17 @@ impl Context {
                 (timer_function)(&mut timer_state);
 
                 self.running_timers.push(timer_state);
+                for t in passed_over {
+                    self.running_timers.push(t);
+                }
 
                 return;
             }
+
+            passed_over.push(self.running_timers.pop().unwrap());
+        }
+        for t in passed_over {
+            self.running_timers.push(t);
         }
 
         for pending_timer in self.timers.iter_mut() {


### PR DESCRIPTION
## Summary

Fixes #530.

`Context::modify_timer` searched `running_timers` (a min-heap ordered by trigger time, not by timer id) by only ever calling `peek()` on the top entry:

```rust
while let Some(next_timer_state) = self.running_timers.peek() {
    if next_timer_state.id == timer {
        // ... pop, modify, push, return
    }
}
```

If the target `timer` wasn't the current top-of-heap entry, the `if` never matched, nothing was popped, and the next loop iteration's `peek()` returned the exact same element again - an infinite loop. Since this runs on the UI thread with no blocking wait involved, it presents as a hard hang rather than a panic or a visible deadlock in a debugger's thread-wait view.

This is easy to trigger with completely ordinary usage: any app with two timers running at once (e.g. the built-in `Environment::caret_timer`, registered for every `Context` and started on a `Textbox` focus-in event, racing an application-level timer started via `cx.add_timer`/`cx.start_timer`) can hit it as soon as the two aren't in the "lucky" heap order.

## Fix

Pop non-matching entries aside into a `Vec` while searching, keep peeking the new top, and once found (or if the heap is exhausted), push everything back - including the modified target - before returning. Same shape as a normal linear/heap walk that needs to temporarily displace elements it's not looking for.

## Testing

- `cargo check -p vizia_core` passes.
- Verified against a real repro in a downstream CLAP audio plugin (two timers: a custom app timer + `Environment::caret_timer` after a `Textbox` gained focus) - hung reliably before this fix, opens and runs normally after.

No behavior change for the already-working path (target found at heap top on the first `peek()`).