### PR TITLE
Use per-window clipboard providers

### DIFF
--- a/crates/vizia_core/src/context/backend.rs
+++ b/crates/vizia_core/src/context/backend.rs
@@ -194,8 +194,12 @@ impl BackendContext {
     /// You should not call this method unless you are writing a windowing backend, in which case
     /// you should consult the existing windowing backends for usage information.
     #[cfg(feature = "clipboard")]
-    pub fn set_clipboard_provider(&mut self, clipboard: Box<dyn ClipboardProvider>) {
-        self.0.clipboard = clipboard;
+    pub fn set_clipboard_provider(
+        &mut self,
+        window: Entity,
+        clipboard: Box<dyn ClipboardProvider>,
+    ) {
+        self.0.clipboards.insert(window, clipboard);
     }
 
     /// Send an event with custom origin and propagation information.

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -88,7 +88,7 @@ pub struct EventContext<'a> {
     pub(crate) running_timers: &'a mut BinaryHeap<TimerState>,
     cursor_icon_locked: &'a mut bool,
     #[cfg(feature = "clipboard")]
-    clipboard: &'a mut Box<dyn ClipboardProvider>,
+    clipboards: &'a mut HashMap<Entity, Box<dyn ClipboardProvider>>,
     pub(crate) event_proxy: &'a mut Option<Box<dyn crate::context::EventProxy>>,
     pub(crate) drop_data: &'a mut Option<DropData>,
     pub(crate) active_drag_view: &'a mut Option<Entity>,
@@ -145,7 +145,7 @@ impl<'a> EventContext<'a> {
             running_timers: &mut cx.running_timers,
             cursor_icon_locked: &mut cx.cursor_icon_locked,
             #[cfg(feature = "clipboard")]
-            clipboard: &mut cx.clipboard,
+            clipboards: &mut cx.clipboards,
             event_proxy: &mut cx.event_proxy,
             drop_data: &mut cx.drop_data,
             active_drag_view: &mut cx.active_drag_view,
@@ -183,7 +183,7 @@ impl<'a> EventContext<'a> {
             running_timers: &mut cx.running_timers,
             cursor_icon_locked: &mut cx.cursor_icon_locked,
             #[cfg(feature = "clipboard")]
-            clipboard: &mut cx.clipboard,
+            clipboards: &mut cx.clipboards,
             event_proxy: &mut cx.event_proxy,
             drop_data: &mut cx.drop_data,
             active_drag_view: &mut cx.active_drag_view,
@@ -736,7 +736,7 @@ impl<'a> EventContext<'a> {
     /// This may fail for a variety of backend-specific reasons.
     #[cfg(feature = "clipboard")]
     pub fn get_clipboard(&mut self) -> Result<String, Box<dyn Error + Send + Sync + 'static>> {
-        self.clipboard.get_contents()
+        self.current_window_clipboard().get_contents()
     }
 
     /// Set the contents of the system clipboard.
@@ -747,7 +747,18 @@ impl<'a> EventContext<'a> {
         &mut self,
         text: String,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-        self.clipboard.set_contents(text)
+        self.current_window_clipboard().set_contents(text)
+    }
+
+    #[cfg(feature = "clipboard")]
+    fn current_window_clipboard(&mut self) -> &mut Box<dyn ClipboardProvider> {
+        let window = if self.tree.is_window(self.current) {
+            self.current
+        } else {
+            self.tree.get_parent_window(self.current).unwrap_or(Entity::root())
+        };
+
+        self.clipboards.entry(window).or_insert_with(super::default_clipboard_provider)
     }
 
     /// Toggles the addition/removal of a class name for the current view.

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -189,7 +189,7 @@ pub struct Context {
     pub(crate) event_proxy: Option<Box<dyn EventProxy>>,
 
     #[cfg(feature = "clipboard")]
-    pub(crate) clipboard: Box<dyn ClipboardProvider>,
+    pub(crate) clipboards: HashMap<Entity, Box<dyn ClipboardProvider>>,
 
     pub(crate) click_time: Instant,
     pub(crate) clicks: usize,
@@ -275,7 +275,7 @@ impl Context {
             event_proxy: None,
 
             #[cfg(feature = "clipboard")]
-            clipboard: default_clipboard_provider(),
+            clipboards: HashMap::new(),
             click_time: Instant::now(),
             clicks: 0,
             click_pos: (0.0, 0.0),
@@ -628,6 +628,8 @@ impl Context {
 
             if self.windows.contains_key(entity) {
                 self.windows.remove(entity);
+                #[cfg(feature = "clipboard")]
+                self.clipboards.remove(entity);
             }
 
             self.tree.remove(*entity).expect("");

--- a/crates/vizia_winit/src/application.rs
+++ b/crates/vizia_winit/src/application.rs
@@ -312,6 +312,20 @@ impl Application {
         let window_id = window_state.window.id();
         self.windows.insert(window_id, window_state);
         self.window_ids.insert(window_entity, window_id);
+
+        #[cfg(all(
+            feature = "clipboard",
+            feature = "wayland",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ))]
+        self.init_wayland_clipboard(window_entity, &window);
+
         Ok(window)
     }
 
@@ -326,7 +340,7 @@ impl Application {
             target_os = "openbsd"
         )
     ))]
-    fn init_wayland_clipboard(&mut self, window: &winit::window::Window) {
+    fn init_wayland_clipboard(&mut self, window_entity: Entity, window: &winit::window::Window) {
         let Ok(display_handle) = window.display_handle() else {
             return;
         };
@@ -336,7 +350,7 @@ impl Application {
             // at least as long as the window/application lifetime where the provider is used.
             let (_, clipboard) =
                 unsafe { create_clipboards_from_external(handle.display.as_ptr()) };
-            self.cx.set_clipboard_provider(Box::new(clipboard));
+            self.cx.set_clipboard_provider(window_entity, Box::new(clipboard));
         }
     }
 
@@ -438,19 +452,6 @@ impl ApplicationHandler<UserEvent> for Application {
             let main_window: Arc<winit::window::Window> = self
                 .create_window(event_loop, Entity::root(), &self.window_description.clone(), None)
                 .expect("failed to create initial window");
-
-            #[cfg(all(
-                feature = "clipboard",
-                feature = "wayland",
-                any(
-                    target_os = "linux",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "netbsd",
-                    target_os = "openbsd"
-                )
-            ))]
-            self.init_wayland_clipboard(&main_window);
 
             let custom_cursors = Arc::new(load_default_cursors(event_loop));
             self.cx.add_main_window(

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -44,13 +44,13 @@ use winit::{dpi::*, window::WindowId};
 pub struct WinState {
     pub entity: Entity,
     pub id: WindowId,
-    pub window: Arc<winit::window::Window>,
     pub surface: skia_safe::Surface,
     pub dirty_surface: skia_safe::Surface,
     pub gr_context: skia_safe::gpu::DirectContext,
     pub gl_surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
     gl_context: glutin::context::PossiblyCurrentContext,
     gl_config: Config,
+    pub window: Arc<winit::window::Window>,
     pub should_close: bool,
     #[cfg(target_os = "windows")]
     pub is_initially_cloaked: bool,
@@ -58,7 +58,7 @@ pub struct WinState {
 
 impl Drop for WinState {
     fn drop(&mut self) {
-        self.gl_context.make_current(&self.gl_surface).unwrap();
+        let _ = self.gl_context.make_current(&self.gl_surface);
     }
 }
 

--- a/crates/vizia_winit/src/window.rs
+++ b/crates/vizia_winit/src/window.rs
@@ -43,14 +43,14 @@ use winit::{dpi::*, window::WindowId};
 
 pub struct WinState {
     pub entity: Entity,
-    gl_config: Config,
-    gl_context: glutin::context::PossiblyCurrentContext,
-    pub gl_surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
     pub id: WindowId,
-    pub gr_context: skia_safe::gpu::DirectContext,
     pub window: Arc<winit::window::Window>,
     pub surface: skia_safe::Surface,
     pub dirty_surface: skia_safe::Surface,
+    pub gr_context: skia_safe::gpu::DirectContext,
+    pub gl_surface: glutin::surface::Surface<glutin::surface::WindowSurface>,
+    gl_context: glutin::context::PossiblyCurrentContext,
+    gl_config: Config,
     pub should_close: bool,
     #[cfg(target_os = "windows")]
     pub is_initially_cloaked: bool,


### PR DESCRIPTION
Reordered `WinState` fields in `window.rs` so Skia and GL-related resources are grouped and dropped in a safer sequence during teardown. This helps avoid shutdown-time resource ordering issues between the Skia `DirectContext`, GL surface/context, and config.