### PR TITLE
Fix running timer lookup loops

### DIFF
--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1428,17 +1428,17 @@ impl<'a> EventContext<'a> {
 
     /// Modifies the state of an existing timer with the provided `Timer` id.
     pub fn modify_timer(&mut self, timer: Timer, timer_function: impl Fn(&mut TimerState)) {
-        while let Some(next_timer_state) = self.running_timers.peek() {
-            if next_timer_state.id == timer {
-                let mut timer_state = self.running_timers.pop().unwrap();
+        let mut running_timers = std::mem::take(self.running_timers).into_vec();
 
-                (timer_function)(&mut timer_state);
-
-                self.running_timers.push(timer_state);
-
-                return;
-            }
+        if let Some(timer_state) =
+            running_timers.iter_mut().find(|timer_state| timer_state.id == timer)
+        {
+            (timer_function)(timer_state);
+            *self.running_timers = running_timers.into();
+            return;
         }
+
+        *self.running_timers = running_timers.into();
 
         for pending_timer in self.timers.iter_mut() {
             if pending_timer.id == timer {
@@ -1452,16 +1452,10 @@ impl<'a> EventContext<'a> {
         timer: Timer,
         timer_function: impl Fn(&TimerState) -> T,
     ) -> Option<T> {
-        while let Some(next_timer_state) = self.running_timers.peek() {
-            if next_timer_state.id == timer {
-                let timer_state = self.running_timers.pop().unwrap();
-
-                let t = (timer_function)(&timer_state);
-
-                self.running_timers.push(timer_state);
-
-                return Some(t);
-            }
+        if let Some(timer_state) =
+            self.running_timers.iter().find(|timer_state| timer_state.id == timer)
+        {
+            return Some(timer_function(timer_state));
         }
 
         for pending_timer in self.timers.iter() {

--- a/crates/vizia_core/src/context/event.rs
+++ b/crates/vizia_core/src/context/event.rs
@@ -1428,7 +1428,7 @@ impl<'a> EventContext<'a> {
 
     /// Modifies the state of an existing timer with the provided `Timer` id.
     pub fn modify_timer(&mut self, timer: Timer, timer_function: impl Fn(&mut TimerState)) {
-        let mut running_timers = std::mem::take(self.running_timers).into_vec();
+        let mut running_timers = self.running_timers.clone().into_vec();
 
         if let Some(timer_state) =
             running_timers.iter_mut().find(|timer_state| timer_state.id == timer)
@@ -1437,8 +1437,6 @@ impl<'a> EventContext<'a> {
             *self.running_timers = running_timers.into();
             return;
         }
-
-        *self.running_timers = running_timers.into();
 
         for pending_timer in self.timers.iter_mut() {
             if pending_timer.id == timer {

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -868,17 +868,17 @@ impl Context {
 
     /// Modifies the state of an existing timer with the provided `Timer` id.
     pub fn modify_timer(&mut self, timer: Timer, timer_function: impl Fn(&mut TimerState)) {
-        while let Some(next_timer_state) = self.running_timers.peek() {
-            if next_timer_state.id == timer {
-                let mut timer_state = self.running_timers.pop().unwrap();
+        let mut running_timers = std::mem::take(&mut self.running_timers).into_vec();
 
-                (timer_function)(&mut timer_state);
-
-                self.running_timers.push(timer_state);
-
-                return;
-            }
+        if let Some(timer_state) =
+            running_timers.iter_mut().find(|timer_state| timer_state.id == timer)
+        {
+            (timer_function)(timer_state);
+            self.running_timers = running_timers.into();
+            return;
         }
+
+        self.running_timers = running_timers.into();
 
         for pending_timer in self.timers.iter_mut() {
             if pending_timer.id == timer {

--- a/crates/vizia_core/src/context/mod.rs
+++ b/crates/vizia_core/src/context/mod.rs
@@ -868,7 +868,7 @@ impl Context {
 
     /// Modifies the state of an existing timer with the provided `Timer` id.
     pub fn modify_timer(&mut self, timer: Timer, timer_function: impl Fn(&mut TimerState)) {
-        let mut running_timers = std::mem::take(&mut self.running_timers).into_vec();
+        let mut running_timers = self.running_timers.clone().into_vec();
 
         if let Some(timer_state) =
             running_timers.iter_mut().find(|timer_state| timer_state.id == timer)
@@ -877,8 +877,6 @@ impl Context {
             self.running_timers = running_timers.into();
             return;
         }
-
-        self.running_timers = running_timers.into();
 
         for pending_timer in self.timers.iter_mut() {
             if pending_timer.id == timer {


### PR DESCRIPTION
Timer lookup in `Context` and `EventContext` no longer relies on `peek()` inside a `while` loop, which could loop forever when the top heap entry didn’t match the requested timer ID. The code now searches all running timers (`iter`/`iter_mut`) and, for mutable access, temporarily takes and restores the heap after applying updates. This makes `modify_timer` and `query_timer` reliably find non-top running timers without hanging.